### PR TITLE
Add TDM map voting and map-specific spawns

### DIFF
--- a/src/main/java/com/hfr/command/CommandTDM.java
+++ b/src/main/java/com/hfr/command/CommandTDM.java
@@ -7,6 +7,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
 
+import java.util.List;
+import java.util.Map;
+
 public class CommandTDM extends CommandBase {
 
     @Override
@@ -16,7 +19,7 @@ public class CommandTDM extends CommandBase {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "/tdm <toggle|friendlyfire <on|off>|autobalance <on|off|now>|addspawn <red|blue>|setteam <player> <red|blue>|clear>";
+        return "/tdm <vote <map>|maps|toggle|friendlyfire <on|off>|autobalance <on|off|now>|addspawn <red|blue>|map <create|delete|select|addspawn|clearspawns|list> ...|setteam <player> <red|blue>|clear>";
     }
 
     @Override
@@ -27,6 +30,34 @@ public class CommandTDM extends CommandBase {
         }
 
         World world = sender.getEntityWorld();
+
+        if (args[0].equalsIgnoreCase("maps") || args[0].equalsIgnoreCase("listmaps")) {
+            sendMapList(sender, world);
+            return;
+        }
+
+        if (args[0].equalsIgnoreCase("vote")) {
+            if (args.length < 2) {
+                sender.addChatMessage(new ChatComponentText("Usage: /tdm vote <map>"));
+                return;
+            }
+
+            EntityPlayer player = getCommandSenderAsPlayer(sender);
+            String selectedMap = TDMManager.voteForMap(world, player.getCommandSenderName(), args[1]);
+            if (selectedMap == null) {
+                sender.addChatMessage(new ChatComponentText("Unable to vote. TDM must be enabled and the map must exist."));
+                return;
+            }
+
+            sender.addChatMessage(new ChatComponentText("Voted for TDM map " + TDMManager.normalizeMapName(args[1]) + ". Selected map: " + selectedMap));
+            sendVoteCounts(sender, world);
+            return;
+        }
+
+        if (!isAdmin(sender)) {
+            sender.addChatMessage(new ChatComponentText("You can use /tdm maps or /tdm vote <map>."));
+            return;
+        }
 
         if (args[0].equalsIgnoreCase("toggle")) {
             boolean enabled = TDMManager.toggle(world);
@@ -74,6 +105,11 @@ public class CommandTDM extends CommandBase {
             return;
         }
 
+        if (args[0].equalsIgnoreCase("map")) {
+            processMapCommand(sender, args, world);
+            return;
+        }
+
         if (args[0].equalsIgnoreCase("addspawn")) {
             if (args.length < 2) {
                 sender.addChatMessage(new ChatComponentText("Usage: /tdm addspawn <red|blue>"));
@@ -97,7 +133,7 @@ public class CommandTDM extends CommandBase {
             );
 
             sender.addChatMessage(new ChatComponentText(
-                    "Spawn added for " + team.name + ". Total: " + TDMManager.getSpawnCount(world)
+                    "Legacy spawn added for " + team.name + ". Total: " + TDMManager.getSpawnCount(world)
                             + " (red: " + TDMManager.getSpawnCount(world, TDMManager.Team.RED)
                             + ", blue: " + TDMManager.getSpawnCount(world, TDMManager.Team.BLUE) + ")"
             ));
@@ -123,11 +159,135 @@ public class CommandTDM extends CommandBase {
 
         if (args[0].equalsIgnoreCase("clear")) {
             TDMManager.clearSpawns(world);
-            sender.addChatMessage(new ChatComponentText("TDM spawns cleared"));
+            sender.addChatMessage(new ChatComponentText("Legacy TDM spawns cleared"));
             return;
         }
 
         sender.addChatMessage(new ChatComponentText(getCommandUsage(sender)));
+    }
+
+    private void processMapCommand(ICommandSender sender, String[] args, World world) {
+        if (args.length < 2) {
+            sender.addChatMessage(new ChatComponentText("Usage: /tdm map <create|delete|select|addspawn|clearspawns|list>"));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("list")) {
+            sendMapList(sender, world);
+            return;
+        }
+
+        if (args.length < 3) {
+            sender.addChatMessage(new ChatComponentText("Usage: /tdm map " + args[1] + " <map>"));
+            return;
+        }
+
+        String mapName = TDMManager.normalizeMapName(args[2]);
+        if (mapName.length() == 0) {
+            sender.addChatMessage(new ChatComponentText("Map name cannot be empty."));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("create")) {
+            if (!TDMManager.createMap(world, mapName)) {
+                sender.addChatMessage(new ChatComponentText("TDM map already exists or has an invalid name: " + mapName));
+                return;
+            }
+            sender.addChatMessage(new ChatComponentText("Created TDM map: " + mapName));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("delete")) {
+            if (!TDMManager.deleteMap(world, mapName)) {
+                sender.addChatMessage(new ChatComponentText("Unknown TDM map: " + mapName));
+                return;
+            }
+            sender.addChatMessage(new ChatComponentText("Deleted TDM map: " + mapName));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("select")) {
+            if (!TDMManager.selectMap(world, mapName)) {
+                sender.addChatMessage(new ChatComponentText("Unknown TDM map: " + mapName));
+                return;
+            }
+            sender.addChatMessage(new ChatComponentText("Selected TDM map: " + mapName));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("clearspawns")) {
+            if (!TDMManager.clearMapSpawns(world, mapName)) {
+                sender.addChatMessage(new ChatComponentText("Unknown TDM map: " + mapName));
+                return;
+            }
+            sender.addChatMessage(new ChatComponentText("Cleared spawns for TDM map: " + mapName));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("addspawn")) {
+            if (args.length < 4) {
+                sender.addChatMessage(new ChatComponentText("Usage: /tdm map addspawn <map> <red|blue>"));
+                return;
+            }
+
+            TDMManager.Team team = TDMManager.Team.fromName(args[3]);
+            if (team == null) {
+                sender.addChatMessage(new ChatComponentText("Unknown TDM team: " + args[3]));
+                return;
+            }
+
+            EntityPlayer player = getCommandSenderAsPlayer(sender);
+            TDMManager.addMapSpawn(world, mapName, team, player.dimension, (int) player.posX, (int) player.posY, (int) player.posZ);
+            sender.addChatMessage(new ChatComponentText(
+                    "Spawn added for " + team.name + " on map " + mapName + ". Total: " + TDMManager.getMapSpawnCount(world, mapName)
+                            + " (red: " + TDMManager.getMapSpawnCount(world, mapName, TDMManager.Team.RED)
+                            + ", blue: " + TDMManager.getMapSpawnCount(world, mapName, TDMManager.Team.BLUE) + ")"
+            ));
+            return;
+        }
+
+        sender.addChatMessage(new ChatComponentText("Usage: /tdm map <create|delete|select|addspawn|clearspawns|list>"));
+    }
+
+    private void sendMapList(ICommandSender sender, World world) {
+        List<String> maps = TDMManager.getMapNames(world);
+        if (maps.isEmpty()) {
+            sender.addChatMessage(new ChatComponentText("No TDM maps defined. Admins can use /tdm map create <map>."));
+            return;
+        }
+
+        String selected = TDMManager.getSelectedMap(world);
+        sender.addChatMessage(new ChatComponentText("TDM maps: " + join(maps) + ". Selected: " + (selected.length() == 0 ? "none" : selected)));
+        sendVoteCounts(sender, world);
+    }
+
+    private void sendVoteCounts(ICommandSender sender, World world) {
+        Map<String, Integer> votes = TDMManager.getVoteCounts(world);
+        if (votes.isEmpty()) {
+            return;
+        }
+
+        String message = "Votes: ";
+        boolean first = true;
+        for (Map.Entry<String, Integer> entry : votes.entrySet()) {
+            if (!first) {
+                message += ", ";
+            }
+            message += entry.getKey() + "=" + entry.getValue();
+            first = false;
+        }
+        sender.addChatMessage(new ChatComponentText(message));
+    }
+
+    private String join(List<String> values) {
+        String joined = "";
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                joined += ", ";
+            }
+            joined += values.get(i);
+        }
+        return joined;
     }
 
     private Boolean parseToggle(String value) {
@@ -142,8 +302,17 @@ public class CommandTDM extends CommandBase {
         return null;
     }
 
+    private boolean isAdmin(ICommandSender sender) {
+        return sender.canCommandSenderUseCommand(4, getCommandName());
+    }
+
     @Override
     public int getRequiredPermissionLevel() {
-        return 4;
+        return 0;
+    }
+
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        return true;
     }
 }

--- a/src/main/java/com/hfr/tdm/TDMData.java
+++ b/src/main/java/com/hfr/tdm/TDMData.java
@@ -8,6 +8,7 @@ import net.minecraftforge.common.DimensionManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -18,8 +19,11 @@ public class TDMData extends WorldSavedData {
     public boolean enabled = false;
     public boolean friendlyFireEnabled = true;
     public boolean autoBalanceEnabled = true;
+    public String selectedMap = "";
     public final List<TDMManager.SpawnPoint> spawns = new ArrayList<TDMManager.SpawnPoint>();
+    public final Map<String, TDMManager.TDMMap> maps = new LinkedHashMap<String, TDMManager.TDMMap>();
     public final Map<String, TDMManager.Team> playerTeams = new HashMap<String, TDMManager.Team>();
+    public final Map<String, String> mapVotes = new HashMap<String, String>();
 
     public TDMData(String name) {
         super(name);
@@ -52,24 +56,42 @@ public class TDMData extends WorldSavedData {
         enabled = nbt.getBoolean("enabled");
         friendlyFireEnabled = !nbt.hasKey("friendlyFireEnabled") || nbt.getBoolean("friendlyFireEnabled");
         autoBalanceEnabled = !nbt.hasKey("autoBalanceEnabled") || nbt.getBoolean("autoBalanceEnabled");
+        selectedMap = nbt.hasKey("selectedMap") ? nbt.getString("selectedMap").toLowerCase() : "";
         spawns.clear();
+        maps.clear();
         playerTeams.clear();
+        mapVotes.clear();
 
         int spawnCount = nbt.getInteger("spawnCount");
         for (int i = 0; i < spawnCount; i++) {
             NBTTagCompound spawnTag = nbt.getCompoundTag("spawn" + i);
-            TDMManager.Team team = TDMManager.Team.fromName(spawnTag.getString("team"));
-            if (team == null) {
+            TDMManager.SpawnPoint spawn = readSpawn(spawnTag);
+            if (spawn != null) {
+                spawns.add(spawn);
+            }
+        }
+
+        int mapCount = nbt.getInteger("mapCount");
+        for (int i = 0; i < mapCount; i++) {
+            NBTTagCompound mapTag = nbt.getCompoundTag("map" + i);
+            String mapName = mapTag.getString("name").toLowerCase();
+            if (mapName.length() == 0) {
                 continue;
             }
 
-            spawns.add(new TDMManager.SpawnPoint(
-                    team,
-                    spawnTag.getInteger("dim"),
-                    spawnTag.getInteger("x"),
-                    spawnTag.getInteger("y"),
-                    spawnTag.getInteger("z")
-            ));
+            TDMManager.TDMMap map = new TDMManager.TDMMap(mapName);
+            int mapSpawnCount = mapTag.getInteger("spawnCount");
+            for (int j = 0; j < mapSpawnCount; j++) {
+                TDMManager.SpawnPoint spawn = readSpawn(mapTag.getCompoundTag("spawn" + j));
+                if (spawn != null) {
+                    map.spawns.add(spawn);
+                }
+            }
+            maps.put(map.name, map);
+        }
+
+        if (selectedMap.length() > 0 && !maps.containsKey(selectedMap)) {
+            selectedMap = "";
         }
 
         int playerCount = nbt.getInteger("playerCount");
@@ -80,6 +102,15 @@ public class TDMData extends WorldSavedData {
                 playerTeams.put(player.toLowerCase(), team);
             }
         }
+
+        int voteCount = nbt.getInteger("voteCount");
+        for (int i = 0; i < voteCount; i++) {
+            String player = nbt.getString("votePlayer" + i).toLowerCase();
+            String map = nbt.getString("voteMap" + i).toLowerCase();
+            if (player.length() > 0 && maps.containsKey(map)) {
+                mapVotes.put(player, map);
+            }
+        }
     }
 
     @Override
@@ -87,18 +118,25 @@ public class TDMData extends WorldSavedData {
         nbt.setBoolean("enabled", enabled);
         nbt.setBoolean("friendlyFireEnabled", friendlyFireEnabled);
         nbt.setBoolean("autoBalanceEnabled", autoBalanceEnabled);
+        nbt.setString("selectedMap", selectedMap);
         nbt.setInteger("spawnCount", spawns.size());
 
         for (int i = 0; i < spawns.size(); i++) {
-            TDMManager.SpawnPoint spawn = spawns.get(i);
-            NBTTagCompound spawnTag = new NBTTagCompound();
-            spawnTag.setString("team", spawn.team.name);
-            spawnTag.setInteger("dim", spawn.dim);
-            spawnTag.setInteger("x", spawn.x);
-            spawnTag.setInteger("y", spawn.y);
-            spawnTag.setInteger("z", spawn.z);
-            nbt.setTag("spawn" + i, spawnTag);
+            nbt.setTag("spawn" + i, writeSpawn(spawns.get(i)));
         }
+
+        int mapIndex = 0;
+        for (TDMManager.TDMMap map : maps.values()) {
+            NBTTagCompound mapTag = new NBTTagCompound();
+            mapTag.setString("name", map.name);
+            mapTag.setInteger("spawnCount", map.spawns.size());
+            for (int i = 0; i < map.spawns.size(); i++) {
+                mapTag.setTag("spawn" + i, writeSpawn(map.spawns.get(i)));
+            }
+            nbt.setTag("map" + mapIndex, mapTag);
+            mapIndex++;
+        }
+        nbt.setInteger("mapCount", mapIndex);
 
         int playerIndex = 0;
         for (Map.Entry<String, TDMManager.Team> entry : playerTeams.entrySet()) {
@@ -107,5 +145,38 @@ public class TDMData extends WorldSavedData {
             playerIndex++;
         }
         nbt.setInteger("playerCount", playerIndex);
+
+        int voteIndex = 0;
+        for (Map.Entry<String, String> entry : mapVotes.entrySet()) {
+            nbt.setString("votePlayer" + voteIndex, entry.getKey());
+            nbt.setString("voteMap" + voteIndex, entry.getValue());
+            voteIndex++;
+        }
+        nbt.setInteger("voteCount", voteIndex);
+    }
+
+    private TDMManager.SpawnPoint readSpawn(NBTTagCompound spawnTag) {
+        TDMManager.Team team = TDMManager.Team.fromName(spawnTag.getString("team"));
+        if (team == null) {
+            return null;
+        }
+
+        return new TDMManager.SpawnPoint(
+                team,
+                spawnTag.getInteger("dim"),
+                spawnTag.getInteger("x"),
+                spawnTag.getInteger("y"),
+                spawnTag.getInteger("z")
+        );
+    }
+
+    private NBTTagCompound writeSpawn(TDMManager.SpawnPoint spawn) {
+        NBTTagCompound spawnTag = new NBTTagCompound();
+        spawnTag.setString("team", spawn.team.name);
+        spawnTag.setInteger("dim", spawn.dim);
+        spawnTag.setInteger("x", spawn.x);
+        spawnTag.setInteger("y", spawn.y);
+        spawnTag.setInteger("z", spawn.z);
+        return spawnTag;
     }
 }

--- a/src/main/java/com/hfr/tdm/TDMManager.java
+++ b/src/main/java/com/hfr/tdm/TDMManager.java
@@ -12,7 +12,9 @@ import net.minecraft.world.World;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -43,6 +45,15 @@ public class TDMManager {
             }
 
             return null;
+        }
+    }
+
+    public static class TDMMap {
+        public final String name;
+        public final List<SpawnPoint> spawns = new ArrayList<SpawnPoint>();
+
+        public TDMMap(String name) {
+            this.name = normalizeMapName(name);
         }
     }
 
@@ -97,6 +108,180 @@ public class TDMManager {
         TDMData data = TDMData.get(world);
         data.autoBalanceEnabled = enabled;
         data.markDirty();
+    }
+
+
+    public static boolean createMap(World world, String mapName) {
+        String normalized = normalizeMapName(mapName);
+        if (normalized.length() == 0) {
+            return false;
+        }
+
+        TDMData data = TDMData.get(world);
+        if (data.maps.containsKey(normalized)) {
+            return false;
+        }
+
+        data.maps.put(normalized, new TDMMap(normalized));
+        if (data.selectedMap.length() == 0) {
+            data.selectedMap = normalized;
+        }
+        data.markDirty();
+        return true;
+    }
+
+    public static boolean deleteMap(World world, String mapName) {
+        String normalized = normalizeMapName(mapName);
+        TDMData data = TDMData.get(world);
+        if (data.maps.remove(normalized) == null) {
+            return false;
+        }
+
+        if (data.selectedMap.equals(normalized)) {
+            data.selectedMap = "";
+        }
+
+        List<String> playersToClear = new ArrayList<String>();
+        for (Map.Entry<String, String> entry : data.mapVotes.entrySet()) {
+            if (entry.getValue().equals(normalized)) {
+                playersToClear.add(entry.getKey());
+            }
+        }
+        for (String player : playersToClear) {
+            data.mapVotes.remove(player);
+        }
+
+        data.markDirty();
+        return true;
+    }
+
+    public static boolean selectMap(World world, String mapName) {
+        String normalized = normalizeMapName(mapName);
+        TDMData data = TDMData.get(world);
+        if (!data.maps.containsKey(normalized)) {
+            return false;
+        }
+
+        data.selectedMap = normalized;
+        data.markDirty();
+        return true;
+    }
+
+    public static String getSelectedMap(World world) {
+        return TDMData.get(world).selectedMap;
+    }
+
+    public static boolean hasMap(World world, String mapName) {
+        return TDMData.get(world).maps.containsKey(normalizeMapName(mapName));
+    }
+
+    public static List<String> getMapNames(World world) {
+        return new ArrayList<String>(TDMData.get(world).maps.keySet());
+    }
+
+    public static void addMapSpawn(World world, String mapName, Team team, int dim, int x, int y, int z) {
+        TDMData data = TDMData.get(world);
+        String normalized = normalizeMapName(mapName);
+        TDMMap map = data.maps.get(normalized);
+        if (map == null) {
+            map = new TDMMap(normalized);
+            data.maps.put(normalized, map);
+        }
+
+        map.spawns.add(new SpawnPoint(team, dim, x, y, z));
+        if (data.selectedMap.length() == 0) {
+            data.selectedMap = normalized;
+        }
+        data.markDirty();
+    }
+
+    public static boolean clearMapSpawns(World world, String mapName) {
+        TDMMap map = TDMData.get(world).maps.get(normalizeMapName(mapName));
+        if (map == null) {
+            return false;
+        }
+
+        map.spawns.clear();
+        TDMData.get(world).markDirty();
+        return true;
+    }
+
+    public static int getMapSpawnCount(World world, String mapName) {
+        TDMMap map = TDMData.get(world).maps.get(normalizeMapName(mapName));
+        return map == null ? 0 : map.spawns.size();
+    }
+
+    public static int getMapSpawnCount(World world, String mapName, Team team) {
+        TDMMap map = TDMData.get(world).maps.get(normalizeMapName(mapName));
+        if (map == null) {
+            return 0;
+        }
+
+        int count = 0;
+        for (SpawnPoint spawn : map.spawns) {
+            if (spawn.team == team) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public static String voteForMap(World world, String playerName, String mapName) {
+        String normalized = normalizeMapName(mapName);
+        TDMData data = TDMData.get(world);
+        if (!data.enabled || !data.maps.containsKey(normalized)) {
+            return null;
+        }
+
+        data.mapVotes.put(playerName.toLowerCase(), normalized);
+        String winner = getWinningMap(data);
+        if (winner != null && !winner.equals(data.selectedMap)) {
+            data.selectedMap = winner;
+        }
+        data.markDirty();
+        return data.selectedMap;
+    }
+
+    public static Map<String, Integer> getVoteCounts(World world) {
+        TDMData data = TDMData.get(world);
+        Map<String, Integer> counts = new LinkedHashMap<String, Integer>();
+        for (String mapName : data.maps.keySet()) {
+            counts.put(mapName, Integer.valueOf(0));
+        }
+        for (String mapName : data.mapVotes.values()) {
+            if (counts.containsKey(mapName)) {
+                counts.put(mapName, Integer.valueOf(counts.get(mapName).intValue() + 1));
+            }
+        }
+        return counts;
+    }
+
+    private static String getWinningMap(TDMData data) {
+        String winner = null;
+        int winnerVotes = -1;
+        Map<String, Integer> counts = new LinkedHashMap<String, Integer>();
+        for (String mapName : data.maps.keySet()) {
+            counts.put(mapName, Integer.valueOf(0));
+        }
+        for (String mapName : data.mapVotes.values()) {
+            if (counts.containsKey(mapName)) {
+                counts.put(mapName, Integer.valueOf(counts.get(mapName).intValue() + 1));
+            }
+        }
+        for (Map.Entry<String, Integer> entry : counts.entrySet()) {
+            if (entry.getValue().intValue() > winnerVotes) {
+                winner = entry.getKey();
+                winnerVotes = entry.getValue().intValue();
+            }
+        }
+        return winner;
+    }
+
+    public static String normalizeMapName(String mapName) {
+        if (mapName == null) {
+            return "";
+        }
+        return mapName.trim().toLowerCase();
     }
 
     public static void addSpawn(World world, Team team, int dim, int x, int y, int z) {
@@ -344,11 +529,16 @@ public class TDMManager {
     }
 
     public static SpawnPoint getRandomSpawn(World world, Team team, Random rand) {
+        TDMData data = TDMData.get(world);
         List<SpawnPoint> valid = new ArrayList<SpawnPoint>();
-        for (SpawnPoint spawn : TDMData.get(world).spawns) {
-            if (spawn.team == team && spawn.dim == world.provider.dimensionId) {
-                valid.add(spawn);
-            }
+        TDMMap selected = data.maps.get(data.selectedMap);
+
+        if (selected != null) {
+            addValidSpawns(valid, selected.spawns, team, world.provider.dimensionId);
+        }
+
+        if (valid.isEmpty()) {
+            addValidSpawns(valid, data.spawns, team, world.provider.dimensionId);
         }
 
         if (valid.isEmpty()) {
@@ -356,5 +546,13 @@ public class TDMManager {
         }
 
         return valid.get(rand.nextInt(valid.size()));
+    }
+
+    private static void addValidSpawns(List<SpawnPoint> valid, List<SpawnPoint> spawns, Team team, int dim) {
+        for (SpawnPoint spawn : spawns) {
+            if (spawn.team == team && spawn.dim == dim) {
+                valid.add(spawn);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a way to define named TDM maps and let players vote on which map's spawn set should be used for team spawns. 
- Allow admins to manage map definitions and map-specific spawn points so respawns/teams can be placed per-map rather than only via a single global spawn list.

### Description
- Persist map state by extending `TDMData` with `selectedMap`, a `maps` registry (`TDMMap`), and `mapVotes`, and read/write them to NBT so maps and votes survive restarts. 
- Add `TDMMap` and map management APIs in `TDMManager` including `createMap`, `deleteMap`, `selectMap`, `addMapSpawn`, `clearMapSpawns`, `getMapNames`, `getMapSpawnCount`, `voteForMap`, `getVoteCounts`, `getWinningMap` and `normalizeMapName`. 
- Change respawn logic so `getRandomSpawn` prefers the currently selected map's spawn set and falls back to legacy global spawns when the selected map has no valid team/dimension spawns, and add `addValidSpawns` helper. 
- Extend the `/tdm` command (`CommandTDM`) to expose player-facing `maps` and `vote <map>` commands and admin `map <create|delete|select|addspawn|clearspawns|list>` subcommands, plus listing vote counts; keep legacy `addspawn`/`clear` as "legacy" global spawns.

### Testing
- Ran `git diff --check` and local repository checks to validate changes (no diff-check issues reported). 
- Attempted a Java compile via `gradle compileJava`, but the build was blocked by remote dependency resolution (ForgeGradle metadata requests returned HTTP 403), so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a055ff882ac83239bcc03f8fb4b1407)