### PR TITLE
Add war-time chat alert for successful claim flag placement

### DIFF
--- a/src/main/java/com/hfr/blocks/clowder/Conquerer.java
+++ b/src/main/java/com/hfr/blocks/clowder/Conquerer.java
@@ -19,6 +19,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.MathHelper;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.World;
 
 public class Conquerer extends BlockContainer {
@@ -73,12 +74,14 @@ public class Conquerer extends BlockContainer {
 			Clowder clowder = Clowder.getClowderFromPlayer((EntityPlayer) player);
 			flag.owner = clowder;
 
-			if (clowder != null && flag.checkBorder(x, z) && flag.canSeeSky() && noProximity(world, x, y, z)) { //todo here??? no this is conquerer
-				//successful flag placement here?? I think?
-				//maybe send the coordinates to the enemy faction? Here? IF that is what this is.
+			if (clowder != null && flag.checkBorder(x, z) && flag.canSeeSky() && noProximity(world, x, y, z)) {
 
 				flag.owner.addPrestigeReq(0.2F, world);
 				flag.markDirty();
+				MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(
+						EnumChatFormatting.RED + "[WAR] " + EnumChatFormatting.GOLD + clowder.name +
+						EnumChatFormatting.YELLOW + " placed a claim flag at " + EnumChatFormatting.AQUA + "(" + x + ", " + y + ", " + z + ")"
+				));
 			} else {
 				flag.owner = null;
 				((EntityPlayer) player).addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "You won't be able to raise this flag. This may be due to:"));


### PR DESCRIPTION
### Motivation
- During wartime a global notification should be sent when a faction successfully places a conquest/claim flag so all players know which faction claimed a chunk and the exact location.

### Description
- Send a server-wide chat message from `Conquerer.onBlockPlacedBy(...)` using `MinecraftServer.getServer().getConfigurationManager().sendChatMsg(...)` that includes the claiming faction name (`clowder.name`) and the `(x, y, z)` coordinates, and add the `import net.minecraft.server.MinecraftServer;` required for broadcasting.

### Testing
- Attempted to compile with `./gradlew -q compileJava` which failed because the repository does not include a Gradle wrapper (`./gradlew`), and no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d3a798330832984ba935f291134e7)