### PR TITLE
Fix merge territory transfer, add argument validation and granular war admin toggles

### DIFF
--- a/src/main/java/com/hfr/clowder/Clowder.java
+++ b/src/main/java/com/hfr/clowder/Clowder.java
@@ -1176,10 +1176,17 @@ public class Clowder {
 		}
 
 		// 7. Merge stats
+		for (ClowderTerritory.TerritoryMeta meta : ClowderTerritory.territories.values()) {
+			if (meta != null && meta.owner != null && meta.owner.zone == ClowderTerritory.Zone.FACTION && meta.owner.owner == this) {
+				meta.owner.owner = target;
+			}
+		}
+
+		// 8. Merge stats
 		target.addPrestige(this.prestige, world);
 		target.addPrestigeGen(this.prestigeGen, world);
 
-		// 8. Notify both sides
+		// 9. Notify both sides
 		target.notifyAll(world, new ChatComponentText(
 				CommandClowder.TITLE + this.name + " merged into " + target.name + "!"
 		));
@@ -1187,10 +1194,10 @@ public class Clowder {
 				CommandClowder.TITLE + "Your faction has merged into " + target.name + "!"
 		));
 
-		// 9. Delete this clowder
+		// 10. Delete this clowder
 		this.disbandClowder(world);
 
-		// 10. Save
+		// 11. Save
 		ClowderData.getData(world).markDirty();
 	}
 

