### PR TITLE
TDM: add map system, voting, per-map kits, HUD, packets and command extensions

### DIFF
--- a/src/main/java/com/hfr/command/CommandKit.java
+++ b/src/main/java/com/hfr/command/CommandKit.java
@@ -16,7 +16,7 @@ public class CommandKit extends CommandBase {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "/kit <blue|red>";
+        return "/kit <blue|red> [map]";
     }
 
     @Override
@@ -33,8 +33,10 @@ public class CommandKit extends CommandBase {
         }
 
         EntityPlayer player = getCommandSenderAsPlayer(sender);
-        int kitCount = TDMKitManager.addKit(team, player);
-        sender.addChatMessage(new ChatComponentText("Saved " + team.name + " kit #" + kitCount + " from your inventory to tdm_kits.txt"));
+        String mapName = args.length >= 2 ? TDMManager.normalizeMapName(args[1]) : TDMManager.getSelectedMap(sender.getEntityWorld());
+        int kitCount = TDMKitManager.addKit(mapName, team, player);
+        String mapText = mapName.length() > 0 ? " for map " + mapName : " as a global fallback";
+        sender.addChatMessage(new ChatComponentText("Saved " + team.name + " kit #" + kitCount + mapText + " from your inventory to tdm_kits.txt"));
     }
 
     @Override

--- a/src/main/java/com/hfr/command/CommandTDM.java
+++ b/src/main/java/com/hfr/command/CommandTDM.java
@@ -7,6 +7,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
 
+import java.util.List;
+import java.util.Map;
+
 public class CommandTDM extends CommandBase {
 
     @Override
@@ -16,7 +19,7 @@ public class CommandTDM extends CommandBase {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "/tdm <toggle|friendlyfire <on|off>|autobalance <on|off|now>|addspawn <red|blue>|setteam <player> <red|blue>|clear>";
+        return "/tdm <vote <map>|maps|toggle|friendlyfire <on|off>|autobalance <on|off|now>|addspawn <red|blue>|map <create|delete|select|addspawn|clearspawns|list> ...|setteam <player> <red|blue>|clear>";
     }
 
     @Override
@@ -27,6 +30,34 @@ public class CommandTDM extends CommandBase {
         }
 
         World world = sender.getEntityWorld();
+
+        if (args[0].equalsIgnoreCase("maps") || args[0].equalsIgnoreCase("listmaps")) {
+            sendMapList(sender, world);
+            return;
+        }
+
+        if (args[0].equalsIgnoreCase("vote")) {
+            if (args.length < 2) {
+                sender.addChatMessage(new ChatComponentText("Usage: /tdm vote <map>"));
+                return;
+            }
+
+            EntityPlayer player = getCommandSenderAsPlayer(sender);
+            String votedMap = TDMManager.voteForMap(world, player.getCommandSenderName(), args[1]);
+            if (votedMap == null) {
+                sender.addChatMessage(new ChatComponentText("Unable to vote. A TDM map vote must be active and the map must exist."));
+                return;
+            }
+
+            sender.addChatMessage(new ChatComponentText("Voted for TDM map " + votedMap + "."));
+            sendVoteCounts(sender, world);
+            return;
+        }
+
+        if (!isAdmin(sender)) {
+            sender.addChatMessage(new ChatComponentText("You can use /tdm maps or /tdm vote <map>."));
+            return;
+        }
 
         if (args[0].equalsIgnoreCase("toggle")) {
             boolean enabled = TDMManager.toggle(world);
@@ -74,6 +105,11 @@ public class CommandTDM extends CommandBase {
             return;
         }
 
+        if (args[0].equalsIgnoreCase("map")) {
+            processMapCommand(sender, args, world);
+            return;
+        }
+
         if (args[0].equalsIgnoreCase("addspawn")) {
             if (args.length < 2) {
                 sender.addChatMessage(new ChatComponentText("Usage: /tdm addspawn <red|blue>"));
@@ -97,7 +133,7 @@ public class CommandTDM extends CommandBase {
             );
 
             sender.addChatMessage(new ChatComponentText(
-                    "Spawn added for " + team.name + ". Total: " + TDMManager.getSpawnCount(world)
+                    "Legacy spawn added for " + team.name + ". Total: " + TDMManager.getSpawnCount(world)
                             + " (red: " + TDMManager.getSpawnCount(world, TDMManager.Team.RED)
                             + ", blue: " + TDMManager.getSpawnCount(world, TDMManager.Team.BLUE) + ")"
             ));
@@ -123,11 +159,135 @@ public class CommandTDM extends CommandBase {
 
         if (args[0].equalsIgnoreCase("clear")) {
             TDMManager.clearSpawns(world);
-            sender.addChatMessage(new ChatComponentText("TDM spawns cleared"));
+            sender.addChatMessage(new ChatComponentText("Legacy TDM spawns cleared"));
             return;
         }
 
         sender.addChatMessage(new ChatComponentText(getCommandUsage(sender)));
+    }
+
+    private void processMapCommand(ICommandSender sender, String[] args, World world) {
+        if (args.length < 2) {
+            sender.addChatMessage(new ChatComponentText("Usage: /tdm map <create|delete|select|addspawn|clearspawns|list>"));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("list")) {
+            sendMapList(sender, world);
+            return;
+        }
+
+        if (args.length < 3) {
+            sender.addChatMessage(new ChatComponentText("Usage: /tdm map " + args[1] + " <map>"));
+            return;
+        }
+
+        String mapName = TDMManager.normalizeMapName(args[2]);
+        if (mapName.length() == 0) {
+            sender.addChatMessage(new ChatComponentText("Map name cannot be empty."));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("create")) {
+            if (!TDMManager.createMap(world, mapName)) {
+                sender.addChatMessage(new ChatComponentText("TDM map already exists or has an invalid name: " + mapName));
+                return;
+            }
+            sender.addChatMessage(new ChatComponentText("Created TDM map: " + mapName));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("delete")) {
+            if (!TDMManager.deleteMap(world, mapName)) {
+                sender.addChatMessage(new ChatComponentText("Unknown TDM map: " + mapName));
+                return;
+            }
+            sender.addChatMessage(new ChatComponentText("Deleted TDM map: " + mapName));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("select")) {
+            if (!TDMManager.selectMap(world, mapName)) {
+                sender.addChatMessage(new ChatComponentText("Unknown TDM map: " + mapName));
+                return;
+            }
+            sender.addChatMessage(new ChatComponentText("Selected TDM map: " + mapName));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("clearspawns")) {
+            if (!TDMManager.clearMapSpawns(world, mapName)) {
+                sender.addChatMessage(new ChatComponentText("Unknown TDM map: " + mapName));
+                return;
+            }
+            sender.addChatMessage(new ChatComponentText("Cleared spawns for TDM map: " + mapName));
+            return;
+        }
+
+        if (args[1].equalsIgnoreCase("addspawn")) {
+            if (args.length < 4) {
+                sender.addChatMessage(new ChatComponentText("Usage: /tdm map addspawn <map> <red|blue>"));
+                return;
+            }
+
+            TDMManager.Team team = TDMManager.Team.fromName(args[3]);
+            if (team == null) {
+                sender.addChatMessage(new ChatComponentText("Unknown TDM team: " + args[3]));
+                return;
+            }
+
+            EntityPlayer player = getCommandSenderAsPlayer(sender);
+            TDMManager.addMapSpawn(world, mapName, team, player.dimension, (int) player.posX, (int) player.posY, (int) player.posZ);
+            sender.addChatMessage(new ChatComponentText(
+                    "Spawn added for " + team.name + " on map " + mapName + ". Total: " + TDMManager.getMapSpawnCount(world, mapName)
+                            + " (red: " + TDMManager.getMapSpawnCount(world, mapName, TDMManager.Team.RED)
+                            + ", blue: " + TDMManager.getMapSpawnCount(world, mapName, TDMManager.Team.BLUE) + ")"
+            ));
+            return;
+        }
+
+        sender.addChatMessage(new ChatComponentText("Usage: /tdm map <create|delete|select|addspawn|clearspawns|list>"));
+    }
+
+    private void sendMapList(ICommandSender sender, World world) {
+        List<String> maps = TDMManager.getMapNames(world);
+        if (maps.isEmpty()) {
+            sender.addChatMessage(new ChatComponentText("No TDM maps defined. Admins can use /tdm map create <map>."));
+            return;
+        }
+
+        String selected = TDMManager.getSelectedMap(world);
+        sender.addChatMessage(new ChatComponentText("TDM maps: " + join(maps) + ". Selected: " + (selected.length() == 0 ? "none" : selected)));
+        sendVoteCounts(sender, world);
+    }
+
+    private void sendVoteCounts(ICommandSender sender, World world) {
+        Map<String, Integer> votes = TDMManager.getVoteCounts(world);
+        if (votes.isEmpty()) {
+            return;
+        }
+
+        String message = "Votes: ";
+        boolean first = true;
+        for (Map.Entry<String, Integer> entry : votes.entrySet()) {
+            if (!first) {
+                message += ", ";
+            }
+            message += entry.getKey() + "=" + entry.getValue();
+            first = false;
+        }
+        sender.addChatMessage(new ChatComponentText(message));
+    }
+
+    private String join(List<String> values) {
+        String joined = "";
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                joined += ", ";
+            }
+            joined += values.get(i);
+        }
+        return joined;
     }
 
     private Boolean parseToggle(String value) {
@@ -142,8 +302,17 @@ public class CommandTDM extends CommandBase {
         return null;
     }
 
+    private boolean isAdmin(ICommandSender sender) {
+        return sender.canCommandSenderUseCommand(4, getCommandName());
+    }
+
     @Override
     public int getRequiredPermissionLevel() {
-        return 4;
+        return 0;
+    }
+
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        return true;
     }
 }

--- a/src/main/java/com/hfr/inventory/gui/GUITDMMapVote.java
+++ b/src/main/java/com/hfr/inventory/gui/GUITDMMapVote.java
@@ -1,0 +1,51 @@
+package com.hfr.inventory.gui;
+
+import com.hfr.packet.PacketDispatcher;
+import com.hfr.packet.client.TDMMapVoteSelectPacket;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.util.EnumChatFormatting;
+
+public class GUITDMMapVote extends GuiScreen {
+
+    private final String[] mapNames;
+    private final int voteSeconds;
+
+    public GUITDMMapVote(String[] mapNames, int voteSeconds) {
+        this.mapNames = mapNames;
+        this.voteSeconds = voteSeconds;
+    }
+
+    @Override
+    public void initGui() {
+        this.buttonList.clear();
+        int x = this.width / 2 - 100;
+        int y = this.height / 2 - (mapNames.length * 24) / 2;
+
+        for (int i = 0; i < mapNames.length; i++) {
+            this.buttonList.add(new GuiButton(i, x, y + i * 24, 200, 20, mapNames[i]));
+        }
+    }
+
+    @Override
+    protected void actionPerformed(GuiButton button) {
+        if (button.id >= 0 && button.id < mapNames.length) {
+            PacketDispatcher.wrapper.sendToServer(new TDMMapVoteSelectPacket(mapNames[button.id]));
+        }
+        this.mc.displayGuiScreen(null);
+    }
+
+    @Override
+    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+        this.drawDefaultBackground();
+        int y = this.height / 2 - (mapNames.length * 24) / 2 - 32;
+        this.drawCenteredString(this.fontRendererObj, EnumChatFormatting.BOLD + "Vote for the next TDM map", this.width / 2, y, 0xFFFFFF);
+        this.drawCenteredString(this.fontRendererObj, "Voting ends in " + voteSeconds + " seconds.", this.width / 2, y + 12, 0xA0A0A0);
+        super.drawScreen(mouseX, mouseY, partialTicks);
+    }
+
+    @Override
+    public boolean doesGuiPauseGame() {
+        return false;
+    }
+}

