### PR TITLE
Fix NPE in MCH bullet EntityJoinWorldEvent handling

### DIFF
--- a/src/main/java/com/hfr/clowder/ClowderEvents.java
+++ b/src/main/java/com/hfr/clowder/ClowderEvents.java
@@ -721,19 +721,18 @@ public void handleChatServer(ServerChatEvent event) {
 	public void entityInit(EntityJoinWorldEvent event) {
 		Entity entity = event.entity;
 
-		// Check if the entity is relevant using reflection to get classes
-		Class<?> MCH_EntityBaseBullet = ReflectionUtils.getClass("mcheli.weapon.MCH_EntityBaseBullet");
-		Class<?> MCH_EntityBullet = ReflectionUtils.getClass("mcheli.weapon.MCH_EntityBullet");
-		Class<?> MCH_EntityRocket = ReflectionUtils.getClass("mcheli.weapon.MCH_EntityRocket");
+		boolean isRelevantEntity =
+				(MCH_ENTITY_BASE_BULLET != null && MCH_ENTITY_BASE_BULLET.isInstance(entity)) ||
+				(MCH_ENTITY_BULLET != null && MCH_ENTITY_BULLET.isInstance(entity)) ||
+				(MCH_ENTITY_ROCKET != null && MCH_ENTITY_ROCKET.isInstance(entity));
 
-		if (!(MCH_EntityBaseBullet.isInstance(entity) || MCH_EntityBullet.isInstance(entity) || MCH_EntityRocket.isInstance(entity))) {
-			return; // Early exit if not relevant
+		if (!isRelevantEntity) {
+			return;
 		}
 
-		// Check ownership and zone using the existing logic
 		Ownership owner = ClowderTerritory.getOwner((int) entity.posX, (int) entity.posZ);
-		if (owner.zone == Zone.SAFEZONE) {
-			entity.setDead(); // Kill the entity if it's in a safezone
+		if (owner != null && owner.zone == Zone.SAFEZONE) {
+			entity.setDead();
 			event.setCanceled(true);
 		}
 	}


### PR DESCRIPTION
### Motivation
- Prevent a NullPointerException in `ClowderEvents.entityInit` when MCHeli classes are absent or `ClowderTerritory.getOwner` returns null.

### Description
- Use the cached static class references (`MCH_ENTITY_BASE_BULLET`, `MCH_ENTITY_BULLET`, `MCH_ENTITY_ROCKET`) with null guards before calling `isInstance` to avoid per-event reflection and NPEs.
- Add a null check for `owner` before reading `owner.zone` while preserving the existing behavior of removing and canceling safezone projectiles.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a150fc1ab908329a1844e35259b12a0)