--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -168,12 +168,12 @@ public class CommandClowder extends CommandBase {
 		//	return;
 		//}
 
-		if(cmd.equals("merge")) {
+		if(cmd.equals("merge") && args.length > 1) {
 			cmdMerge(sender, args[1]);
 			return;
 		}
 
-		if(cmd.equals("acceptmerge")) {
+		if(cmd.equals("acceptmerge") && args.length > 1) {
 			acceptMerge(sender, args[1]);
 			return;
 		}
@@ -414,7 +414,59 @@ public class CommandClowder extends CommandBase {
 			return;
 		}
 
+		if(requiresArgument(cmd)) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Invalid format. Usage: " + getUsageFor(cmd)));
+			return;
+		}
 		sender.addChatMessage(new ChatComponentText(ERROR + getCommandUsage(sender)));
+	}
+
+	private boolean requiresArgument(String cmd) {
+		return cmd.equals("merge") || cmd.equals("acceptmerge") || cmd.equals("color") || cmd.equals("rename")
+				|| cmd.equals("motd") || cmd.equals("owner") || cmd.equals("apply") || cmd.equals("accept")
+				|| cmd.equals("befriend") || cmd.equals("ally") || cmd.equals("acceptfriend") || cmd.equals("acceptally")
+				|| cmd.equals("deny") || cmd.equals("kick") || cmd.equals("unfriend") || cmd.equals("unally")
+				|| cmd.equals("flag") || cmd.equals("allywarp") || cmd.equals("addwarp") || cmd.equals("setwarp")
+				|| cmd.equals("delwarp") || cmd.equals("warp") || cmd.equals("deposit") || cmd.equals("withdraw")
+				|| cmd.equals("promote") || cmd.equals("demote") || cmd.equals("nameclaim")
+				|| cmd.equals("declarewar") || cmd.equals("peace") || cmd.equals("acceptpeace")
+				|| cmd.equals("ceasefire") || cmd.equals("acceptceasefire") || cmd.equals("surrender")
+				|| cmd.equals("acceptsurrender") || cmd.equals("defendally");
+	}
+
+	private String getUsageFor(String cmd) {
+		if(cmd.equals("merge")) return "/c merge <faction>";
+		if(cmd.equals("acceptmerge")) return "/c acceptmerge <faction>";
+		if(cmd.equals("color")) return "/c color <hexadecimal>";
+		if(cmd.equals("rename")) return "/c rename <name>";
+		if(cmd.equals("motd")) return "/c motd <message>";
+		if(cmd.equals("owner")) return "/c owner <player>";
+		if(cmd.equals("apply")) return "/c apply <faction>";
+		if(cmd.equals("accept")) return "/c accept <player>";
+		if(cmd.equals("befriend") || cmd.equals("ally")) return "/c befriend <faction>";
+		if(cmd.equals("acceptfriend") || cmd.equals("acceptally")) return "/c acceptfriend <player>";
+		if(cmd.equals("deny")) return "/c deny <player>";
+		if(cmd.equals("kick")) return "/c kick <player>";
+		if(cmd.equals("unfriend") || cmd.equals("unally")) return "/c unfriend <faction>";
+		if(cmd.equals("flag")) return "/c flag <flag>";
+		if(cmd.equals("allywarp")) return "/c allywarp <faction>";
+		if(cmd.equals("addwarp") || cmd.equals("setwarp")) return "/c setwarp <name>";
+		if(cmd.equals("delwarp")) return "/c delwarp <name>";
+		if(cmd.equals("warp")) return "/c warp <name>";
+		if(cmd.equals("deposit")) return "/c deposit <amount>";
+		if(cmd.equals("withdraw")) return "/c withdraw <amount>";
+		if(cmd.equals("promote")) return "/c promote <player>";
+		if(cmd.equals("demote")) return "/c demote <player>";
+		if(cmd.equals("nameclaim")) return "/c nameclaim <name>";
+		if(cmd.equals("declarewar")) return "/c declarewar <faction>";
+		if(cmd.equals("peace")) return "/c peace <faction>";
+		if(cmd.equals("acceptpeace")) return "/c acceptpeace <faction>";
+		if(cmd.equals("ceasefire")) return "/c ceasefire <faction>";
+		if(cmd.equals("acceptceasefire")) return "/c acceptceasefire <faction>";
+		if(cmd.equals("surrender")) return "/c surrender <faction>";
+		if(cmd.equals("acceptsurrender")) return "/c acceptsurrender <faction>";
+		if(cmd.equals("defendally")) return "/c defendally <ally>";
+		return getCommandUsage(null);
 	}
 
 	private void cmdHelp(ICommandSender sender, String page) {
@@ -444,6 +496,8 @@ public class CommandClowder extends CommandBase {
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-info {page}" + TITLE + " - Shows info on a faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-list" + TITLE + " - Lists all factions (page functin pending)"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-apply <name>" + TITLE + " - Sends an application to a faction"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-merge <faction>" + TITLE + " - Requests merging your faction into another"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-acceptmerge <faction>" + TITLE + " - Accepts a pending merge request"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-leave" + TITLE + " - Leaves the faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-accept <name>" + TITLE + " - Accepts a player's application"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-deny <name>" + TITLE + " - Denies a player's application"));
@@ -666,37 +720,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 		}
 	}
 
-	//alright, that looks like it SHOULD work,
-	// now we need a balkanization/split command that allows a faction to split into two factions,
-	// with the original faction keeping its name and the new faction getting a new name.
-	// The command would be something like /c split <new faction name> <player1> <player2> ... <playerN>, where the players listed are the ones that will be moved to the new faction. The command would only be usable by the faction owner or officers, and it would require confirmation from the owner to prevent accidental splits. The new faction would start with the same territory as the original faction, and the players that were moved would lose access to the original faction's territory and gain access to the new faction's territory. This would allow for more dynamic faction management and give players more options for how they want to organize themselves within the game.
-
-	private void cmdSplit(ICommandSender sender, String name, String[] players) {
-		EntityPlayer player = getCommandSenderAsPlayer(sender);
-		Clowder clowder = Clowder.getClowderFromPlayer(player);
-
-		if(clowder != null) {
-
-			//officers and above can split factions and invite players in the current faction into the new faction using a different command
-			if(clowder.getPermLevel(player.getDisplayName()) > 1) {
-
-				if(Clowder.getClowderFromName(name) == null) {
-					Clowder newClowder = clowder.split(name, players, player.worldObj);
-					sender.addChatMessage(new ChatComponentText(TITLE + "Successfully split into new faction " + name + "!"));
-					sender.addChatMessage(new ChatComponentText(INFO + "The following players were moved to the new faction: " + String.join(", ", players)));
-				} else {
-					sender.addChatMessage(new ChatComponentText(ERROR + "There is already a faction with this name!"));
-				}
-
-			} else {
-				sender.addChatMessage(new ChatComponentText(ERROR + "You do not have permission to split the faction!"));
-			}
-
-		} else {
-			sender.addChatMessage(new ChatComponentText(ERROR + "You are not in any faction!"));
-		}
-	}
-
+	
 	private void cmdComrades(ICommandSender sender) {
 
 		EntityPlayer player = getCommandSenderAsPlayer(sender);
@@ -1936,7 +1960,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 		Clowder target = Clowder.getClowderFromName(targetName);
 		if (me == null || target == null || me == target) return;
 		if (me.getPermLevel(player.getDisplayName()) < 3) return;
-		if(!CommandClowderAdmin.WAR_COMMAND_CHECKS_DISABLED && target.getOnlineMemberCount() < 2 && !Clowder.forceOnline) {
+		if(!(CommandClowderAdmin.LEGACY_WAR_ENABLED || CommandClowderAdmin.WAR_ONLINE_CHECK_DISABLED) && target.getOnlineMemberCount() < 2 && !Clowder.forceOnline) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "You can only declare war on factions that are currently online (2+ members)."));
 			return;
 		}
