### PR TITLE
Add TDM friendly-fire toggle and auto team balance

### DIFF
--- a/src/main/java/com/hfr/command/CommandTDM.java
+++ b/src/main/java/com/hfr/command/CommandTDM.java
@@ -16,7 +16,7 @@ public class CommandTDM extends CommandBase {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "/tdm <toggle|addspawn <red|blue>|setteam <player> <red|blue>|clear>";
+        return "/tdm <toggle|friendlyfire <on|off>|autobalance <on|off|now>|addspawn <red|blue>|setteam <player> <red|blue>|clear>";
     }
 
     @Override
@@ -31,6 +31,46 @@ public class CommandTDM extends CommandBase {
         if (args[0].equalsIgnoreCase("toggle")) {
             boolean enabled = TDMManager.toggle(world);
             sender.addChatMessage(new ChatComponentText("TDM: " + enabled));
+            return;
+        }
+
+        if (args[0].equalsIgnoreCase("friendlyfire")) {
+            if (args.length < 2) {
+                sender.addChatMessage(new ChatComponentText("Friendly fire is " + TDMManager.isFriendlyFireEnabled(world) + ". Usage: /tdm friendlyfire <on|off>"));
+                return;
+            }
+
+            Boolean enabled = parseToggle(args[1]);
+            if (enabled == null) {
+                sender.addChatMessage(new ChatComponentText("Usage: /tdm friendlyfire <on|off>"));
+                return;
+            }
+
+            TDMManager.setFriendlyFireEnabled(world, enabled.booleanValue());
+            sender.addChatMessage(new ChatComponentText("TDM friendly fire damage: " + (enabled.booleanValue() ? "on" : "off")));
+            return;
+        }
+
+        if (args[0].equalsIgnoreCase("autobalance")) {
+            if (args.length < 2) {
+                sender.addChatMessage(new ChatComponentText("Auto balance is " + TDMManager.isAutoBalanceEnabled(world) + ". Usage: /tdm autobalance <on|off|now>"));
+                return;
+            }
+
+            if (args[1].equalsIgnoreCase("now")) {
+                int moved = TDMManager.balanceTeams(world);
+                sender.addChatMessage(new ChatComponentText("TDM team balance complete. Players moved: " + moved));
+                return;
+            }
+
+            Boolean enabled = parseToggle(args[1]);
+            if (enabled == null) {
+                sender.addChatMessage(new ChatComponentText("Usage: /tdm autobalance <on|off|now>"));
+                return;
+            }
+
+            TDMManager.setAutoBalanceEnabled(world, enabled.booleanValue());
+            sender.addChatMessage(new ChatComponentText("TDM auto balance: " + (enabled.booleanValue() ? "on" : "off")));
             return;
         }
 
@@ -88,6 +128,18 @@ public class CommandTDM extends CommandBase {
         }
 
         sender.addChatMessage(new ChatComponentText(getCommandUsage(sender)));
+    }
+
+    private Boolean parseToggle(String value) {
+        if (value.equalsIgnoreCase("on") || value.equalsIgnoreCase("true") || value.equalsIgnoreCase("enabled")) {
+            return Boolean.TRUE;
+        }
+
+        if (value.equalsIgnoreCase("off") || value.equalsIgnoreCase("false") || value.equalsIgnoreCase("disabled")) {
+            return Boolean.FALSE;
+        }
+
+        return null;
     }
 
     @Override

