### PR TITLE
Add TDM respawn kit selection

### DIFF
--- a/src/main/java/com/hfr/command/CommandKit.java
+++ b/src/main/java/com/hfr/command/CommandKit.java
@@ -1,0 +1,44 @@
+package com.hfr.command;
+
+import com.hfr.tdm.TDMKitManager;
+import com.hfr.tdm.TDMManager;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChatComponentText;
+
+public class CommandKit extends CommandBase {
+
+    @Override
+    public String getCommandName() {
+        return "kit";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/kit <blue|red>";
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if (args.length < 1) {
+            sender.addChatMessage(new ChatComponentText(getCommandUsage(sender)));
+            return;
+        }
+
+        TDMManager.Team team = TDMManager.Team.fromName(args[0]);
+        if (team == null) {
+            sender.addChatMessage(new ChatComponentText("Unknown TDM team: " + args[0]));
+            return;
+        }
+
+        EntityPlayer player = getCommandSenderAsPlayer(sender);
+        int kitCount = TDMKitManager.addKit(team, player);
+        sender.addChatMessage(new ChatComponentText("Saved " + team.name + " kit #" + kitCount + " from your inventory to tdm_kits.txt"));
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 4;
+    }
+}

--- a/src/main/java/com/hfr/inventory/gui/GUITDMKitSelect.java
+++ b/src/main/java/com/hfr/inventory/gui/GUITDMKitSelect.java
@@ -1,0 +1,54 @@
+package com.hfr.inventory.gui;
+
+import com.hfr.packet.PacketDispatcher;
+import com.hfr.packet.client.TDMKitSelectPacket;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.util.EnumChatFormatting;
+
+public class GUITDMKitSelect extends GuiScreen {
+
+    private final String team;
+    private final String[] kitNames;
+
+    public GUITDMKitSelect(String team, String[] kitNames) {
+        this.team = team;
+        this.kitNames = kitNames;
+    }
+
+    @Override
+    public void initGui() {
+        this.buttonList.clear();
+        int x = this.width / 2 - 100;
+        int y = this.height / 2 - (kitNames.length * 24) / 2;
+
+        for (int i = 0; i < kitNames.length; i++) {
+            this.buttonList.add(new GuiButton(i, x, y + i * 24, 200, 20, kitNames[i]));
+        }
+    }
+
+    @Override
+    protected void actionPerformed(GuiButton button) {
+        PacketDispatcher.wrapper.sendToServer(new TDMKitSelectPacket(button.id));
+        this.mc.displayGuiScreen(null);
+    }
+
+    @Override
+    protected void keyTyped(char typedChar, int keyCode) {
+        // Do not allow the menu to be escaped before a kit is selected.
+    }
+
+    @Override
+    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        this.drawDefaultBackground();
+        String title = EnumChatFormatting.BOLD + "Select a " + team + " TDM Kit";
+        this.drawCenteredString(this.fontRendererObj, title, this.width / 2, this.height / 2 - (kitNames.length * 24) / 2 - 28, 0xFFFFFF);
+        this.drawCenteredString(this.fontRendererObj, "You have Resistance and Regeneration until you pick one.", this.width / 2, this.height / 2 - (kitNames.length * 24) / 2 - 16, 0xA0A0A0);
+        super.drawScreen(mouseX, mouseY, partialTicks);
+    }
+
+    @Override
+    public boolean doesGuiPauseGame() {
+        return false;
+    }
+}

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -782,6 +782,7 @@ public class MainRegistry
 		event.registerServerCommand(new CommandXMarket());
 		event.registerServerCommand(new CommandStoneDrop());
 		MuteManager.init();
+		TDMKitManager.init();
 		IgnoreManager.init();
 		event.registerServerCommand(new CommandMute());
 		event.registerServerCommand(new CommandUnmute());
@@ -791,6 +792,7 @@ public class MainRegistry
 		event.registerServerCommand(new CommandXMulti());
 		event.registerServerCommand(new CommandInvSee());
 		event.registerServerCommand(new CommandTDM());