@@ -1961,6 +1985,10 @@ private void cmdCreate(ICommandSender sender, String name) {
 	}
 
 	private void cmdRequestPeace(ICommandSender sender, String targetName) {
+		if (CommandClowderAdmin.LEGACY_WAR_ENABLED) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Legacy war mode is enabled: peace/ceasefire/surrender mechanics are disabled."));
+			return;
+		}
 		EntityPlayer player = getCommandSenderAsPlayer(sender);
 		Clowder me = Clowder.getClowderFromPlayer(player);
 		Clowder target = Clowder.getClowderFromName(targetName);
@@ -1970,11 +1998,15 @@ private void cmdCreate(ICommandSender sender, String name) {
 		target.notifyAll(player.worldObj, new ChatComponentText(INFO + me.name + " has offered peace. Use /c acceptpeace " + me.name));
 	}
 	private void cmdAcceptPeace(ICommandSender sender, String targetName) {
+		if (CommandClowderAdmin.LEGACY_WAR_ENABLED) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Legacy war mode is enabled: peace/ceasefire/surrender mechanics are disabled."));
+			return;
+		}
 		EntityPlayer player = getCommandSenderAsPlayer(sender);
 		Clowder me = Clowder.getClowderFromPlayer(player);
 		Clowder target = Clowder.getClowderFromName(targetName);
 		if (me == null || target == null || me == target || me.getPermLevel(player.getDisplayName()) < 3) return;
-		if(!CommandClowderAdmin.WAR_COMMAND_CHECKS_DISABLED && !me.isAtWarWith(target)) return;
+		if(!(CommandClowderAdmin.LEGACY_WAR_ENABLED || CommandClowderAdmin.WAR_STATE_CHECK_DISABLED) && !me.isAtWarWith(target)) return;
 		if(!target.peaceRequests.contains(me.name)) return;
 		target.peaceRequests.remove(me.name);
 		me.activeWars.remove(target.name); target.activeWars.remove(me.name);
@@ -1985,15 +2017,23 @@ private void cmdCreate(ICommandSender sender, String name) {
 		MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(EnumChatFormatting.GREEN + "[WAR] " + me.name + " and " + target.name + " have agreed to peace."));
 	}
 	private void cmdRequestCeasefire(ICommandSender sender, String targetName) {
+		if (CommandClowderAdmin.LEGACY_WAR_ENABLED) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Legacy war mode is enabled: peace/ceasefire/surrender mechanics are disabled."));
+			return;
+		}
 		EntityPlayer player = getCommandSenderAsPlayer(sender);
 		Clowder me = Clowder.getClowderFromPlayer(player);
 		Clowder target = Clowder.getClowderFromName(targetName);
 		if (me == null || target == null || me == target || me.getPermLevel(player.getDisplayName()) < 3) return;
-		if(!CommandClowderAdmin.WAR_COMMAND_CHECKS_DISABLED && !me.isAtWarWith(target)) return;
+		if(!(CommandClowderAdmin.LEGACY_WAR_ENABLED || CommandClowderAdmin.WAR_STATE_CHECK_DISABLED) && !me.isAtWarWith(target)) return;
 		me.ceasefireRequests.add(target.name);
 		target.notifyAll(player.worldObj, new ChatComponentText(INFO + me.name + " has proposed a ceasefire. Use /c acceptceasefire " + me.name));
 	}
 	private void cmdAcceptCeasefire(ICommandSender sender, String targetName) {
+		if (CommandClowderAdmin.LEGACY_WAR_ENABLED) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Legacy war mode is enabled: peace/ceasefire/surrender mechanics are disabled."));
+			return;
+		}
 		EntityPlayer player = getCommandSenderAsPlayer(sender);
 		Clowder me = Clowder.getClowderFromPlayer(player);
 		Clowder target = Clowder.getClowderFromName(targetName);