--- a/src/main/java/com/hfr/tdm/TDMData.java
+++ b/src/main/java/com/hfr/tdm/TDMData.java
@@ -16,6 +16,8 @@ public class TDMData extends WorldSavedData {
     public static final String DATA_NAME = "xenofactions_tdm";
 
     public boolean enabled = false;
+    public boolean friendlyFireEnabled = true;
+    public boolean autoBalanceEnabled = true;
     public final List<TDMManager.SpawnPoint> spawns = new ArrayList<TDMManager.SpawnPoint>();
     public final Map<String, TDMManager.Team> playerTeams = new HashMap<String, TDMManager.Team>();
 
@@ -48,6 +50,8 @@ public class TDMData extends WorldSavedData {
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
         enabled = nbt.getBoolean("enabled");
+        friendlyFireEnabled = !nbt.hasKey("friendlyFireEnabled") || nbt.getBoolean("friendlyFireEnabled");
+        autoBalanceEnabled = !nbt.hasKey("autoBalanceEnabled") || nbt.getBoolean("autoBalanceEnabled");
         spawns.clear();
         playerTeams.clear();
 
@@ -81,6 +85,8 @@ public class TDMData extends WorldSavedData {
     @Override
     public void writeToNBT(NBTTagCompound nbt) {
         nbt.setBoolean("enabled", enabled);
+        nbt.setBoolean("friendlyFireEnabled", friendlyFireEnabled);
+        nbt.setBoolean("autoBalanceEnabled", autoBalanceEnabled);
         nbt.setInteger("spawnCount", spawns.size());
 
         for (int i = 0; i < spawns.size(); i++) {

--- a/src/main/java/com/hfr/tdm/TDMHandler.java
+++ b/src/main/java/com/hfr/tdm/TDMHandler.java
@@ -2,7 +2,10 @@ package com.hfr.tdm;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.DamageSource;
+import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 
 import java.util.HashMap;
@@ -12,6 +15,8 @@ import java.util.Random;
 public class TDMHandler {
 
     private static final int RESPAWN_RETRY_TICKS = 20;
+    private static final int AUTO_BALANCE_INTERVAL_TICKS = 100;
+    private long lastAutoBalanceTick = -1;
     private final Map<String, Integer> pendingRespawns = new HashMap<String, Integer>();
     private final Random random = new Random();
 
@@ -34,14 +39,16 @@ public class TDMHandler {
 
         TDMManager.tickKitSelection(event.player);
 
+        if (!TDMManager.isEnabled(event.player.worldObj)) {
+            pendingRespawns.remove(getKey(event.player));
+            return;
+        }
+
+        runAutoBalance(event.player);
+
         String playerName = getKey(event.player);
         Integer ticksLeft = pendingRespawns.get(playerName);
         if (ticksLeft == null) return;
-
-        if (!TDMManager.isEnabled(event.player.worldObj)) {
-            pendingRespawns.remove(playerName);
-            return;
-        }
 
         if (TDMManager.respawnPlayer(event.player, random)) {
             pendingRespawns.remove(playerName);
@@ -52,6 +59,56 @@ public class TDMHandler {
         } else {
             pendingRespawns.put(playerName, ticksLeft - 1);
         }
+    }
+
+    @SubscribeEvent
+    public void onLivingAttack(LivingAttackEvent event) {
+        if (event.entityLiving.worldObj.isRemote) return;
+        if (!(event.entityLiving instanceof EntityPlayer)) return;
+        if (!TDMManager.isEnabled(event.entityLiving.worldObj)) return;
+        if (TDMManager.isFriendlyFireEnabled(event.entityLiving.worldObj)) return;
+
+        EntityPlayer victim = (EntityPlayer) event.entityLiving;
+        EntityPlayer attacker = getAttackingPlayer(event.source);
+        if (attacker == null || attacker == victim) return;
+
+        TDMManager.Team victimTeam = TDMManager.getPlayerTeam(victim.worldObj, victim.getCommandSenderName());
+        TDMManager.Team attackerTeam = TDMManager.getPlayerTeam(victim.worldObj, attacker.getCommandSenderName());
+        if (victimTeam != null && victimTeam == attackerTeam) {
+            event.setCanceled(true);
+        }
+    }
+
+    private void runAutoBalance(EntityPlayer player) {
+        if (!TDMManager.isAutoBalanceEnabled(player.worldObj)) {
+            return;
+        }
+
+        long worldTime = player.worldObj.getTotalWorldTime();
+        if (lastAutoBalanceTick == worldTime || worldTime % AUTO_BALANCE_INTERVAL_TICKS != 0) {
+            return;
+        }
+
+        lastAutoBalanceTick = worldTime;
+        TDMManager.balanceTeams(player.worldObj);
+    }
+
+    private EntityPlayer getAttackingPlayer(DamageSource source) {
+        if (source == null) {
+            return null;
+        }
+
+        Entity attacker = source.getEntity();
+        if (attacker instanceof EntityPlayer) {
+            return (EntityPlayer) attacker;
+        }
+
+        attacker = source.getSourceOfDamage();
+        if (attacker instanceof EntityPlayer) {
+            return (EntityPlayer) attacker;
+        }
+
+        return null;
     }
 
     private void queueRespawn(EntityPlayer player) {

--- a/src/main/java/com/hfr/tdm/TDMManager.java
+++ b/src/main/java/com/hfr/tdm/TDMManager.java
@@ -4,6 +4,8 @@ import com.hfr.packet.PacketDispatcher;
 import com.hfr.packet.effect.TDMKitGuiPacket;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.World;
@@ -77,6 +79,26 @@ public class TDMManager {
         return data.enabled;
     }
 
+    public static boolean isFriendlyFireEnabled(World world) {
+        return TDMData.get(world).friendlyFireEnabled;
+    }
+
+    public static void setFriendlyFireEnabled(World world, boolean enabled) {
+        TDMData data = TDMData.get(world);
+        data.friendlyFireEnabled = enabled;
+        data.markDirty();
+    }
+
+    public static boolean isAutoBalanceEnabled(World world) {
+        return TDMData.get(world).autoBalanceEnabled;
+    }
+
+    public static void setAutoBalanceEnabled(World world, boolean enabled) {
+        TDMData data = TDMData.get(world);
+        data.autoBalanceEnabled = enabled;
+        data.markDirty();
+    }
+
     public static void addSpawn(World world, Team team, int dim, int x, int y, int z) {
         TDMData data = TDMData.get(world);
         data.spawns.add(new SpawnPoint(team, dim, x, y, z));
@@ -131,16 +153,107 @@ public class TDMManager {
     private static Team getSmallestTeam(TDMData data) {
         int red = 0;
         int blue = 0;
+        List<EntityPlayerMP> onlinePlayers = getOnlinePlayers();
 
-        for (Team team : data.playerTeams.values()) {
-            if (team == Team.RED) {
-                red++;
-            } else if (team == Team.BLUE) {
-                blue++;
+        if (!onlinePlayers.isEmpty()) {
+            for (EntityPlayerMP player : onlinePlayers) {
+                Team team = data.playerTeams.get(player.getCommandSenderName().toLowerCase());
+                if (team == Team.RED) {
+                    red++;
+                } else if (team == Team.BLUE) {
+                    blue++;
+                }
+            }
+        } else {
+            for (Team team : data.playerTeams.values()) {
+                if (team == Team.RED) {
+                    red++;
+                } else if (team == Team.BLUE) {
+                    blue++;
+                }
             }
         }
 
         return red <= blue ? Team.RED : Team.BLUE;
+    }
+
+    public static int balanceTeams(World world) {
+        TDMData data = TDMData.get(world);
+        if (!data.enabled) {
+            return 0;
+        }
+
+        List<EntityPlayerMP> onlinePlayers = getOnlinePlayers();
+        if (onlinePlayers.size() < 2) {
+            return 0;
+        }
+
+        boolean assigned = false;
+        for (EntityPlayerMP player : onlinePlayers) {
+            String playerName = player.getCommandSenderName().toLowerCase();
+            if (!data.playerTeams.containsKey(playerName)) {
+                data.playerTeams.put(playerName, getSmallestTeam(data));
+                assigned = true;
+            }
+        }
+
+        int moved = 0;
+        while (Math.abs(getOnlineTeamCount(data, Team.RED) - getOnlineTeamCount(data, Team.BLUE)) > 1) {
+            Team larger = getOnlineTeamCount(data, Team.RED) > getOnlineTeamCount(data, Team.BLUE) ? Team.RED : Team.BLUE;
+            Team smaller = larger == Team.RED ? Team.BLUE : Team.RED;
+            EntityPlayerMP playerToMove = getLastOnlinePlayerOnTeam(data, larger);
+            if (playerToMove == null) {
+                break;
+            }
+
+            data.playerTeams.put(playerToMove.getCommandSenderName().toLowerCase(), smaller);
+            pendingKitSelection.remove(getPlayerKey(playerToMove));
+            playerToMove.addChatMessage(new ChatComponentText("You were moved to " + smaller.name + " to balance TDM teams."));
+            promptForKit(playerToMove);
+            moved++;
+        }
+
+        if (assigned || moved > 0) {
+            data.markDirty();
+        }
+
+        return moved;
+    }
+
+    private static int getOnlineTeamCount(TDMData data, Team team) {
+        int count = 0;
+        for (EntityPlayerMP player : getOnlinePlayers()) {
+            if (data.playerTeams.get(player.getCommandSenderName().toLowerCase()) == team) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static EntityPlayerMP getLastOnlinePlayerOnTeam(TDMData data, Team team) {
+        List<EntityPlayerMP> onlinePlayers = getOnlinePlayers();
+        for (int i = onlinePlayers.size() - 1; i >= 0; i--) {
+            EntityPlayerMP player = onlinePlayers.get(i);
+            if (data.playerTeams.get(player.getCommandSenderName().toLowerCase()) == team) {
+                return player;
+            }
+        }
+        return null;
+    }
+
+    private static List<EntityPlayerMP> getOnlinePlayers() {
+        List<EntityPlayerMP> players = new ArrayList<EntityPlayerMP>();
+        MinecraftServer server = MinecraftServer.getServer();
+        if (server == null || server.getConfigurationManager() == null) {
+            return players;
+        }
+
+        for (Object player : server.getConfigurationManager().playerEntityList) {
+            if (player instanceof EntityPlayerMP) {
+                players.add((EntityPlayerMP) player);
+            }
+        }
+        return players;
     }
 
     public static void promptForKit(EntityPlayer player) {


### PR DESCRIPTION
### Motivation
- Provide server admins control over friendly fire in TDM and enable optional automatic team balancing to keep matches fair.
- Persist the new settings across restarts and keep sensible defaults for existing worlds.

### Description
- Add persistent flags `friendlyFireEnabled` and `autoBalanceEnabled` to `TDMData` with NBT read/write defaults for compatibility. 
- Add manager APIs in `TDMManager` to get/set these flags and implement `balanceTeams` plus online-player helpers to assign/move players and re-prompt kits. 
- Update `TDMHandler` to cancel same-team damage when friendly fire is disabled and to periodically run auto-balance while TDM is enabled. 
- Extend `/tdm` admin command (`CommandTDM`) with `friendlyfire <on|off>` and `autobalance <on|off|now>` subcommands and a `parseToggle` helper. 

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted to run `gradle compileJava` and `gradle test`, but both runs failed to resolve ForgeGradle metadata from configured repositories (HTTP 403), so compilation and tests could not be executed in this environment.
- No automated unit tests were added; runtime behavior validated through code inspection and local commits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0558b2c49c8323bd08c366efebc2b6)