+		event.registerServerCommand(new CommandKit());
 		MarketData.loadMarketData();
 
 		//and now we just pray that the market data does not cope over serverside

--- a/src/main/java/com/hfr/packet/PacketDispatcher.java
+++ b/src/main/java/com/hfr/packet/PacketDispatcher.java
@@ -71,6 +71,8 @@ public class PacketDispatcher {
 		wrapper.registerMessage(ReseatRequestPacket.Handler.class, ReseatRequestPacket.class, i++, Side.SERVER);
 
 		wrapper.registerMessage(PacketAddImage.Handler.class, PacketAddImage.class, i++, Side.SERVER);
+		wrapper.registerMessage(TDMKitGuiPacket.Handler.class, TDMKitGuiPacket.class, i++, Side.CLIENT);
+		wrapper.registerMessage(TDMKitSelectPacket.Handler.class, TDMKitSelectPacket.class, i++, Side.SERVER);
 
 	}
 	

--- a/src/main/java/com/hfr/packet/client/TDMKitSelectPacket.java
+++ b/src/main/java/com/hfr/packet/client/TDMKitSelectPacket.java
@@ -1,0 +1,42 @@
+package com.hfr.packet.client;
+
+import com.hfr.tdm.TDMManager;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChatComponentText;
+
+public class TDMKitSelectPacket implements IMessage {
+
+    private int kitIndex;
+
+    public TDMKitSelectPacket() { }
+
+    public TDMKitSelectPacket(int kitIndex) {
+        this.kitIndex = kitIndex;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        kitIndex = buf.readInt();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(kitIndex);
+    }
+
+    public static class Handler implements IMessageHandler<TDMKitSelectPacket, IMessage> {
+
+        @Override
+        public IMessage onMessage(TDMKitSelectPacket message, MessageContext ctx) {
+            EntityPlayer player = ctx.getServerHandler().playerEntity;
+            if (!TDMManager.selectKit(player, message.kitIndex)) {
+                player.addChatMessage(new ChatComponentText("Unable to select that TDM kit."));
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/hfr/packet/effect/TDMKitGuiPacket.java
+++ b/src/main/java/com/hfr/packet/effect/TDMKitGuiPacket.java
@@ -1,0 +1,53 @@
+package com.hfr.packet.effect;
+
+import com.hfr.inventory.gui.GUITDMKitSelect;
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.Minecraft;
+
+public class TDMKitGuiPacket implements IMessage {
+
+    private String team;
+    private String[] kitNames;
+
+    public TDMKitGuiPacket() { }
+
+    public TDMKitGuiPacket(String team, String[] kitNames) {
+        this.team = team;
+        this.kitNames = kitNames;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        team = ByteBufUtils.readUTF8String(buf);
+        int count = buf.readInt();
+        kitNames = new String[count];
+        for (int i = 0; i < count; i++) {
+            kitNames[i] = ByteBufUtils.readUTF8String(buf);
+        }
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        ByteBufUtils.writeUTF8String(buf, team);
+        buf.writeInt(kitNames.length);
+        for (int i = 0; i < kitNames.length; i++) {
+            ByteBufUtils.writeUTF8String(buf, kitNames[i]);
+        }
+    }
+
+    public static class Handler implements IMessageHandler<TDMKitGuiPacket, IMessage> {
+
+        @Override
+        @SideOnly(Side.CLIENT)
+        public IMessage onMessage(TDMKitGuiPacket message, MessageContext ctx) {
+            Minecraft.getMinecraft().displayGuiScreen(new GUITDMKitSelect(message.team, message.kitNames));
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/hfr/tdm/TDMHandler.java
+++ b/src/main/java/com/hfr/tdm/TDMHandler.java
@@ -32,6 +32,8 @@ public class TDMHandler {
         if (event.phase != TickEvent.Phase.END) return;
         if (event.player.worldObj.isRemote) return;
 
+        TDMManager.tickKitSelection(event.player);
+
         String playerName = getKey(event.player);
         Integer ticksLeft = pendingRespawns.get(playerName);
         if (ticksLeft == null) return;
@@ -41,8 +43,12 @@ public class TDMHandler {
             return;
         }
 
-        if (TDMManager.respawnPlayer(event.player, random) || ticksLeft <= 1) {
+        if (TDMManager.respawnPlayer(event.player, random)) {
             pendingRespawns.remove(playerName);
+            TDMManager.promptForKit(event.player);
+        } else if (ticksLeft <= 1) {
+            pendingRespawns.remove(playerName);
+            TDMManager.promptForKit(event.player);
         } else {
             pendingRespawns.put(playerName, ticksLeft - 1);
         }

--- a/src/main/java/com/hfr/tdm/TDMKitManager.java
+++ b/src/main/java/com/hfr/tdm/TDMKitManager.java
@@ -1,0 +1,203 @@
+package com.hfr.tdm;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.server.MinecraftServer;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public class TDMKitManager {
+
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final int MAIN_INVENTORY_SIZE = 36;
+    private static final int ARMOR_INVENTORY_SIZE = 4;
+    private static final Map<TDMManager.Team, List<KitEntry>> kits = new EnumMap<TDMManager.Team, List<KitEntry>>(TDMManager.Team.class);
+    private static File saveFile;
+
+    static {
+        for (TDMManager.Team team : TDMManager.Team.values()) {
+            kits.put(team, new ArrayList<KitEntry>());
+        }
+    }
+
+    public static void init() {
+        File worldDir = MinecraftServer.getServer().getEntityWorld().getSaveHandler().getWorldDirectory();
+        saveFile = new File(worldDir, "tdm_kits.txt");
+        load();
+    }
+
+    public static int addKit(TDMManager.Team team, EntityPlayer player) {
+        List<ItemEntry> items = new ArrayList<ItemEntry>();
+
+        for (int i = 0; i < MAIN_INVENTORY_SIZE; i++) {
+            ItemStack stack = player.inventory.mainInventory[i];
+            if (stack != null) {
+                items.add(new ItemEntry(i, stack));
+            }
+        }
+
+        for (int i = 0; i < ARMOR_INVENTORY_SIZE; i++) {
+            ItemStack stack = player.inventory.armorInventory[i];
+            if (stack != null) {
+                items.add(new ItemEntry(MAIN_INVENTORY_SIZE + i, stack));
+            }
+        }
+
+        List<KitEntry> teamKits = kits.get(team);
+        KitEntry kit = new KitEntry(team.name.substring(0, 1).toUpperCase() + team.name.substring(1) + " Kit " + (teamKits.size() + 1), items);
+        teamKits.add(kit);
+        save();
+        return teamKits.size();
+    }
+
+    public static int getKitCount(TDMManager.Team team) {
+        return kits.get(team).size();
+    }
+
+    public static String[] getKitNames(TDMManager.Team team) {
+        List<KitEntry> teamKits = kits.get(team);
+        String[] names = new String[teamKits.size()];
+        for (int i = 0; i < teamKits.size(); i++) {
+            names[i] = teamKits.get(i).name;
+        }
+        return names;
+    }
+
+    public static boolean applyKit(TDMManager.Team team, int kitIndex, EntityPlayer player) {
+        List<KitEntry> teamKits = kits.get(team);
+        if (kitIndex < 0 || kitIndex >= teamKits.size()) {
+            return false;
+        }
+
+        player.inventory.clearInventory(null, -1);
+        for (int i = 0; i < ARMOR_INVENTORY_SIZE; i++) {
+            player.inventory.armorInventory[i] = null;
+        }
+
+        KitEntry kit = teamKits.get(kitIndex);
+        for (ItemEntry item : kit.items) {
+            ItemStack stack = item.toItemStack();
+            if (stack == null) {
+                continue;
+            }
+
+            if (item.slot >= 0 && item.slot < MAIN_INVENTORY_SIZE) {
+                player.inventory.mainInventory[item.slot] = stack;
+            } else if (item.slot >= MAIN_INVENTORY_SIZE && item.slot < MAIN_INVENTORY_SIZE + ARMOR_INVENTORY_SIZE) {
+                player.inventory.armorInventory[item.slot - MAIN_INVENTORY_SIZE] = stack;
+            }
+        }
+
+        player.inventory.markDirty();
+        player.inventoryContainer.detectAndSendChanges();
+        return true;
+    }
+
+    private static void save() {
+        if (saveFile == null) return;
+
+        SaveData data = new SaveData();
+        data.red = kits.get(TDMManager.Team.RED);
+        data.blue = kits.get(TDMManager.Team.BLUE);
+
+        try {
+            Writer writer = new FileWriter(saveFile);
+            try {
+                GSON.toJson(data, writer);
+            } finally {
+                writer.close();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void load() {
+        for (TDMManager.Team team : TDMManager.Team.values()) {
+            kits.get(team).clear();
+        }
+
+        if (saveFile == null || !saveFile.exists()) return;
+
+        try {
+            Reader reader = new FileReader(saveFile);
+            try {
+                Type type = new TypeToken<SaveData>() {}.getType();
+                SaveData data = GSON.fromJson(reader, type);
+                if (data != null) {
+                    if (data.red != null) kits.get(TDMManager.Team.RED).addAll(data.red);
+                    if (data.blue != null) kits.get(TDMManager.Team.BLUE).addAll(data.blue);
+                }
+            } finally {
+                reader.close();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static class SaveData {
+        List<KitEntry> red = new ArrayList<KitEntry>();
+        List<KitEntry> blue = new ArrayList<KitEntry>();
+    }
+
+    private static class KitEntry {
+        String name;
+        List<ItemEntry> items = new ArrayList<ItemEntry>();
+
+        KitEntry() { }
+
+        KitEntry(String name, List<ItemEntry> items) {
+            this.name = name;
+            this.items = items;
+        }
+    }
+
+    private static class ItemEntry {
+        int slot;
+        String itemName;
+        int count;
+        int metadata;
+        String nbtData;
+
+        ItemEntry() { }
+
+        ItemEntry(int slot, ItemStack stack) {
+            this.slot = slot;
+            this.itemName = Item.itemRegistry.getNameForObject(stack.getItem());
+            this.count = stack.stackSize;
+            this.metadata = stack.getItemDamage();
+            this.nbtData = stack.hasTagCompound() ? stack.getTagCompound().toString() : null;
+        }
+
+        ItemStack toItemStack() {
+            Item item = (Item) Item.itemRegistry.getObject(itemName);
+            if (item == null) return null;
+
+            ItemStack stack = new ItemStack(item, count, metadata);
+            if (nbtData != null) {
+                try {
+                    stack.setTagCompound((NBTTagCompound) JsonToNBT.func_150315_a(nbtData));
+                } catch (Exception e) {
+                    System.err.println("Failed to parse TDM kit NBT for item: " + itemName);
+                }
+            }
+            return stack;
+        }
+    }
+}

--- a/src/main/java/com/hfr/tdm/TDMManager.java
+++ b/src/main/java/com/hfr/tdm/TDMManager.java
@@ -1,16 +1,23 @@
 package com.hfr.tdm;
 
+import com.hfr.packet.PacketDispatcher;
+import com.hfr.packet.effect.TDMKitGuiPacket;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.World;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 public class TDMManager {
 
     public static boolean tdmEnabled = false;
+    private static final Set<String> pendingKitSelection = new HashSet<String>();
 
     public enum Team {
         RED("red"),
@@ -53,6 +60,7 @@ public class TDMManager {
 
     public static void init() {
         tdmEnabled = false;
+        pendingKitSelection.clear();
     }
 
     public static boolean isEnabled(World world) {
@@ -133,6 +141,60 @@ public class TDMManager {
         }
 
         return red <= blue ? Team.RED : Team.BLUE;
+    }
+
+    public static void promptForKit(EntityPlayer player) {
+        if (!(player instanceof EntityPlayerMP)) {
+            return;
+        }
+
+        Team team = getOrAssignPlayerTeam(player);
+        if (TDMKitManager.getKitCount(team) <= 0) {
+            player.addChatMessage(new net.minecraft.util.ChatComponentText("No TDM kits have been saved for " + team.name + ". Ask an admin to use /kit " + team.name + "."));
+            return;
+        }
+
+        pendingKitSelection.add(getPlayerKey(player));
+        PacketDispatcher.wrapper.sendTo(new TDMKitGuiPacket(team.name, TDMKitManager.getKitNames(team)), (EntityPlayerMP) player);
+    }
+
+    public static void tickKitSelection(EntityPlayer player) {
+        if (!pendingKitSelection.contains(getPlayerKey(player))) {
+            return;
+        }
+
+        if (!isEnabled(player.worldObj)) {
+            pendingKitSelection.remove(getPlayerKey(player));
+            return;
+        }
+
+        player.addPotionEffect(new PotionEffect(Potion.resistance.id, 40, 4, true));
+        player.addPotionEffect(new PotionEffect(Potion.regeneration.id, 40, 4, true));
+    }
+
+    public static boolean selectKit(EntityPlayer player, int kitIndex) {
+        if (!pendingKitSelection.contains(getPlayerKey(player))) {
+            return false;
+        }
+
+        if (!isEnabled(player.worldObj)) {
+            pendingKitSelection.remove(getPlayerKey(player));
+            return false;
+        }
+
+        Team team = getOrAssignPlayerTeam(player);
+        if (!TDMKitManager.applyKit(team, kitIndex, player)) {
+            return false;
+        }
+
+        pendingKitSelection.remove(getPlayerKey(player));
+        player.removePotionEffect(Potion.resistance.id);
+        player.removePotionEffect(Potion.regeneration.id);
+        return true;
+    }
+
+    private static String getPlayerKey(EntityPlayer player) {
+        return player.getCommandSenderName().toLowerCase();
     }
 
     public static boolean respawnPlayer(EntityPlayer player, Random rand) {


### PR DESCRIPTION
### Motivation
- Provide a simple kit workflow for TDM so players are prompted to pick a kit on respawn while `/tdm` is enabled and are temporarily protected until they choose. 
- Allow admins to create persistent team kits from their current inventory and armor so servers can manage team loadouts without editing code. 

### Description
- Added a new `TDMKitManager` class that serializes/deserializes team kits to `tdm_kits.txt` in the world save using Gson and stores item name, count, metadata and NBT for restore (`src/main/java/com/hfr/tdm/TDMKitManager.java`).
- Added an admin command ` kit <blue|red> ` implemented in `CommandKit` which saves the command sender’s main inventory and armor into the selected team’s kit list (`src/main/java/com/hfr/command/CommandKit.java`).
- Added client GUI `GUITDMKitSelect` and two packets `TDMKitGuiPacket` (server->client) and `TDMKitSelectPacket` (client->server) to open the kit selection UI and submit choices, and registered those packets in `PacketDispatcher` (`src/main/java/com/hfr/inventory/gui/GUITDMKitSelect.java`, `src/main/java/com/hfr/packet/effect/TDMKitGuiPacket.java`, `src/main/java/com/hfr/packet/client/TDMKitSelectPacket.java`, `src/main/java/com/hfr/packet/PacketDispatcher.java`).
- Integrated kit prompting into the TDM respawn flow by extending `TDMManager` to track pending selections and apply `Resistance`/`Regeneration` until the player chooses a kit, and by updating `TDMHandler` to prompt players after respawn; registered initialization and the new command in `MainRegistry` (`src/main/java/com/hfr/tdm/TDMManager.java`, `src/main/java/com/hfr/tdm/TDMHandler.java`, `src/main/java/com/hfr/main/MainRegistry.java`).

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it completed successfully. 
- Attempted `gradle compileJava` to perform a full compile but the build was blocked by external repository access errors (ForgeGradle metadata requests returned HTTP 403), so a local compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0552a651b48323b93d6652287886a9)