@@ -2007,15 +2047,23 @@ private void cmdCreate(ICommandSender sender, String name) {
 		}
 	}
 	private void cmdSurrender(ICommandSender sender, String targetName) {
+		if (CommandClowderAdmin.LEGACY_WAR_ENABLED) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Legacy war mode is enabled: peace/ceasefire/surrender mechanics are disabled."));
+			return;
+		}
 		EntityPlayer player = getCommandSenderAsPlayer(sender);
 		Clowder me = Clowder.getClowderFromPlayer(player);
 		Clowder target = Clowder.getClowderFromName(targetName);
 		if (me == null || target == null || me == target || me.getPermLevel(player.getDisplayName()) < 3) return;
-		if(!CommandClowderAdmin.WAR_COMMAND_CHECKS_DISABLED && !me.isAtWarWith(target)) return;
+		if(!(CommandClowderAdmin.LEGACY_WAR_ENABLED || CommandClowderAdmin.WAR_STATE_CHECK_DISABLED) && !me.isAtWarWith(target)) return;
 		me.surrenderRequests.add(target.name);
 		target.notifyAll(player.worldObj, new ChatComponentText(CRITICAL + me.name + " offers surrender. Use /c acceptsurrender " + me.name + " to accept."));
 	}
 	private void cmdAcceptSurrender(ICommandSender sender, String targetName) {
+		if (CommandClowderAdmin.LEGACY_WAR_ENABLED) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Legacy war mode is enabled: peace/ceasefire/surrender mechanics are disabled."));
+			return;
+		}
 		EntityPlayer player = getCommandSenderAsPlayer(sender);
 		Clowder me = Clowder.getClowderFromPlayer(player);
 		Clowder target = Clowder.getClowderFromName(targetName);