--- a/src/main/java/com/hfr/main/EventHandlerClient.java
+++ b/src/main/java/com/hfr/main/EventHandlerClient.java
@@ -30,6 +30,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderManager;
@@ -65,9 +66,55 @@ public class EventHandlerClient {
 	public static boolean tilt = false;
 	public static boolean shader = false;
 	
+	private static boolean tdmHudEnabled = false;
+	private static boolean tdmVoting = false;
+	private static int tdmRoundSeconds = 0;
+	private static int tdmVoteSeconds = 0;
+	private static int tdmRedScore = 0;
+	private static int tdmBlueScore = 0;
+	private static String tdmMapName = "";
+
 	public static List<int[]> resourceBorders = new ArrayList();
 	boolean resources = false;
 	
+	public static void updateTDMStatus(boolean enabled, boolean voting, int roundSeconds, int voteSeconds, int redScore, int blueScore, String mapName) {
+		tdmHudEnabled = enabled;
+		tdmVoting = voting;
+		tdmRoundSeconds = roundSeconds;
+		tdmVoteSeconds = voteSeconds;
+		tdmRedScore = redScore;
+		tdmBlueScore = blueScore;
+		tdmMapName = mapName == null ? "" : mapName;
+	}
+
+	private static void drawTDMHud() {
+		if (!tdmHudEnabled) {
+			return;
+		}
+
+		Minecraft mc = Minecraft.getMinecraft();
+		if (mc == null || mc.fontRenderer == null) {
+			return;
+		}
+
+		FontRenderer font = mc.fontRenderer;
+		String timer = tdmVoting ? "Map vote: " + formatSeconds(tdmVoteSeconds) : "Round: " + formatSeconds(tdmRoundSeconds);
+		String map = tdmMapName.length() > 0 ? " Map: " + tdmMapName : "";
+		String text = timer + "  Red: " + tdmRedScore + "  Blue: " + tdmBlueScore + map;
+		ScaledResolution resolution = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
+		int x = (resolution.getScaledWidth() - font.getStringWidth(text)) / 2;
+		font.drawStringWithShadow(text, Math.max(2, x), 6, tdmVoting ? 0xFFFF55 : 0xFFFFFF);
+	}
+
+	private static String formatSeconds(int seconds) {
+		if (seconds < 0) {
+			seconds = 0;
+		}
+		int minutes = seconds / 60;
+		int secs = seconds % 60;
+		return minutes + ":" + (secs < 10 ? "0" : "") + secs;
+	}
+
 	public void register() {
 
 		MinecraftForge.EVENT_BUS.register(this);
@@ -79,6 +126,10 @@ public class EventHandlerClient {
 		
 		EntityPlayer player = Minecraft.getMinecraft().thePlayer;
 		
+		if(event.type == ElementType.TEXT) {
+			drawTDMHud();
+		}
+
 		if(event.type == ElementType.CROSSHAIRS)
 		{
 			//anti-ragex mechanism, do not delete - oops i deleted it

--- a/src/main/java/com/hfr/packet/PacketDispatcher.java
+++ b/src/main/java/com/hfr/packet/PacketDispatcher.java
@@ -73,6 +73,9 @@ public class PacketDispatcher {
 		wrapper.registerMessage(PacketAddImage.Handler.class, PacketAddImage.class, i++, Side.SERVER);
 		wrapper.registerMessage(TDMKitGuiPacket.Handler.class, TDMKitGuiPacket.class, i++, Side.CLIENT);
 		wrapper.registerMessage(TDMKitSelectPacket.Handler.class, TDMKitSelectPacket.class, i++, Side.SERVER);
+		wrapper.registerMessage(TDMStatusPacket.Handler.class, TDMStatusPacket.class, i++, Side.CLIENT);
+		wrapper.registerMessage(TDMMapVoteGuiPacket.Handler.class, TDMMapVoteGuiPacket.class, i++, Side.CLIENT);
+		wrapper.registerMessage(TDMMapVoteSelectPacket.Handler.class, TDMMapVoteSelectPacket.class, i++, Side.SERVER);
 
 	}
 	

--- a/src/main/java/com/hfr/packet/client/TDMMapVoteSelectPacket.java
+++ b/src/main/java/com/hfr/packet/client/TDMMapVoteSelectPacket.java
@@ -1,0 +1,45 @@
+package com.hfr.packet.client;
+
+import com.hfr.tdm.TDMManager;
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChatComponentText;
+
+public class TDMMapVoteSelectPacket implements IMessage {
+
+    private String mapName;
+
+    public TDMMapVoteSelectPacket() { }
+
+    public TDMMapVoteSelectPacket(String mapName) {
+        this.mapName = mapName;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        mapName = ByteBufUtils.readUTF8String(buf);
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        ByteBufUtils.writeUTF8String(buf, mapName);
+    }
+
+    public static class Handler implements IMessageHandler<TDMMapVoteSelectPacket, IMessage> {
+
+        @Override
+        public IMessage onMessage(TDMMapVoteSelectPacket message, MessageContext ctx) {
+            EntityPlayer player = ctx.getServerHandler().playerEntity;
+            if (!TDMManager.isMapVoteActive(player.worldObj) || TDMManager.voteForMap(player.worldObj, player.getCommandSenderName(), message.mapName) == null) {
+                player.addChatMessage(new ChatComponentText("Unable to vote for that TDM map."));
+            } else {
+                player.addChatMessage(new ChatComponentText("Voted for TDM map " + TDMManager.normalizeMapName(message.mapName) + "."));
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/hfr/packet/effect/TDMMapVoteGuiPacket.java
+++ b/src/main/java/com/hfr/packet/effect/TDMMapVoteGuiPacket.java
@@ -1,0 +1,53 @@
+package com.hfr.packet.effect;
+
+import com.hfr.inventory.gui.GUITDMMapVote;
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.Minecraft;
+
+public class TDMMapVoteGuiPacket implements IMessage {
+
+    private String[] mapNames;
+    private int voteSeconds;
+
+    public TDMMapVoteGuiPacket() { }
+
+    public TDMMapVoteGuiPacket(String[] mapNames, int voteSeconds) {
+        this.mapNames = mapNames;
+        this.voteSeconds = voteSeconds;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        voteSeconds = buf.readInt();
+        int count = buf.readInt();
+        mapNames = new String[count];
+        for (int i = 0; i < count; i++) {
+            mapNames[i] = ByteBufUtils.readUTF8String(buf);
+        }
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(voteSeconds);
+        buf.writeInt(mapNames.length);
+        for (int i = 0; i < mapNames.length; i++) {
+            ByteBufUtils.writeUTF8String(buf, mapNames[i]);
+        }
+    }
+
+    public static class Handler implements IMessageHandler<TDMMapVoteGuiPacket, IMessage> {
+
+        @Override
+        @SideOnly(Side.CLIENT)
+        public IMessage onMessage(TDMMapVoteGuiPacket message, MessageContext ctx) {
+            Minecraft.getMinecraft().displayGuiScreen(new GUITDMMapVote(message.mapNames, message.voteSeconds));
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/hfr/packet/effect/TDMStatusPacket.java
+++ b/src/main/java/com/hfr/packet/effect/TDMStatusPacket.java
@@ -1,0 +1,65 @@
+package com.hfr.packet.effect;
+
+import com.hfr.main.EventHandlerClient;
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+
+public class TDMStatusPacket implements IMessage {
+
+    private boolean enabled;
+    private boolean voting;
+    private int roundSeconds;
+    private int voteSeconds;
+    private int redScore;
+    private int blueScore;
+    private String mapName;
+
+    public TDMStatusPacket() { }
+
+    public TDMStatusPacket(boolean enabled, boolean voting, int roundSeconds, int voteSeconds, int redScore, int blueScore, String mapName) {
+        this.enabled = enabled;
+        this.voting = voting;
+        this.roundSeconds = roundSeconds;
+        this.voteSeconds = voteSeconds;
+        this.redScore = redScore;
+        this.blueScore = blueScore;
+        this.mapName = mapName == null ? "" : mapName;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        enabled = buf.readBoolean();
+        voting = buf.readBoolean();
+        roundSeconds = buf.readInt();
+        voteSeconds = buf.readInt();
+        redScore = buf.readInt();
+        blueScore = buf.readInt();
+        mapName = ByteBufUtils.readUTF8String(buf);
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeBoolean(enabled);
+        buf.writeBoolean(voting);
+        buf.writeInt(roundSeconds);
+        buf.writeInt(voteSeconds);
+        buf.writeInt(redScore);
+        buf.writeInt(blueScore);
+        ByteBufUtils.writeUTF8String(buf, mapName);
+    }
+
+    public static class Handler implements IMessageHandler<TDMStatusPacket, IMessage> {
+
+        @Override
+        @SideOnly(Side.CLIENT)
+        public IMessage onMessage(TDMStatusPacket message, MessageContext ctx) {
+            EventHandlerClient.updateTDMStatus(message.enabled, message.voting, message.roundSeconds, message.voteSeconds, message.redScore, message.blueScore, message.mapName);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/hfr/tdm/TDMData.java
+++ b/src/main/java/com/hfr/tdm/TDMData.java
@@ -8,6 +8,7 @@ import net.minecraftforge.common.DimensionManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -18,8 +19,16 @@ public class TDMData extends WorldSavedData {
     public boolean enabled = false;
     public boolean friendlyFireEnabled = true;
     public boolean autoBalanceEnabled = true;
+    public String selectedMap = "";
+    public int redScore = 0;
+    public int blueScore = 0;
+    public long roundEndTick = 0;
+    public boolean mapVoteActive = false;
+    public long mapVoteEndTick = 0;
     public final List<TDMManager.SpawnPoint> spawns = new ArrayList<TDMManager.SpawnPoint>();
+    public final Map<String, TDMManager.TDMMap> maps = new LinkedHashMap<String, TDMManager.TDMMap>();
     public final Map<String, TDMManager.Team> playerTeams = new HashMap<String, TDMManager.Team>();
+    public final Map<String, String> mapVotes = new HashMap<String, String>();
 
     public TDMData(String name) {
         super(name);
@@ -52,24 +61,47 @@ public class TDMData extends WorldSavedData {
         enabled = nbt.getBoolean("enabled");
         friendlyFireEnabled = !nbt.hasKey("friendlyFireEnabled") || nbt.getBoolean("friendlyFireEnabled");
         autoBalanceEnabled = !nbt.hasKey("autoBalanceEnabled") || nbt.getBoolean("autoBalanceEnabled");
+        selectedMap = nbt.hasKey("selectedMap") ? nbt.getString("selectedMap").toLowerCase() : "";
+        redScore = nbt.getInteger("redScore");
+        blueScore = nbt.getInteger("blueScore");
+        roundEndTick = nbt.hasKey("roundEndTick") ? nbt.getLong("roundEndTick") : 0;
+        mapVoteActive = nbt.getBoolean("mapVoteActive");
+        mapVoteEndTick = nbt.hasKey("mapVoteEndTick") ? nbt.getLong("mapVoteEndTick") : 0;
         spawns.clear();
+        maps.clear();
         playerTeams.clear();
+        mapVotes.clear();
 
         int spawnCount = nbt.getInteger("spawnCount");
         for (int i = 0; i < spawnCount; i++) {
             NBTTagCompound spawnTag = nbt.getCompoundTag("spawn" + i);
-            TDMManager.Team team = TDMManager.Team.fromName(spawnTag.getString("team"));
-            if (team == null) {
+            TDMManager.SpawnPoint spawn = readSpawn(spawnTag);
+            if (spawn != null) {
+                spawns.add(spawn);
+            }
+        }
+
+        int mapCount = nbt.getInteger("mapCount");
+        for (int i = 0; i < mapCount; i++) {
+            NBTTagCompound mapTag = nbt.getCompoundTag("map" + i);
+            String mapName = mapTag.getString("name").toLowerCase();
+            if (mapName.length() == 0) {
                 continue;
             }
 
-            spawns.add(new TDMManager.SpawnPoint(
-                    team,
-                    spawnTag.getInteger("dim"),
-                    spawnTag.getInteger("x"),
-                    spawnTag.getInteger("y"),
-                    spawnTag.getInteger("z")
-            ));
+            TDMManager.TDMMap map = new TDMManager.TDMMap(mapName);
+            int mapSpawnCount = mapTag.getInteger("spawnCount");
+            for (int j = 0; j < mapSpawnCount; j++) {
+                TDMManager.SpawnPoint spawn = readSpawn(mapTag.getCompoundTag("spawn" + j));
+                if (spawn != null) {
+                    map.spawns.add(spawn);
+                }
+            }
+            maps.put(map.name, map);
+        }
+
+        if (selectedMap.length() > 0 && !maps.containsKey(selectedMap)) {
+            selectedMap = "";
         }
 
         int playerCount = nbt.getInteger("playerCount");
@@ -80,6 +112,15 @@ public class TDMData extends WorldSavedData {
                 playerTeams.put(player.toLowerCase(), team);
             }
         }
+
+        int voteCount = nbt.getInteger("voteCount");
+        for (int i = 0; i < voteCount; i++) {
+            String player = nbt.getString("votePlayer" + i).toLowerCase();
+            String map = nbt.getString("voteMap" + i).toLowerCase();
+            if (player.length() > 0 && maps.containsKey(map)) {
+                mapVotes.put(player, map);
+            }
+        }
     }
 
     @Override
@@ -87,18 +128,30 @@ public class TDMData extends WorldSavedData {
         nbt.setBoolean("enabled", enabled);
         nbt.setBoolean("friendlyFireEnabled", friendlyFireEnabled);
         nbt.setBoolean("autoBalanceEnabled", autoBalanceEnabled);
+        nbt.setString("selectedMap", selectedMap);
+        nbt.setInteger("redScore", redScore);
+        nbt.setInteger("blueScore", blueScore);
+        nbt.setLong("roundEndTick", roundEndTick);
+        nbt.setBoolean("mapVoteActive", mapVoteActive);
+        nbt.setLong("mapVoteEndTick", mapVoteEndTick);
         nbt.setInteger("spawnCount", spawns.size());
 
         for (int i = 0; i < spawns.size(); i++) {
-            TDMManager.SpawnPoint spawn = spawns.get(i);
-            NBTTagCompound spawnTag = new NBTTagCompound();
-            spawnTag.setString("team", spawn.team.name);
-            spawnTag.setInteger("dim", spawn.dim);
-            spawnTag.setInteger("x", spawn.x);
-            spawnTag.setInteger("y", spawn.y);
-            spawnTag.setInteger("z", spawn.z);
-            nbt.setTag("spawn" + i, spawnTag);
+            nbt.setTag("spawn" + i, writeSpawn(spawns.get(i)));
         }
+
+        int mapIndex = 0;
+        for (TDMManager.TDMMap map : maps.values()) {
+            NBTTagCompound mapTag = new NBTTagCompound();
+            mapTag.setString("name", map.name);
+            mapTag.setInteger("spawnCount", map.spawns.size());
+            for (int i = 0; i < map.spawns.size(); i++) {
+                mapTag.setTag("spawn" + i, writeSpawn(map.spawns.get(i)));
+            }
+            nbt.setTag("map" + mapIndex, mapTag);
+            mapIndex++;
+        }
+        nbt.setInteger("mapCount", mapIndex);
 
         int playerIndex = 0;
         for (Map.Entry<String, TDMManager.Team> entry : playerTeams.entrySet()) {
@@ -107,5 +160,38 @@ public class TDMData extends WorldSavedData {
             playerIndex++;
         }
         nbt.setInteger("playerCount", playerIndex);
+
+        int voteIndex = 0;
+        for (Map.Entry<String, String> entry : mapVotes.entrySet()) {
+            nbt.setString("votePlayer" + voteIndex, entry.getKey());
+            nbt.setString("voteMap" + voteIndex, entry.getValue());
+            voteIndex++;
+        }
+        nbt.setInteger("voteCount", voteIndex);
+    }
+
+    private TDMManager.SpawnPoint readSpawn(NBTTagCompound spawnTag) {
+        TDMManager.Team team = TDMManager.Team.fromName(spawnTag.getString("team"));
+        if (team == null) {
+            return null;
+        }
+
+        return new TDMManager.SpawnPoint(
+                team,
+                spawnTag.getInteger("dim"),
+                spawnTag.getInteger("x"),
+                spawnTag.getInteger("y"),
+                spawnTag.getInteger("z")
+        );
+    }
+
+    private NBTTagCompound writeSpawn(TDMManager.SpawnPoint spawn) {
+        NBTTagCompound spawnTag = new NBTTagCompound();
+        spawnTag.setString("team", spawn.team.name);
+        spawnTag.setInteger("dim", spawn.dim);
+        spawnTag.setInteger("x", spawn.x);
+        spawnTag.setInteger("y", spawn.y);
+        spawnTag.setInteger("z", spawn.z);
+        return spawnTag;
     }
 }

--- a/src/main/java/com/hfr/tdm/TDMHandler.java
+++ b/src/main/java/com/hfr/tdm/TDMHandler.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
+import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 
 import java.util.HashMap;
@@ -17,6 +18,7 @@ public class TDMHandler {
     private static final int RESPAWN_RETRY_TICKS = 20;
     private static final int AUTO_BALANCE_INTERVAL_TICKS = 100;
     private long lastAutoBalanceTick = -1;
+    private long lastRoundTick = -1;
     private final Map<String, Integer> pendingRespawns = new HashMap<String, Integer>();
     private final Random random = new Random();
 
@@ -44,6 +46,7 @@ public class TDMHandler {
             return;
         }
 
+        runRoundTimer(event.player);
         runAutoBalance(event.player);
 
         String playerName = getKey(event.player);
@@ -58,6 +61,25 @@ public class TDMHandler {
             TDMManager.promptForKit(event.player);
         } else {
             pendingRespawns.put(playerName, ticksLeft - 1);
+        }
+    }
+
+
+    @SubscribeEvent
+    public void onLivingDeath(LivingDeathEvent event) {
+        if (event.entityLiving.worldObj.isRemote) return;
+        if (!(event.entityLiving instanceof EntityPlayer)) return;
+        if (!TDMManager.isEnabled(event.entityLiving.worldObj)) return;
+        if (TDMManager.isMapVoteActive(event.entityLiving.worldObj)) return;
+
+        EntityPlayer victim = (EntityPlayer) event.entityLiving;
+        EntityPlayer attacker = getAttackingPlayer(event.source);
+        if (attacker == null || attacker == victim) return;
+
+        TDMManager.Team victimTeam = TDMManager.getPlayerTeam(victim.worldObj, victim.getCommandSenderName());
+        TDMManager.Team attackerTeam = TDMManager.getPlayerTeam(victim.worldObj, attacker.getCommandSenderName());
+        if (attackerTeam != null && attackerTeam != victimTeam) {
+            TDMManager.addKillScore(victim.worldObj, attackerTeam);
         }
     }
 
@@ -77,6 +99,17 @@ public class TDMHandler {
         if (victimTeam != null && victimTeam == attackerTeam) {
             event.setCanceled(true);
         }
+    }
+
+
+    private void runRoundTimer(EntityPlayer player) {
+        long worldTime = player.worldObj.getTotalWorldTime();
+        if (lastRoundTick == worldTime) {
+            return;
+        }
+
+        lastRoundTick = worldTime;
+        TDMManager.tickRound(player.worldObj);
     }
 
     private void runAutoBalance(EntityPlayer player) {

--- a/src/main/java/com/hfr/tdm/TDMKitManager.java
+++ b/src/main/java/com/hfr/tdm/TDMKitManager.java
@@ -18,6 +18,7 @@ import java.io.Writer;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -26,13 +27,12 @@ public class TDMKitManager {
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static final int MAIN_INVENTORY_SIZE = 36;
     private static final int ARMOR_INVENTORY_SIZE = 4;
-    private static final Map<TDMManager.Team, List<KitEntry>> kits = new EnumMap<TDMManager.Team, List<KitEntry>>(TDMManager.Team.class);
+    private static final String GLOBAL_MAP = "";
+    private static final Map<String, Map<TDMManager.Team, List<KitEntry>>> kits = new LinkedHashMap<String, Map<TDMManager.Team, List<KitEntry>>>();
     private static File saveFile;
 
     static {
-        for (TDMManager.Team team : TDMManager.Team.values()) {
-            kits.put(team, new ArrayList<KitEntry>());
-        }
+        getOrCreateMapKits(GLOBAL_MAP);
     }
 
     public static void init() {
@@ -42,6 +42,11 @@ public class TDMKitManager {
     }
 
     public static int addKit(TDMManager.Team team, EntityPlayer player) {
+        return addKit(GLOBAL_MAP, team, player);
+    }
+
+    public static int addKit(String mapName, TDMManager.Team team, EntityPlayer player) {
+        String normalizedMap = TDMManager.normalizeMapName(mapName);
         List<ItemEntry> items = new ArrayList<ItemEntry>();
 
         for (int i = 0; i < MAIN_INVENTORY_SIZE; i++) {
@@ -58,19 +63,28 @@ public class TDMKitManager {
             }
         }
 
-        List<KitEntry> teamKits = kits.get(team);
-        KitEntry kit = new KitEntry(team.name.substring(0, 1).toUpperCase() + team.name.substring(1) + " Kit " + (teamKits.size() + 1), items);
+        List<KitEntry> teamKits = getOrCreateTeamKits(normalizedMap, team);
+        String mapPrefix = normalizedMap.length() > 0 ? normalizedMap + " " : "";
+        KitEntry kit = new KitEntry(mapPrefix + team.name.substring(0, 1).toUpperCase() + team.name.substring(1) + " Kit " + (teamKits.size() + 1), items);
         teamKits.add(kit);
         save();
         return teamKits.size();
     }
 
     public static int getKitCount(TDMManager.Team team) {
-        return kits.get(team).size();
+        return getKitCount(GLOBAL_MAP, team);
+    }
+
+    public static int getKitCount(String mapName, TDMManager.Team team) {
+        return getTeamKits(mapName, team).size();
     }
 
     public static String[] getKitNames(TDMManager.Team team) {
-        List<KitEntry> teamKits = kits.get(team);
+        return getKitNames(GLOBAL_MAP, team);
+    }
+
+    public static String[] getKitNames(String mapName, TDMManager.Team team) {
+        List<KitEntry> teamKits = getTeamKits(mapName, team);
         String[] names = new String[teamKits.size()];
         for (int i = 0; i < teamKits.size(); i++) {
             names[i] = teamKits.get(i).name;
@@ -79,7 +93,11 @@ public class TDMKitManager {
     }
 
     public static boolean applyKit(TDMManager.Team team, int kitIndex, EntityPlayer player) {
-        List<KitEntry> teamKits = kits.get(team);
+        return applyKit(GLOBAL_MAP, team, kitIndex, player);
+    }
+
+    public static boolean applyKit(String mapName, TDMManager.Team team, int kitIndex, EntityPlayer player) {
+        List<KitEntry> teamKits = getTeamKits(mapName, team);
         if (kitIndex < 0 || kitIndex >= teamKits.size()) {
             return false;
         }
@@ -108,12 +126,54 @@ public class TDMKitManager {
         return true;
     }
 
+    private static List<KitEntry> getTeamKits(String mapName, TDMManager.Team team) {
+        String normalizedMap = TDMManager.normalizeMapName(mapName);
+        Map<TDMManager.Team, List<KitEntry>> mapKits = kits.get(normalizedMap);
+        if (mapKits != null && mapKits.get(team) != null && !mapKits.get(team).isEmpty()) {
+            return mapKits.get(team);
+        }
+
+        Map<TDMManager.Team, List<KitEntry>> globalKits = kits.get(GLOBAL_MAP);
+        if (globalKits == null || globalKits.get(team) == null) {
+            return new ArrayList<KitEntry>();
+        }
+        return globalKits.get(team);
+    }
+
+    private static List<KitEntry> getOrCreateTeamKits(String mapName, TDMManager.Team team) {
+        return getOrCreateMapKits(mapName).get(team);
+    }
+
+    private static Map<TDMManager.Team, List<KitEntry>> getOrCreateMapKits(String mapName) {
+        String normalizedMap = TDMManager.normalizeMapName(mapName);
+        Map<TDMManager.Team, List<KitEntry>> mapKits = kits.get(normalizedMap);
+        if (mapKits == null) {
+            mapKits = new EnumMap<TDMManager.Team, List<KitEntry>>(TDMManager.Team.class);
+            for (TDMManager.Team team : TDMManager.Team.values()) {
+                mapKits.put(team, new ArrayList<KitEntry>());
+            }
+            kits.put(normalizedMap, mapKits);
+        }
+        return mapKits;
+    }
+
     private static void save() {
         if (saveFile == null) return;
 
         SaveData data = new SaveData();
-        data.red = kits.get(TDMManager.Team.RED);
-        data.blue = kits.get(TDMManager.Team.BLUE);
+        Map<TDMManager.Team, List<KitEntry>> globalKits = getOrCreateMapKits(GLOBAL_MAP);
+        data.red = globalKits.get(TDMManager.Team.RED);
+        data.blue = globalKits.get(TDMManager.Team.BLUE);
+        for (Map.Entry<String, Map<TDMManager.Team, List<KitEntry>>> entry : kits.entrySet()) {
+            if (entry.getKey().length() == 0) {
+                continue;
+            }
+
+            TeamKitData mapData = new TeamKitData();
+            mapData.red = entry.getValue().get(TDMManager.Team.RED);
+            mapData.blue = entry.getValue().get(TDMManager.Team.BLUE);
+            data.maps.put(entry.getKey(), mapData);
+        }
 
         try {
             Writer writer = new FileWriter(saveFile);
@@ -128,9 +188,8 @@ public class TDMKitManager {
     }
 
     private static void load() {
-        for (TDMManager.Team team : TDMManager.Team.values()) {
-            kits.get(team).clear();
-        }
+        kits.clear();
+        getOrCreateMapKits(GLOBAL_MAP);
 
         if (saveFile == null || !saveFile.exists()) return;
 
@@ -140,8 +199,21 @@ public class TDMKitManager {
                 Type type = new TypeToken<SaveData>() {}.getType();
                 SaveData data = GSON.fromJson(reader, type);
                 if (data != null) {
-                    if (data.red != null) kits.get(TDMManager.Team.RED).addAll(data.red);
-                    if (data.blue != null) kits.get(TDMManager.Team.BLUE).addAll(data.blue);
+                    Map<TDMManager.Team, List<KitEntry>> globalKits = getOrCreateMapKits(GLOBAL_MAP);
+                    if (data.red != null) globalKits.get(TDMManager.Team.RED).addAll(data.red);
+                    if (data.blue != null) globalKits.get(TDMManager.Team.BLUE).addAll(data.blue);
+                    if (data.maps != null) {
+                        for (Map.Entry<String, TeamKitData> entry : data.maps.entrySet()) {
+                            String mapName = TDMManager.normalizeMapName(entry.getKey());
+                            if (mapName.length() == 0 || entry.getValue() == null) {
+                                continue;
+                            }
+
+                            Map<TDMManager.Team, List<KitEntry>> mapKits = getOrCreateMapKits(mapName);
+                            if (entry.getValue().red != null) mapKits.get(TDMManager.Team.RED).addAll(entry.getValue().red);
+                            if (entry.getValue().blue != null) mapKits.get(TDMManager.Team.BLUE).addAll(entry.getValue().blue);
+                        }
+                    }
                 }
             } finally {
                 reader.close();
@@ -151,7 +223,11 @@ public class TDMKitManager {
         }
     }
 
-    private static class SaveData {
+    private static class SaveData extends TeamKitData {
+        Map<String, TeamKitData> maps = new LinkedHashMap<String, TeamKitData>();
+    }
+
+    private static class TeamKitData {
         List<KitEntry> red = new ArrayList<KitEntry>();
         List<KitEntry> blue = new ArrayList<KitEntry>();
     }

--- a/src/main/java/com/hfr/tdm/TDMManager.java
+++ b/src/main/java/com/hfr/tdm/TDMManager.java
@@ -2,6 +2,8 @@ package com.hfr.tdm;
 
 import com.hfr.packet.PacketDispatcher;
 import com.hfr.packet.effect.TDMKitGuiPacket;
+import com.hfr.packet.effect.TDMMapVoteGuiPacket;
+import com.hfr.packet.effect.TDMStatusPacket;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
@@ -12,13 +14,19 @@ import net.minecraft.world.World;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
 public class TDMManager {
 
     public static boolean tdmEnabled = false;
+    public static final int ROUND_TICKS = 20 * 60 * 20;
+    public static final int MAP_VOTE_TICKS = 30 * 20;
+    public static final int SCORE_LIMIT = 10000;
+    public static final int POINTS_PER_KILL = 100;
     private static final Set<String> pendingKitSelection = new HashSet<String>();
 
     public enum Team {
@@ -43,6 +51,15 @@ public class TDMManager {
             }
 
             return null;
+        }
+    }
+
+    public static class TDMMap {
+        public final String name;
+        public final List<SpawnPoint> spawns = new ArrayList<SpawnPoint>();
+
+        public TDMMap(String name) {
+            this.name = normalizeMapName(name);
         }
     }
 
@@ -75,7 +92,16 @@ public class TDMManager {
         TDMData data = TDMData.get(world);
         data.enabled = !data.enabled;
         tdmEnabled = data.enabled;
+        if (data.enabled) {
+            startRound(world, false);
+        } else {
+            data.roundEndTick = 0;
+            data.mapVoteActive = false;
+            data.mapVoteEndTick = 0;
+            data.mapVotes.clear();
+        }
         data.markDirty();
+        sendStatusToAll(world);
         return data.enabled;
     }
 
@@ -97,6 +123,344 @@ public class TDMManager {
         TDMData data = TDMData.get(world);
         data.autoBalanceEnabled = enabled;
         data.markDirty();
+    }
+
+
+    public static boolean createMap(World world, String mapName) {
+        String normalized = normalizeMapName(mapName);
+        if (normalized.length() == 0) {
+            return false;
+        }
+
+        TDMData data = TDMData.get(world);
+        if (data.maps.containsKey(normalized)) {
+            return false;
+        }
+
+        data.maps.put(normalized, new TDMMap(normalized));
+        if (data.selectedMap.length() == 0) {
+            data.selectedMap = normalized;
+        }
+        data.markDirty();
+        return true;
+    }
+
+    public static boolean deleteMap(World world, String mapName) {
+        String normalized = normalizeMapName(mapName);
+        TDMData data = TDMData.get(world);
+        if (data.maps.remove(normalized) == null) {
+            return false;
+        }
+
+        if (data.selectedMap.equals(normalized)) {
+            data.selectedMap = "";
+        }
+
+        List<String> playersToClear = new ArrayList<String>();
+        for (Map.Entry<String, String> entry : data.mapVotes.entrySet()) {
+            if (entry.getValue().equals(normalized)) {
+                playersToClear.add(entry.getKey());
+            }
+        }
+        for (String player : playersToClear) {
+            data.mapVotes.remove(player);
+        }
+
+        data.markDirty();
+        return true;
+    }
+
+    public static boolean selectMap(World world, String mapName) {
+        String normalized = normalizeMapName(mapName);
+        TDMData data = TDMData.get(world);
+        if (!data.maps.containsKey(normalized)) {
+            return false;
+        }
+
+        data.selectedMap = normalized;
+        data.markDirty();
+        return true;
+    }
+
+    public static String getSelectedMap(World world) {
+        return TDMData.get(world).selectedMap;
+    }
+
+    public static boolean hasMap(World world, String mapName) {
+        return TDMData.get(world).maps.containsKey(normalizeMapName(mapName));
+    }
+
+    public static List<String> getMapNames(World world) {
+        return new ArrayList<String>(TDMData.get(world).maps.keySet());
+    }
+
+    public static void addMapSpawn(World world, String mapName, Team team, int dim, int x, int y, int z) {
+        TDMData data = TDMData.get(world);
+        String normalized = normalizeMapName(mapName);
+        TDMMap map = data.maps.get(normalized);
+        if (map == null) {
+            map = new TDMMap(normalized);
+            data.maps.put(normalized, map);
+        }
+
+        map.spawns.add(new SpawnPoint(team, dim, x, y, z));
+        if (data.selectedMap.length() == 0) {
+            data.selectedMap = normalized;
+        }
+        data.markDirty();
+    }
+
+    public static boolean clearMapSpawns(World world, String mapName) {
+        TDMMap map = TDMData.get(world).maps.get(normalizeMapName(mapName));
+        if (map == null) {
+            return false;
+        }
+
+        map.spawns.clear();
+        TDMData.get(world).markDirty();
+        return true;
+    }
+
+    public static int getMapSpawnCount(World world, String mapName) {
+        TDMMap map = TDMData.get(world).maps.get(normalizeMapName(mapName));
+        return map == null ? 0 : map.spawns.size();
+    }
+
+    public static int getMapSpawnCount(World world, String mapName, Team team) {
+        TDMMap map = TDMData.get(world).maps.get(normalizeMapName(mapName));
+        if (map == null) {
+            return 0;
+        }
+
+        int count = 0;
+        for (SpawnPoint spawn : map.spawns) {
+            if (spawn.team == team) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    public static String voteForMap(World world, String playerName, String mapName) {
+        String normalized = normalizeMapName(mapName);
+        TDMData data = TDMData.get(world);
+        if (!data.enabled || !data.mapVoteActive || !data.maps.containsKey(normalized)) {
+            return null;
+        }
+
+        data.mapVotes.put(playerName.toLowerCase(), normalized);
+        data.markDirty();
+        return normalized;
+    }
+
+    public static Map<String, Integer> getVoteCounts(World world) {
+        TDMData data = TDMData.get(world);
+        Map<String, Integer> counts = new LinkedHashMap<String, Integer>();
+        for (String mapName : data.maps.keySet()) {
+            counts.put(mapName, Integer.valueOf(0));
+        }
+        for (String mapName : data.mapVotes.values()) {
+            if (counts.containsKey(mapName)) {
+                counts.put(mapName, Integer.valueOf(counts.get(mapName).intValue() + 1));
+            }
+        }
+        return counts;
+    }
+
+    private static String getWinningMap(TDMData data) {
+        String winner = null;
+        int winnerVotes = -1;
+        Map<String, Integer> counts = new LinkedHashMap<String, Integer>();
+        for (String mapName : data.maps.keySet()) {
+            counts.put(mapName, Integer.valueOf(0));
+        }
+        for (String mapName : data.mapVotes.values()) {
+            if (counts.containsKey(mapName)) {
+                counts.put(mapName, Integer.valueOf(counts.get(mapName).intValue() + 1));
+            }
+        }
+        for (Map.Entry<String, Integer> entry : counts.entrySet()) {
+            if (entry.getValue().intValue() > winnerVotes) {
+                winner = entry.getKey();
+                winnerVotes = entry.getValue().intValue();
+            }
+        }
+        return winner;
+    }
+
+    public static String normalizeMapName(String mapName) {
+        if (mapName == null) {
+            return "";
+        }
+        return mapName.trim().toLowerCase();
+    }
+
+
+    public static void tickRound(World world) {
+        TDMData data = TDMData.get(world);
+        if (!data.enabled) {
+            return;
+        }
+
+        long now = world.getTotalWorldTime();
+        if (data.mapVoteActive) {
+            if (data.mapVoteEndTick <= 0) {
+                data.mapVoteEndTick = now + MAP_VOTE_TICKS;
+                data.markDirty();
+            }
+            if (now >= data.mapVoteEndTick) {
+                finishMapVote(world);
+            } else {
+                sendStatusToAll(world);
+            }
+            return;
+        }
+
+        if (data.roundEndTick <= 0 || now > data.roundEndTick + MAP_VOTE_TICKS) {
+            startRound(world, false);
+            return;
+        }
+
+        if (now >= data.roundEndTick || data.redScore >= SCORE_LIMIT || data.blueScore >= SCORE_LIMIT) {
+            startMapVote(world);
+            return;
+        }
+
+        if (now % 20 == 0) {
+            sendStatusToAll(world);
+        }
+    }
+
+    public static void startRound(World world, boolean resetVotes) {
+        TDMData data = TDMData.get(world);
+        data.redScore = 0;
+        data.blueScore = 0;
+        data.roundEndTick = world.getTotalWorldTime() + ROUND_TICKS;
+        data.mapVoteActive = false;
+        data.mapVoteEndTick = 0;
+        if (resetVotes) {
+            data.mapVotes.clear();
+        }
+        data.markDirty();
+        sendStatusToAll(world);
+    }
+
+    public static void addKillScore(World world, Team scoringTeam) {
+        TDMData data = TDMData.get(world);
+        if (!data.enabled || data.mapVoteActive || scoringTeam == null) {
+            return;
+        }
+
+        if (scoringTeam == Team.RED) {
+            data.redScore += POINTS_PER_KILL;
+        } else if (scoringTeam == Team.BLUE) {
+            data.blueScore += POINTS_PER_KILL;
+        }
+        data.markDirty();
+
+        if (data.redScore >= SCORE_LIMIT || data.blueScore >= SCORE_LIMIT) {
+            startMapVote(world);
+        } else {
+            sendStatusToAll(world);
+        }
+    }
+
+    public static void startMapVote(World world) {
+        TDMData data = TDMData.get(world);
+        if (data.mapVoteActive) {
+            return;
+        }
+
+        data.mapVoteActive = true;
+        data.mapVoteEndTick = world.getTotalWorldTime() + MAP_VOTE_TICKS;
+        data.mapVotes.clear();
+        data.markDirty();
+        sendMapVoteGuiToAll(world);
+        sendStatusToAll(world);
+    }
+
+    public static void finishMapVote(World world) {
+        TDMData data = TDMData.get(world);
+        String winner = getWinningMap(data);
+        if (winner != null && data.maps.containsKey(winner)) {
+            data.selectedMap = winner;
+        }
+        data.mapVoteActive = false;
+        data.mapVoteEndTick = 0;
+        data.mapVotes.clear();
+        data.markDirty();
+        startRound(world, false);
+        teleportAllPlayersToSelectedMap(world);
+    }
+
+    public static int getRemainingRoundSeconds(World world) {
+        TDMData data = TDMData.get(world);
+        if (!data.enabled || data.roundEndTick <= 0) {
+            return 0;
+        }
+        return Math.max(0, (int) ((data.roundEndTick - world.getTotalWorldTime() + 19) / 20));
+    }
+
+    public static int getRemainingVoteSeconds(World world) {
+        TDMData data = TDMData.get(world);
+        if (!data.enabled || !data.mapVoteActive || data.mapVoteEndTick <= 0) {
+            return 0;
+        }
+        return Math.max(0, (int) ((data.mapVoteEndTick - world.getTotalWorldTime() + 19) / 20));
+    }
+
+    public static boolean isMapVoteActive(World world) {
+        return TDMData.get(world).mapVoteActive;
+    }
+
+    public static int getScore(World world, Team team) {
+        TDMData data = TDMData.get(world);
+        return team == Team.RED ? data.redScore : data.blueScore;
+    }
+
+    public static void sendStatusToAll(World world) {
+        TDMData data = TDMData.get(world);
+        for (EntityPlayerMP player : getOnlinePlayers()) {
+            if (player.worldObj.provider.dimensionId == world.provider.dimensionId) {
+                PacketDispatcher.wrapper.sendTo(new TDMStatusPacket(
+                        data.enabled,
+                        data.mapVoteActive,
+                        getRemainingRoundSeconds(world),
+                        getRemainingVoteSeconds(world),
+                        data.redScore,
+                        data.blueScore,
+                        data.selectedMap
+                ), player);
+            }
+        }
+    }
+
+    private static void sendMapVoteGuiToAll(World world) {
+        List<String> mapNames = getMapNames(world);
+        if (mapNames.isEmpty()) {
+            return;
+        }
+
+        String[] maps = mapNames.toArray(new String[mapNames.size()]);
+        for (EntityPlayerMP player : getOnlinePlayers()) {
+            if (player.worldObj.provider.dimensionId == world.provider.dimensionId) {
+                PacketDispatcher.wrapper.sendTo(new TDMMapVoteGuiPacket(maps, MAP_VOTE_TICKS / 20), player);
+            }
+        }
+    }
+
+    private static void teleportAllPlayersToSelectedMap(World world) {
+        Random rand = new Random();
+        for (EntityPlayerMP player : getOnlinePlayers()) {
+            if (player.worldObj.provider.dimensionId != world.provider.dimensionId) {
+                continue;
+            }
+
+            if (respawnPlayer(player, rand)) {
+                pendingKitSelection.remove(getPlayerKey(player));
+                promptForKit(player);
+            }
+        }
     }
 
     public static void addSpawn(World world, Team team, int dim, int x, int y, int z) {
@@ -262,13 +626,14 @@ public class TDMManager {
         }
 
         Team team = getOrAssignPlayerTeam(player);
-        if (TDMKitManager.getKitCount(team) <= 0) {
-            player.addChatMessage(new net.minecraft.util.ChatComponentText("No TDM kits have been saved for " + team.name + ". Ask an admin to use /kit " + team.name + "."));
+        String mapName = getSelectedMap(player.worldObj);
+        if (TDMKitManager.getKitCount(mapName, team) <= 0) {
+            player.addChatMessage(new net.minecraft.util.ChatComponentText("No TDM kits have been saved for " + team.name + " on map " + (mapName.length() == 0 ? "global" : mapName) + ". Ask an admin to use /kit " + team.name + " [map]."));
             return;
         }
 
         pendingKitSelection.add(getPlayerKey(player));
-        PacketDispatcher.wrapper.sendTo(new TDMKitGuiPacket(team.name, TDMKitManager.getKitNames(team)), (EntityPlayerMP) player);
+        PacketDispatcher.wrapper.sendTo(new TDMKitGuiPacket(team.name, TDMKitManager.getKitNames(mapName, team)), (EntityPlayerMP) player);
     }
 
     public static void tickKitSelection(EntityPlayer player) {
@@ -298,7 +663,7 @@ public class TDMManager {
         }
 
         Team team = getOrAssignPlayerTeam(player);
-        if (!TDMKitManager.applyKit(team, kitIndex, player)) {
+        if (!TDMKitManager.applyKit(getSelectedMap(player.worldObj), team, kitIndex, player)) {
             return false;
         }
 
@@ -344,11 +709,16 @@ public class TDMManager {
     }
 
     public static SpawnPoint getRandomSpawn(World world, Team team, Random rand) {
+        TDMData data = TDMData.get(world);
         List<SpawnPoint> valid = new ArrayList<SpawnPoint>();
-        for (SpawnPoint spawn : TDMData.get(world).spawns) {
-            if (spawn.team == team && spawn.dim == world.provider.dimensionId) {
-                valid.add(spawn);
-            }
+        TDMMap selected = data.maps.get(data.selectedMap);
+
+        if (selected != null) {
+            addValidSpawns(valid, selected.spawns, team, world.provider.dimensionId);
+        }
+
+        if (valid.isEmpty()) {
+            addValidSpawns(valid, data.spawns, team, world.provider.dimensionId);
         }
 
         if (valid.isEmpty()) {
@@ -356,5 +726,13 @@ public class TDMManager {
         }
 
         return valid.get(rand.nextInt(valid.size()));
+    }
+
+    private static void addValidSpawns(List<SpawnPoint> valid, List<SpawnPoint> spawns, Team team, int dim) {
+        for (SpawnPoint spawn : spawns) {
+            if (spawn.team == team && spawn.dim == dim) {
+                valid.add(spawn);
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Add map-aware TDM functionality including map creation/selection, map voting, per-map spawns and kits, and a lightweight client UX for voting/status so rounds and scores can be managed per-map.

### Description

- Persist TDM state: `TDMData` now stores maps, selected map, scores, round/vote timers and per-player map votes and is updated to read/write these fields. 
- Map and round logic: `TDMManager` adds map CRUD (`createMap`, `deleteMap`, `selectMap`, `getMapNames`), map spawns, voting (`voteForMap`, `getVoteCounts`, `startMapVote`, `finishMapVote`), round ticking (`tickRound`, `startRound`) and scoring (`addKillScore`), plus helper methods to send status/UI to online players. 
- Per-map kits and global fallback: `TDMKitManager` now supports kits keyed by map name with a global fallback, updated serialization format, public `addKit`/`getKitNames`/`applyKit` overloads that accept a map name, and `save`/`load` logic for map-specific kit sets. 
- Commands and permissions: `CommandTDM` and `CommandKit` were extended to support `maps`, `vote`, `map <create|delete|select|addspawn|clearspawns|list>`, optional `[map]` parameter for ` /kit`, map listing/voting available to non-admins while admin-only actions remain protected, and `getRequiredPermissionLevel`/`canCommandSenderUseCommand` adjustments. 
- Networking & client UI: added `TDMStatusPacket`, `TDMMapVoteGuiPacket` and client packet `TDMMapVoteSelectPacket`, registered them in `PacketDispatcher`, and added `GUITDMMapVote` to present map vote choices. 
- Client HUD and handlers: `EventHandlerClient` draws a TDM status HUD and exposes `updateTDMStatus`, and `TDMHandler` now ticks round timers, records kill scoring on death, and triggers map vote flow. 

### Testing

- Project build was executed with `gradle build` and completed successfully. 
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a055ff882ac83239bcc03f8fb4b1407)