--- a/src/main/java/com/hfr/command/CommandClowderAdmin.java
+++ b/src/main/java/com/hfr/command/CommandClowderAdmin.java
@@ -26,7 +26,9 @@ public class CommandClowderAdmin extends CommandBase {
 
 	public static boolean WARENABLED = false;
 	public static boolean WAR_COOLDOWNS_DISABLED = false;
-	public static boolean WAR_COMMAND_CHECKS_DISABLED = false;
+	public static boolean WAR_ONLINE_CHECK_DISABLED = false;
+	public static boolean WAR_STATE_CHECK_DISABLED = false;
+	public static boolean LEGACY_WAR_ENABLED = false;
 
 	@Override
 	public String getCommandName() {
@@ -198,9 +200,37 @@ public class CommandClowderAdmin extends CommandBase {
 			sender.addChatMessage(new ChatComponentText(INFO + "War cooldown skipping is now " + (WAR_COOLDOWNS_DISABLED ? "ENABLED" : "DISABLED") + "."));
 			return;
 		}
-		if(cmd.equals("ignorewarchecks")) {
-			WAR_COMMAND_CHECKS_DISABLED = !WAR_COMMAND_CHECKS_DISABLED;
-			sender.addChatMessage(new ChatComponentText(INFO + "War/peace command checks are now " + (WAR_COMMAND_CHECKS_DISABLED ? "IGNORED" : "ENFORCED") + "."));
+		if(cmd.equals("ignorewarcooldowncheck")) {
+			WAR_COOLDOWNS_DISABLED = !WAR_COOLDOWNS_DISABLED;
+			sender.addChatMessage(new ChatComponentText(INFO + "War cooldown checks are now " + (WAR_COOLDOWNS_DISABLED ? "IGNORED" : "ENFORCED") + "."));
+			return;
+		}
+		if(cmd.equals("ignorewaronlinecheck")) {
+			WAR_ONLINE_CHECK_DISABLED = !WAR_ONLINE_CHECK_DISABLED;
+			sender.addChatMessage(new ChatComponentText(INFO + "War online checks are now " + (WAR_ONLINE_CHECK_DISABLED ? "IGNORED" : "ENFORCED") + "."));
+			return;
+		}
+		if(cmd.equals("ignorewarstatecheck")) {
+			WAR_STATE_CHECK_DISABLED = !WAR_STATE_CHECK_DISABLED;
+			sender.addChatMessage(new ChatComponentText(INFO + "War state checks are now " + (WAR_STATE_CHECK_DISABLED ? "IGNORED" : "ENFORCED") + "."));
+			return;
+		}
+		if(cmd.equals("skipwarcooldown")) {
+			for (Clowder c : Clowder.clowders) {
+				c.noWarUntil.clear();
+				c.formerAllyNoWarUntil.clear();
+			}
+			sender.addChatMessage(new ChatComponentText(INFO + "All faction war cooldowns have been reset to 0."));
+			return;
+		}
+		if(cmd.equals("enablelegacywar")) {
+			LEGACY_WAR_ENABLED = !LEGACY_WAR_ENABLED;
+			if(LEGACY_WAR_ENABLED) {
+				WAR_COOLDOWNS_DISABLED = true;
+				WAR_ONLINE_CHECK_DISABLED = true;
+				WAR_STATE_CHECK_DISABLED = true;
+			}
+			sender.addChatMessage(new ChatComponentText(INFO + "Legacy war mode is now " + (LEGACY_WAR_ENABLED ? "ENABLED" : "DISABLED") + "."));
 			return;
 		}
 		
@@ -238,7 +268,11 @@ public class CommandClowderAdmin extends CommandBase {
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-warenable" + TITLE + " - Enables war mode"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-wardisable" + TITLE + " - Disables war mode"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-skipwarcooldowns" + TITLE + " - Toggles global war cooldown bypass"));
-			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-ignorewarchecks" + TITLE + " - Toggles online/war check bypass for war commands"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-skipwarcooldown" + TITLE + " - Instantly clears all war cooldown timers"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-ignorewarcooldowncheck" + TITLE + " - Toggles cooldown check bypass"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-ignorewaronlinecheck" + TITLE + " - Toggles online member check bypass"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-ignorewarstatecheck" + TITLE + " - Toggles at-war state check bypass"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-enablelegacywar" + TITLE + " - Ignores war checks and disables peace/ceasefire/surrender"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-newplayerprotection" + TITLE + " - Toggles 4h PvP / 24h keep-inventory starter protection"));
 		}
 	}


### PR DESCRIPTION
### Motivation
- Ensure that when one faction merges into another, all claimed territories move to the destination faction to avoid ownership inconsistencies.
- Improve player command UX by surfacing clear format/usage errors when required arguments are omitted.
- Replace a single coarse admin war bypass toggle with specific controls and tooling requested (individual checks, instant cooldown reset, and legacy mode).

### Description
- In `Clowder.mergeWith` move any claimed territories owned by the source faction to the target faction by updating `TerritoryMeta.owner.owner` before finalizing the merge. (`Clowder.mergeWith`)
- Require arguments for `merge` / `acceptmerge` dispatch and add centralized invalid-format feedback for commands that require arguments using `requiresArgument` and `getUsageFor`, so players get explicit usage strings (e.g. `"/c merge <faction>"`). (`CommandClowder`) 
- Remove the obsolete split-scaffold block from the player command handling to avoid dead/unreachable code in `CommandClowder`.
- Add merge-related entries to the `/clowder help` pages so help pages flow more logically and include merge operations. (`CommandClowder`) 
- Replace broad `ignorewarchecks` behavior with granular toggles in admin commands: `ignorewarcooldowncheck`, `ignorewaronlinecheck`, `ignorewarstatecheck`, plus `skipwarcooldown` (instantly clears all cooldown timers) and `enablelegacywar` (legacy behavior that ignores checks and disables peace/ceasefire/surrender mechanics). Keep the existing `skipwarcooldowns` toggle for backward-style bypass. (`CommandClowderAdmin`) 
- Update war command logic and diplomacy flows to respect the new flags and to short-circuit peace/ceasefire/surrender when legacy mode is enabled. (`CommandClowder`) 

### Testing
- Attempted automated build with `gradle -q compileJava`; build failed in this environment due to external dependency resolution (ForgeGradle Maven artifact metadata requests returned HTTP 403), so compile could not be verified here.
- Ran repository searches and code inspections to confirm updated command dispatch, help text and the territory ownership reassignment logic; no runtime automated tests were executed due to the unavailable build dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1519b78c9083298f57501ff9b39dee)