### PR TITLE
Introduce City Center system with city levels, named claims, and transfer mechanics

### DIFF
--- a/src/main/java/com/hfr/blocks/clowder/Flag.java
+++ b/src/main/java/com/hfr/blocks/clowder/Flag.java
@@ -3,6 +3,7 @@ package com.hfr.blocks.clowder;
 import com.hfr.blocks.ModBlocks;
 import com.hfr.clowder.Clowder;
 import com.hfr.clowder.ClowderTerritory;
+import com.hfr.clowder.ClowderTerritory.CoordPair;
 import com.hfr.clowder.ClowderTerritory.Ownership;
 import com.hfr.clowder.ClowderTerritory.Zone;
 import com.hfr.main.MainRegistry;
@@ -31,22 +32,22 @@ public class Flag extends BlockContainer {
 	public TileEntity createNewTileEntity(World p_149915_1_, int p_149915_2_) {
 		return new TileEntityFlag();
 	}
-	
+
 	@Override
 	public int getRenderType(){
 		return -1;
 	}
-	
+
 	@Override
 	public boolean isOpaqueCube() {
 		return false;
 	}
-	
+
 	@Override
 	public boolean renderAsNormalBlock() {
 		return false;
 	}
-	
+
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
 		if(world.isRemote)
@@ -60,12 +61,12 @@ public class Flag extends BlockContainer {
 			return true;
 		}
 	}
-	
+
 	@Override
 	public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack itemStack) {
-		
+
 		int i = MathHelper.floor_double(player.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
-		
+
 		if(i == 0)
 		{
 			world.setBlockMetadataWithNotify(x, y, z, 2, 2);
@@ -82,26 +83,42 @@ public class Flag extends BlockContainer {
 		{
 			world.setBlockMetadataWithNotify(x, y, z, 4, 2);
 		}
-		
+
 		if(player instanceof EntityPlayer && !world.isRemote) {
 			TileEntityFlag flag = (TileEntityFlag)world.getTileEntity(x, y, z);
-			
-			Clowder clowder = Clowder.getClowderFromPlayer((EntityPlayer)player);
-			
+			EntityPlayer entityPlayer = (EntityPlayer)player;
+
+			Clowder clowder = Clowder.getClowderFromPlayer(entityPlayer);
+			String cityName = itemStack.hasTagCompound() ? itemStack.stackTagCompound.getString("cityName") : "";
+			CoordPair cityChunk = ClowderTerritory.getCoordPair(x, z);
+			String cityError = ClowderTerritory.getCityPlacementError(cityChunk.x, cityChunk.z);
+
+			if(cityName == null || cityName.trim().isEmpty()) {
+				world.setBlockToAir(x, y, z);
+				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "City Centers require a name. Use /c claim <city name>."));
+				return;
+			}
+			if(cityError != null) {
+				world.setBlockToAir(x, y, z);
+				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + cityError));
+				return;
+			}
+
 			if(clowder != null && flag.canSeeSky()) {
+				flag.name = cityName.trim();
 				flag.setOwner(clowder);
-				flag.setMode(3);
+				flag.setMode(1);
 				flag.isClaimed = true;
 				flag.generateClaim();
 			} else {
 				flag.height = 0.0F;
-				((EntityPlayer)player).addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "You won't be able to raise this flag. This may be due to:"));
-				((EntityPlayer)player).addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "-The flag lacking a solid 5x5 block foundation"));
-				((EntityPlayer)player).addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "-The flag's foundation not having sky access"));
-				((EntityPlayer)player).addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "-You not being in any faction"));
-				((EntityPlayer)player).addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "-The flag being below Y:45 or above Y:200"));
+				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "You won't be able to raise this flag. This may be due to:"));
+				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "-The flag lacking a solid 5x5 block foundation"));
+				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "-The flag's foundation not having sky access"));
+				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "-You not being in any faction"));
+				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "-The flag being below Y:45 or above Y:200"));
 			}
-			
+
 			flag.markDirty();
 		}
 
@@ -128,7 +145,7 @@ public class Flag extends BlockContainer {
 
 		return true;
 	}
-	
+
 	@Override
 	public void breakBlock(World world, int x, int y, int z, Block b, int i)
 	{
@@ -158,7 +175,7 @@ public class Flag extends BlockContainer {
 			//
 			//}
 		}
-		
+
 		super.breakBlock(world, x, y, z, b, i);
     }
 

--- a/src/main/java/com/hfr/clowder/CityLevel.java
+++ b/src/main/java/com/hfr/clowder/CityLevel.java
@@ -1,0 +1,36 @@
+package com.hfr.clowder;
+
+public enum CityLevel {
+	SETTLEMENT("Settlement", 2, 1F, 0.05F),
+	TOWN("Town", 4, 2F, 0.10F),
+	CITY("City", 6, 4F, 0.20F),
+	METROPOLIS("Metropolis", 8, 7F, 0.35F),
+	CAPITAL("Capital", 10, 11F, 0.50F);
+
+	public final String displayName;
+	public final int radius;
+	public final float upgradeCost;
+	public final float upkeep;
+
+	CityLevel(String displayName, int radius, float upgradeCost, float upkeep) {
+		this.displayName = displayName;
+		this.radius = radius;
+		this.upgradeCost = upgradeCost;
+		this.upkeep = upkeep;
+	}
+
+	public CityLevel next() {
+		int next = ordinal() + 1;
+		return next < values().length ? values()[next] : null;
+	}
+
+	public static CityLevel byOrdinal(int ordinal) {
+		if(ordinal < 0 || ordinal >= values().length)
+			return SETTLEMENT;
+		return values()[ordinal];
+	}
+
+	public static int maxRadius() {
+		return CAPITAL.radius;
+	}
+}

--- a/src/main/java/com/hfr/clowder/ClowderTerritory.java
+++ b/src/main/java/com/hfr/clowder/ClowderTerritory.java
@@ -41,6 +41,73 @@ public class ClowderTerritory {
 		return new CoordPair(x / 16, z / 16);
 	}
 	
+
+	public static boolean canPlaceCityCenter(int chunkX, int chunkZ) {
+		return getCityPlacementError(chunkX, chunkZ) == null;
+	}
+
+	public static String getCityPlacementError(int chunkX, int chunkZ) {
+		for(TerritoryMeta meta : territories.values()) {
+			if(meta != null && meta.owner != null && meta.owner.zone == Zone.FACTION && meta.isCityClaim()) {
+				CoordPair other = getCoordPair(meta.flagX, meta.flagZ);
+				double dist = Math.sqrt(Math.pow(chunkX - other.x, 2) + Math.pow(chunkZ - other.z, 2));
+				int required = CityLevel.maxRadius() * 2;
+				if(dist < required)
+					return "City Center is too close to " + meta.cityName + ". City centers must be at least " + required + " chunks apart.";
+			}
+		}
+		return null;
+	}
+
+	public static List<TerritoryMeta> getCityClaims(Clowder owner) {
+		HashMap<String, TerritoryMeta> cities = new HashMap();
+		for(TerritoryMeta meta : territories.values()) {
+			if(meta != null && meta.owner != null && meta.owner.zone == Zone.FACTION && meta.owner.owner == owner && meta.isCityClaim())
+				cities.put(meta.cityId, meta);
+		}
+		return new ArrayList(cities.values());
+	}
+
+	public static TerritoryMeta getCityByName(Clowder owner, String cityName) {
+		if(cityName == null)
+			return null;
+		for(TerritoryMeta meta : getCityClaims(owner)) {
+			if(meta.cityName != null && meta.cityName.equalsIgnoreCase(cityName))
+				return meta;
+		}
+		return null;
+	}
+
+	public static int transferCity(World world, TerritoryMeta city, Clowder newOwner) {
+		if(city == null || !city.isCityClaim() || newOwner == null)
+			return 0;
+		String id = city.cityId;
+		int moved = 0;
+		for(TerritoryMeta meta : territories.values()) {
+			if(meta != null && id.equals(meta.cityId) && meta.owner != null && meta.owner.zone == Zone.FACTION) {
+				meta.owner.owner = newOwner;
+				moved++;
+			}
+		}
+		TileEntity te = world.getTileEntity(city.flagX, city.flagY, city.flagZ);
+		if(te instanceof TileEntityFlag) {
+			TileEntityFlag flag = (TileEntityFlag)te;
+			Clowder oldOwner = flag.owner;
+			if(oldOwner != null && oldOwner != newOwner) {
+				oldOwner.addPrestigeGen(-flag.getGenRate(), world);
+				oldOwner.addPrestigeReq(-flag.getCost(), world);
+				oldOwner.flags--;
+			}
+			flag.owner = newOwner;
+			newOwner.addPrestigeGen(flag.getGenRate(), world);
+			newOwner.addPrestigeReq(flag.getCost(), world);
+			newOwner.flags++;
+			flag.markDirty();
+		}
+		ClowderData.getData(world).markDirty();
+		return moved;
+	}
+
 	//sets the owner of a chunk to a clowder
 	public static void setOwnerForCoord(World world, CoordPair coords, Clowder owner, int fX, int fY, int fZ, String name) {
 		
@@ -59,6 +126,8 @@ public class ClowderTerritory {
 		Ownership o = new Ownership(Zone.FACTION, owner);
 		TerritoryMeta metadata = new TerritoryMeta(o, fX, fY, fZ);
 		metadata.name = name;
+		metadata.cityName = name;
+		metadata.cityId = fX + "," + fY + "," + fZ;
 		//fuck this goddamn shithole of a mod
 		TileEntity flag = world.getTileEntity(fX, fY, fZ);
 		if(flag != null) {
@@ -334,6 +403,9 @@ public class ClowderTerritory {
 		public int flagY;
 		public int flagZ;
 		public String name;
+		public String cityId;
+		public String cityName;
+		public int cityLevel;
 		
 		public TerritoryMeta(Ownership owner, int flagX, int flagY, int flagZ) {
 			this.owner = owner;
@@ -341,6 +413,9 @@ public class ClowderTerritory {
 			this.flagY = flagY;
 			this.flagZ = flagZ;
 			this.name = "";
+			this.cityId = flagX + "," + flagY + "," + flagZ;
+			this.cityName = "";
+			this.cityLevel = 0;
 		}
 
 		public TerritoryMeta(Ownership owner, int flagX, int flagY, int flagZ, World world, String name) {
@@ -368,6 +443,9 @@ public class ClowderTerritory {
 			nbt.setInteger(code + "Y",flagY);
 			nbt.setInteger(code + "Z",flagZ);
 			nbt.setString("name_" + code, name);
+			nbt.setString("cityId_" + code, cityId == null ? "" : cityId);
+			nbt.setString("cityName_" + code, cityName == null ? "" : cityName);
+			nbt.setInteger("cityLevel_" + code, cityLevel);
 		}
 		
 		public static TerritoryMeta readFromNBT(NBTTagCompound nbt, String code) {
@@ -377,17 +455,26 @@ public class ClowderTerritory {
 					nbt.getInteger(code + "X"),
 					nbt.getInteger(code + "Y"),
 					nbt.getInteger(code + "Z")
-					//nbt.getInteger("terr_" + code + "_flagX"),
-					//nbt.getInteger("terr_" + code + "_flagY"),
-					//nbt.getInteger("terr_" + code + "_flagZ"),
-					//nbt.getString("name_" + code)
 			);
-
-
-			
+			meta.name = nbt.getString("name_" + code);
+			meta.cityId = nbt.getString("cityId_" + code);
+			if(meta.cityId == null || meta.cityId.isEmpty())
+				meta.cityId = meta.flagX + "," + meta.flagY + "," + meta.flagZ;
+			meta.cityName = nbt.getString("cityName_" + code);
+			if(meta.cityName == null || meta.cityName.isEmpty())
+				meta.cityName = meta.name;
+			meta.cityLevel = nbt.getInteger("cityLevel_" + code);
 			return meta;
 		}
 		
+		public boolean isCityClaim() {
+			return cityId != null && !cityId.isEmpty() && flagY >= 0;
+		}
+
+		public CityLevel getCityLevel() {
+			return CityLevel.byOrdinal(cityLevel);
+		}
+
 		public int getColor() {
 			
 			if(owner != null) {
@@ -424,6 +511,9 @@ public class ClowderTerritory {
 					
 					int r = flag.getRadius();
 					this.name = flag.getClaimName();
+					this.cityName = flag.getClaimName();
+					if(flag instanceof TileEntityFlag)
+						this.cityLevel = ((TileEntityFlag)flag).cityLevel.ordinal();
 					
 					double dist = Math.sqrt(Math.pow(origin.x - claim.x, 2) + Math.pow(origin.z - claim.z, 2));
 					

--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -10,6 +10,7 @@ import com.hfr.blocks.ModBlocks;
 import com.hfr.clowder.Clowder;
 import com.hfr.clowder.Clowder.ScheduledTeleport;
 import com.hfr.clowder.ClowderFlag;
+import com.hfr.clowder.CityLevel;
 import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.Ownership;
 import com.hfr.clowder.ClowderTerritory.TerritoryMeta;
@@ -21,6 +22,7 @@ import com.hfr.main.MainRegistry;
 import com.hfr.packet.PacketDispatcher;
 import com.hfr.packet.effect.ClowderFlagPacket;
 import com.hfr.tileentity.clowder.ITerritoryProvider;
+import com.hfr.tileentity.clowder.TileEntityFlag;
 import com.hfr.tileentity.clowder.TileEntityFlagBig;
 import com.hfr.tileentity.prop.TileEntityProp;
 import com.hfr.util.ParserUtil;
@@ -35,6 +37,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.MinecraftServer;
@@ -356,8 +359,14 @@ public class CommandClowder extends CommandBase {
 			return;
 		}
 
-		if(cmd.equals("claim")) {
-			cmdClaim(sender);
+		if(cmd.equals("claim") || cmd.equals("city")) {
+			if(args.length > 1 && args[1].equalsIgnoreCase("upgrade")) {
+				cmdCityUpgrade(sender);
+			} else if(args.length > 1) {
+				cmdClaim(sender, String.join(" ", Arrays.copyOfRange(args, 1, args.length)));
+			} else {
+				sender.addChatMessage(new ChatComponentText(ERROR + "Usage: /c claim <city name> or /c city upgrade"));
+			}
 			return;
 		}
 
@@ -386,7 +395,8 @@ public class CommandClowder extends CommandBase {
 			return;
 		}
 		if(cmd.equals("peace") && args.length > 1) {
-			cmdRequestPeace(sender, args[1]);
+			String city = args.length > 2 ? String.join(" ", Arrays.copyOfRange(args, 2, args.length)) : null;
+			cmdRequestPeace(sender, args[1], city);
 			return;
 		}
 		if(cmd.equals("acceptpeace") && args.length > 1) {
@@ -522,7 +532,8 @@ public class CommandClowder extends CommandBase {
 
 		if(p == 4) {
 			//sender.addChatMessage(new ChatComponentText(COMMAND + "-retreat" + TITLE + " - Reatreats after 10 minutes"));
-			sender.addChatMessage(new ChatComponentText(COMMAND + "-claim" + TITLE + " - Creates a new flag"));
+			sender.addChatMessage(new ChatComponentText(COMMAND + "-claim <city name>" + TITLE + " - Creates a named City Center"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-city upgrade" + TITLE + " - Upgrades the City Center for your current claim"));
 			//todo fix
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-balance" + TITLE + " - Displays how much prestige the faction has"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-deposit <amount>" + TITLE + " - Turns prestige items into digiprestige"));
@@ -966,6 +977,11 @@ private void cmdCreate(ICommandSender sender, String name) {
 			sender.addChatMessage(new ChatComponentText(LIST + " -generating: " + clowder.round(clowder.getPrestigeGen()) + " per hour (x" + clowder.round((float) Math.pow(0.99, clowder.getPrestige())) + ")"));
 			sender.addChatMessage(new ChatComponentText(LIST + " -requires: " + clowder.round(clowder.getPrestigeReq()) + " at all times"));
 			sender.addChatMessage(new ChatComponentText(LIST + "Color: " + Integer.toHexString(clowder.color).toUpperCase()));
+			sender.addChatMessage(new ChatComponentText(LIST + "Cities: " + ClowderTerritory.getCityClaims(clowder).size()));
+			for(Object cityObj : ClowderTerritory.getCityClaims(clowder)) {
+				TerritoryMeta city = (TerritoryMeta)cityObj;
+				sender.addChatMessage(new ChatComponentText(LIST + " - " + city.cityName + " [" + city.getCityLevel().displayName + "] radius " + city.getCityLevel().radius + " upkeep " + city.getCityLevel().upkeep));
+			}
 
 		} else {
 			sender.addChatMessage(new ChatComponentText(ERROR + "You are not in any faction!"));
@@ -985,6 +1001,11 @@ private void cmdCreate(ICommandSender sender, String name) {
 			sender.addChatMessage(new ChatComponentText(LIST + "Members: " + clowder.members.size()));
 			sender.addChatMessage(new ChatComponentText(LIST + "Prestige: " + clowder.round(clowder.getPrestige())));
 			sender.addChatMessage(new ChatComponentText(LIST + "Color: " + Integer.toHexString(clowder.color).toUpperCase()));
+			sender.addChatMessage(new ChatComponentText(LIST + "Cities: " + ClowderTerritory.getCityClaims(clowder).size()));
+			for(Object cityObj : ClowderTerritory.getCityClaims(clowder)) {
+				TerritoryMeta city = (TerritoryMeta)cityObj;
+				sender.addChatMessage(new ChatComponentText(LIST + " - " + city.cityName + " [" + city.getCityLevel().displayName + "] radius " + city.getCityLevel().radius + " upkeep " + city.getCityLevel().upkeep));
+			}
 
 		} else {
 			sender.addChatMessage(new ChatComponentText(ERROR + "This faction does not exist!"));
@@ -1730,7 +1751,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 		}
 	}
 
-	//private void cmdClaim(ICommandSender sender) {
+	//private void cmdClaim(ICommandSender sender, String cityName) {
 //
 	//	EntityPlayer player = getCommandSenderAsPlayer(sender);
 	//	Clowder clowder = Clowder.getClowderFromPlayer(player);
@@ -1798,24 +1819,15 @@ private void cmdCreate(ICommandSender sender, String name) {
 	//	}
 	//}
 
-	private void cmdClaim(ICommandSender sender) {
+	private void cmdClaim(ICommandSender sender, String cityName) {
 
 		EntityPlayer player = getCommandSenderAsPlayer(sender);
 		Clowder clowder = Clowder.getClowderFromPlayer(player);
 
-		// Retrieve a unique identifier for the player
-		String playerName = player.getDisplayName();
-
-		// Load the Clowder data
-		ClowderData clowderData = ClowderData.getData(player.getEntityWorld());
-
-		// Check if the player has already claimed a flag
-		if (clowderData.hasPlayerClaimedFlag(playerName)) {
-			sender.addChatMessage(new ChatComponentText(ERROR + "You have already claimed a flag!"));
+		if(cityName == null || cityName.trim().isEmpty()) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Usage: /c claim <city name>"));
 			return;
 		}
-
-
 
 		if(clowder != null) {
 
@@ -1824,16 +1836,51 @@ private void cmdCreate(ICommandSender sender, String name) {
 				return;
 			}
 
-			player.inventory.addItemStackToInventory(new ItemStack(ModBlocks.clowder_flag));
+			ItemStack stack = new ItemStack(ModBlocks.clowder_flag);
+			stack.stackTagCompound = new NBTTagCompound();
+			stack.stackTagCompound.setString("cityName", cityName.trim());
+			stack.setStackDisplayName("City Center: " + cityName.trim());
+			player.inventory.addItemStackToInventory(stack);
 			player.inventoryContainer.detectAndSendChanges();
-			sender.addChatMessage(new ChatComponentText(INFO + "Place the flag to claim new territory!"));
-
-			clowderData.markPlayerClaimedFlag(playerName);
+			sender.addChatMessage(new ChatComponentText(INFO + "Place the City Center to found " + cityName.trim() + "."));
 
 		} else {
 			sender.addChatMessage(new ChatComponentText(ERROR + "You are not in any faction!"));
 		}
 	}
+	private void cmdCityUpgrade(ICommandSender sender) {
+		EntityPlayer player = getCommandSenderAsPlayer(sender);
+		Clowder clowder = Clowder.getClowderFromPlayer(player);
+		if(clowder == null) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "You are not in any faction!"));
+			return;
+		}
+		if(clowder.getPermLevel(player.getDisplayName()) < 2) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "You lack the permissions to upgrade cities!"));
+			return;
+		}
+		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords((int)player.posX, (int)player.posZ);
+		if(meta == null || meta.owner == null || meta.owner.owner != clowder) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Stand inside one of your city claims to upgrade it."));
+			return;
+		}
+		TileEntity te = player.worldObj.getTileEntity(meta.flagX, meta.flagY, meta.flagZ);
+		if(!(te instanceof TileEntityFlag)) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "This claim is not attached to a City Center."));
+			return;
+		}
+		TileEntityFlag city = (TileEntityFlag)te;
+		CityLevel next = city.cityLevel.next();
+		if(next == null) {
+			sender.addChatMessage(new ChatComponentText(ERROR + city.name + " is already a Capital."));
+			return;
+		}
+		if(city.upgradeCity())
+			sender.addChatMessage(new ChatComponentText(INFO + city.name + " upgraded to " + city.cityLevel.displayName + " (radius " + city.cityLevel.radius + ", upkeep " + city.cityLevel.upkeep + ")."));
+		else
+			sender.addChatMessage(new ChatComponentText(ERROR + "Upgrade requires " + next.upgradeCost + " prestige and sequential upkeep capacity."));
+	}
+
 	//I have no idea how territories work, but it looks retarded
 
 	//todo here
@@ -1984,7 +2031,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 				EnumChatFormatting.DARK_RED + "[WAR] " + EnumChatFormatting.GOLD + me.name + EnumChatFormatting.RED + " has declared war on " + EnumChatFormatting.GOLD + target.name + EnumChatFormatting.RED + "!"));
 	}
 
-	private void cmdRequestPeace(ICommandSender sender, String targetName) {
+	private void cmdRequestPeace(ICommandSender sender, String targetName, String transferCity) {
 		if (CommandClowderAdmin.LEGACY_WAR_ENABLED) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "Legacy war mode is enabled: peace/ceasefire/surrender mechanics are disabled."));
 			return;
@@ -1995,7 +2042,17 @@ private void cmdCreate(ICommandSender sender, String name) {
 		if (me == null || target == null || me == target) return;
 		if (me.getPermLevel(player.getDisplayName()) < 3) return;
 		me.peaceRequests.add(target.name);
-		target.notifyAll(player.worldObj, new ChatComponentText(INFO + me.name + " has offered peace. Use /c acceptpeace " + me.name));
+		if(transferCity != null && !transferCity.trim().isEmpty()) {
+			TerritoryMeta city = ClowderTerritory.getCityByName(me, transferCity.trim());
+			if(city == null) {
+				sender.addChatMessage(new ChatComponentText(ERROR + "Unknown city: " + transferCity));
+				return;
+			}
+			me.peaceRequests.add(target.name + ":city:" + city.cityName);
+			target.notifyAll(player.worldObj, new ChatComponentText(INFO + me.name + " has offered peace including transfer of " + city.cityName + ". Use /c acceptpeace " + me.name));
+		} else {
+			target.notifyAll(player.worldObj, new ChatComponentText(INFO + me.name + " has offered peace. Use /c acceptpeace " + me.name));
+		}
 	}
 	private void cmdAcceptPeace(ICommandSender sender, String targetName) {
 		if (CommandClowderAdmin.LEGACY_WAR_ENABLED) {
@@ -2009,6 +2066,19 @@ private void cmdCreate(ICommandSender sender, String name) {
 		if(!(CommandClowderAdmin.LEGACY_WAR_ENABLED || CommandClowderAdmin.WAR_STATE_CHECK_DISABLED) && !me.isAtWarWith(target)) return;
 		if(!target.peaceRequests.contains(me.name)) return;
 		target.peaceRequests.remove(me.name);
+		String prefix = me.name + ":city:";
+		for(Object requestObj : new ArrayList(target.peaceRequests)) {
+			String request = (String)requestObj;
+			if(request.startsWith(prefix)) {
+				String cityName = request.substring(prefix.length());
+				TerritoryMeta city = ClowderTerritory.getCityByName(target, cityName);
+				if(city != null) {
+					int chunks = ClowderTerritory.transferCity(player.worldObj, city, me);
+					MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(EnumChatFormatting.GREEN + "[WAR] " + cityName + " transferred to " + me.name + " (" + chunks + " chunks)."));
+				}
+				target.peaceRequests.remove(request);
+			}
+		}
 		me.activeWars.remove(target.name); target.activeWars.remove(me.name);
 		if(!CommandClowderAdmin.WAR_COOLDOWNS_DISABLED) {
 			long until = System.currentTimeMillis() + 84L * 60L * 60L * 1000L;
@@ -2070,6 +2140,10 @@ private void cmdCreate(ICommandSender sender, String name) {
 		if (me == null || target == null || me == target || me.getPermLevel(player.getDisplayName()) < 3) return;
 		if(!target.surrenderRequests.contains(me.name)) return;
 		target.surrenderRequests.remove(me.name);
+		for(Object cityObj : ClowderTerritory.getCityClaims(target)) {
+			TerritoryMeta city = (TerritoryMeta)cityObj;
+			ClowderTerritory.transferCity(player.worldObj, city, me);
+		}
 		me.activeWars.remove(target.name); target.activeWars.remove(me.name);
 		if(!CommandClowderAdmin.WAR_COOLDOWNS_DISABLED) {
 			long until = System.currentTimeMillis() + 84L * 60L * 60L * 1000L;

--- a/src/main/java/com/hfr/inventory/gui/GUIFlag.java
+++ b/src/main/java/com/hfr/inventory/gui/GUIFlag.java
@@ -23,7 +23,7 @@ public class GUIFlag extends GuiContainer {
 	public static ResourceLocation texture = new ResourceLocation(RefStrings.MODID + ":textures/gui/gui_flag.png");
 	private TileEntityFlag diFurnace;
 	private long press;
-	
+
 	public GUIFlag(InventoryPlayer invPlayer, TileEntityFlag tedf) {
 		super(new ContainerFlag(invPlayer, tedf));
 		diFurnace = tedf;
@@ -31,101 +31,105 @@ public class GUIFlag extends GuiContainer {
 		this.xSize = 176;
 		this.ySize = 168;
 	}
-	
+
 	@Override
 	protected void drawGuiContainerForegroundLayer(int x, int y) {
-		
+
 		String name = I18n.format(diFurnace.getInventoryName());
 		this.fontRendererObj.drawString(name, this.xSize / 2 - this.fontRendererObj.getStringWidth(name) / 2, 6, 4210752);
 		this.fontRendererObj.drawString(I18n.format("container.inventory"), 8, this.ySize - 96 + 2, 4210752);
 
 		float prestige = diFurnace.prestige;
 		float prestigeReq = diFurnace.prestigeReq;
-		
+
 		int color = 0xFF0000;
-		
+
 		if(prestigeReq <= prestige)
 			color = 0x008000;
-		
+
 		this.fontRendererObj.drawString("Prestige: " + Clowder.round(prestige), 50, 34, 4210752);
 		this.fontRendererObj.drawString("Required: " + Clowder.round(prestigeReq), 50, 46, color);
-		
+		this.fontRendererObj.drawString("City: " + diFurnace.name, 50, 58, 4210752);
+		this.fontRendererObj.drawString("Level: " + diFurnace.cityLevel.displayName, 50, 70, 4210752);
+		this.fontRendererObj.drawString("Radius: " + diFurnace.cityLevel.radius + " Upkeep: " + diFurnace.cityLevel.upkeep, 50, 82, 4210752);
+		this.fontRendererObj.drawString("Owner: " + (diFurnace.owner == null ? "None" : diFurnace.owner.name), 50, 94, 4210752);
 
-    	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 17 < y && guiTop + 17 + 18 >= y) {
-    		this.func_146283_a(Arrays.asList(new String[] {"Requires 3 prestige", "Claims land in a 10 chunk radius"}), x - guiLeft, y - guiTop);
-    	}
-    	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 35 < y && guiTop + 35 + 18 >= y) {
-    		this.func_146283_a(Arrays.asList(new String[] {"Requires 2 prestige", "Claims land in a 5 chunk radius"}), x - guiLeft, y - guiTop);
-    	}
-    	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 53 < y && guiTop + 53 + 18 >= y) {
-    		this.func_146283_a(Arrays.asList(new String[] {"Requires 1 prestige", "Claims land in a 1 chunk radius"}), x - guiLeft, y - guiTop);
-    	}
-    	if(guiLeft + 133 <= x && guiLeft + 133 + 18 > x && guiTop + 52 < y && guiTop + 52 + 18 >= y) {
-    		
-    		if(diFurnace.height < 1.0F )
-        		this.func_146283_a(Arrays.asList(new String[] {"Not claimed"}), x - guiLeft, y - guiTop);
-    		else if(diFurnace.mode == 0)
-        		this.func_146283_a(Arrays.asList(new String[] {"Not active"}), x - guiLeft, y - guiTop);
-    		else
-        		this.func_146283_a(Arrays.asList(new String[] {"Active"}), x - guiLeft, y - guiTop);
-    	}
+
+	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 17 < y && guiTop + 17 + 18 >= y) {
+		this.func_146283_a(Arrays.asList(new String[] {"City upgrade handled by /c city upgrade", "Capital max radius: 10 chunks"}), x - guiLeft, y - guiTop);
+	}
+	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 35 < y && guiTop + 35 + 18 >= y) {
+		this.func_146283_a(Arrays.asList(new String[] {"City Center", "Claims by city level"}), x - guiLeft, y - guiTop);
+	}
+	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 53 < y && guiTop + 53 + 18 >= y) {
+		this.func_146283_a(Arrays.asList(new String[] {"Settlement", "Sequential upgrades only"}), x - guiLeft, y - guiTop);
+	}
+	if(guiLeft + 133 <= x && guiLeft + 133 + 18 > x && guiTop + 52 < y && guiTop + 52 + 18 >= y) {
+
+		if(diFurnace.height < 1.0F )
+						this.func_146283_a(Arrays.asList(new String[] {"Not claimed"}), x - guiLeft, y - guiTop);
+		else if(diFurnace.mode == 0)
+						this.func_146283_a(Arrays.asList(new String[] {"Not active"}), x - guiLeft, y - guiTop);
+		else
+						this.func_146283_a(Arrays.asList(new String[] {"Active"}), x - guiLeft, y - guiTop);
+	}
 	}
 
-    protected void mouseClicked(int x, int y, int i) {
-    	super.mouseClicked(x, y, i);
+				protected void mouseClicked(int x, int y, int i) {
+	super.mouseClicked(x, y, i);
 
-    	//A
-    	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 17 < y && guiTop + 17 + 18 >= y) {
+	//A
+	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 17 < y && guiTop + 17 + 18 >= y) {
 
-    		PacketDispatcher.wrapper.sendToServer(new AuxButtonPacket(diFurnace.xCoord, diFurnace.yCoord, diFurnace.zCoord, 0, 0));
+		PacketDispatcher.wrapper.sendToServer(new AuxButtonPacket(diFurnace.xCoord, diFurnace.yCoord, diFurnace.zCoord, 0, 0));
 			mc.getSoundHandler().playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation("gui.button.press"), 1.0F));
-    	}
-    	
-    	//B
-    	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 35 < y && guiTop + 35 + 18 >= y) {
+	}
 
-    		PacketDispatcher.wrapper.sendToServer(new AuxButtonPacket(diFurnace.xCoord, diFurnace.yCoord, diFurnace.zCoord, 0, 1));
-			mc.getSoundHandler().playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation("gui.button.press"), 1.0F));
-    	}
-    	
-    	//C
-    	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 53 < y && guiTop + 53 + 18 >= y) {
+	//B
+	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 35 < y && guiTop + 35 + 18 >= y) {
 
-    		PacketDispatcher.wrapper.sendToServer(new AuxButtonPacket(diFurnace.xCoord, diFurnace.yCoord, diFurnace.zCoord, 0, 2));
+		PacketDispatcher.wrapper.sendToServer(new AuxButtonPacket(diFurnace.xCoord, diFurnace.yCoord, diFurnace.zCoord, 0, 1));
 			mc.getSoundHandler().playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation("gui.button.press"), 1.0F));
-    	}
-    	
-    	//CAPTURE
-    	/*if(!isPressed() && guiLeft + 133 <= x && guiLeft + 133 + 18 > x && guiTop + 16 < y && guiTop + 16 + 18 >= y) {
+	}
 
-    		press = System.currentTimeMillis();
-    		PacketDispatcher.wrapper.sendToServer(new AuxButtonPacket(diFurnace.xCoord, diFurnace.yCoord, diFurnace.zCoord, 0, 3));
+	//C
+	if(guiLeft + 25 <= x && guiLeft + 25 + 18 > x && guiTop + 53 < y && guiTop + 53 + 18 >= y) {
+
+		PacketDispatcher.wrapper.sendToServer(new AuxButtonPacket(diFurnace.xCoord, diFurnace.yCoord, diFurnace.zCoord, 0, 2));
 			mc.getSoundHandler().playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation("gui.button.press"), 1.0F));
-    	}*/
-    }
-	
+	}
+
+	//CAPTURE
+	/*if(!isPressed() && guiLeft + 133 <= x && guiLeft + 133 + 18 > x && guiTop + 16 < y && guiTop + 16 + 18 >= y) {
+
+		press = System.currentTimeMillis();
+		PacketDispatcher.wrapper.sendToServer(new AuxButtonPacket(diFurnace.xCoord, diFurnace.yCoord, diFurnace.zCoord, 0, 3));
+			mc.getSoundHandler().playSound(PositionedSoundRecord.func_147674_a(new ResourceLocation("gui.button.press"), 1.0F));
+	}*/
+				}
+
 	@Override
 	protected void drawGuiContainerBackgroundLayer(float p_146976_1_, int p_146976_2_, int p_146976_3_) {
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 		Minecraft.getMinecraft().getTextureManager().bindTexture(texture);
 		drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
-		
+
 		int i = diFurnace.mode;
-		
+
 		if(i > 0)
 			drawTexturedModalRect(guiLeft + 25, guiTop + 16 - 18 + 18 * i, 176, -18 + 18 * diFurnace.mode, 18, 18);
-		
+
 		if(diFurnace.height < 1.0F)
 			drawTexturedModalRect(guiLeft + 133, guiTop + 52, 176, 72, 18, 18);
 		else if(i > 0)
 			drawTexturedModalRect(guiLeft + 133, guiTop + 52, 176, 108, 18, 18);
 		else
 			drawTexturedModalRect(guiLeft + 133, guiTop + 52, 176, 90, 18, 18);
-		
+
 		if(isPressed())
 			drawTexturedModalRect(guiLeft + 133, guiTop + 16, 176, 54, 18, 18);
 	}
-	
+
 	private boolean isPressed() {
 		return press + 1000 >= System.currentTimeMillis();
 	}

--- a/src/main/java/com/hfr/items/ItemMap.java
+++ b/src/main/java/com/hfr/items/ItemMap.java
@@ -63,6 +63,9 @@ public class ItemMap extends Item {
 				part = "";
 			}
 			
+			TerritoryMeta here = ClowderTerritory.getMetaFromIntCoords((int)player.posX, (int)player.posZ);
+			if(here != null && here.owner != null && here.owner.zone == Zone.FACTION)
+				player.addChatComponentMessage(new ChatComponentText(EnumChatFormatting.YELLOW + "City: " + here.cityName + " (" + here.getCityLevel().displayName + ") - " + (here.owner.owner == null ? "Unknown" : here.owner.owner.name)));
 			printSep(size, player);
 		}
 		

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.hfr.clowder.Clowder;
 import com.hfr.clowder.ClowderFlag;
+import com.hfr.clowder.CityLevel;
 import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.CoordPair;
 import com.hfr.clowder.ClowderTerritory.Ownership;
@@ -32,6 +33,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	public float speed = 1F / (20F * 30F);
 	public int mode = 0;
 	public String name = "";
+	public CityLevel cityLevel = CityLevel.SETTLEMENT;
 	
 	private int timer = 0;
 	
@@ -160,7 +162,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 				MainRegistry.logger.info("Unlocking flag " + xCoord + " " + yCoord + " " + zCoord + " for being unhoisted! (captured!)");
 				
 				if(owner != null)
-					owner.notifyCapture(worldObj, xCoord, zCoord, "flags");
+					owner.notifyCapture(worldObj, xCoord, zCoord, "City Center " + name);
 			}
 			
 			if(prevC != owner)
@@ -194,6 +196,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 				this.updateGauge(owner.color, 1, 250);
 				this.updateGauge(Float.floatToIntBits(owner.getPrestige()), 4, 20);
 				this.updateGauge(Float.floatToIntBits(owner.getPrestigeReq()), 5, 20);
+				this.updateGauge(cityLevel.ordinal(), 6, 20);
 			} else {
 				this.updateGauge(ClowderFlag.NONE.ordinal(), 0, 250);
 				this.updateGauge(0xFFFFFF, 1, 250);
@@ -228,12 +231,12 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 		case 3: height = val * 0.01F; break;
 		case 4: prestige = Float.intBitsToFloat(val); break;
 		case 5: prestigeReq = Float.intBitsToFloat(val); break;
+		case 6: cityLevel = CityLevel.byOrdinal(val); break;
 		}
 	}
 	
 	public float getGenRate() {
-		
-		return getGenRateFromMode(mode);
+		return owner == null ? 0 : Clowder.flagRate;
 	}
 	
 	public static float getGenRateFromMode(int mode) {
@@ -245,20 +248,11 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	}
 	
 	public float getCost() {
-		
-		return getCostFromMode(mode);
+		return cityLevel.upkeep;
 	}
 	
 	public static float getCostFromMode(int mode) {
-
-		if(mode == 1)
-			return Clowder.flagReq * 3;
-		if(mode == 2)
-			return Clowder.flagReq * 2;
-		if(mode == 3)
-			return Clowder.flagReq * 1;
-		
-		return 0;
+		return CityLevel.SETTLEMENT.upkeep;
 	}
 	
 	public void setOwner(Clowder c) {
@@ -288,34 +282,27 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	}
 	
 	public void setMode(int mode) {
-		
-		//if there's no owner, the mode cannot be set
-		if(owner == null) {
-			this.mode = 0;
-			return;
-		}
-
-		float beforeGen = getGenRateFromMode(this.mode);
-		float afterGen = getGenRateFromMode(mode);
-
-		float beforeCost = getCostFromMode(this.mode);
-		float afterCost = getCostFromMode(mode);
-		
-		//if the new requirement is above the prestige level, the mode will not change
-		if(owner.getPrestigeReq() - beforeCost + afterCost > owner.getPrestige())
-			return;
-
-		//subtract old amounts
-		owner.addPrestigeGen(-beforeGen, worldObj);
-		owner.addPrestigeReq(-beforeCost, worldObj);
-		
-		this.mode = mode;
-		
-		//...and add the new ones
-		owner.addPrestigeGen(afterGen, worldObj);
-		owner.addPrestigeReq(afterCost, worldObj);
-		
+		// City Centers always use the current city level for radius/upkeep.
+		this.mode = owner == null ? 0 : 1;
 		this.markDirty();
+	}
+
+	public boolean upgradeCity() {
+		if(owner == null)
+			return false;
+		CityLevel next = cityLevel.next();
+		if(next == null)
+			return false;
+		float beforeCost = getCost();
+		if(owner.getPrestige() < next.upgradeCost || owner.getPrestigeReq() - beforeCost + next.upkeep > owner.getPrestige() - next.upgradeCost)
+			return false;
+		owner.addPrestige(-next.upgradeCost, worldObj);
+		owner.addPrestigeReq(-beforeCost, worldObj);
+		cityLevel = next;
+		owner.addPrestigeReq(getCost(), worldObj);
+		generateClaim();
+		markDirty();
+		return true;
 	}
 	
 	private boolean consumeToken() {
@@ -344,12 +331,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	@Override
 	public int getRadius() {
 		
-		switch(mode) {
-		case 1: return 10;
-		case 2: return 5;
-		case 3: return 2;
-		default: return 0;
-		}
+		return owner == null ? 0 : cityLevel.radius;
 	}
 
 	@Override
@@ -359,10 +341,13 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	
 	public void generateClaim() {
 		
-		int rad = getRadius();
+		int rad = Math.min(getRadius(), CityLevel.maxRadius());
+		String placementError = ClowderTerritory.getCityPlacementError(xCoord >> 4, zCoord >> 4);
+		if(placementError != null && ClowderTerritory.getMetaFromIntCoords(xCoord, zCoord) == null)
+			return;
 		
-		for(int x = -rad; x <= rad; x++) {
-			for(int z = -rad; z <= rad; z++) {
+		for(int x = -CityLevel.maxRadius(); x <= CityLevel.maxRadius(); x++) {
+			for(int z = -CityLevel.maxRadius(); z <= CityLevel.maxRadius(); z++) {
 
 				int posX = xCoord + x * 16;
 				int posZ = zCoord + z * 16;
@@ -370,9 +355,19 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 				
 				TerritoryMeta meta = ClowderTerritory.getMetaFromCoords(loc);
 				
-				if(meta == null || !meta.checkPersistence(worldObj, loc))
-					if(Math.sqrt(Math.pow(x, 2) + Math.pow(z, 2)) < rad)
+				double dist = Math.sqrt(Math.pow(x, 2) + Math.pow(z, 2));
+				if(dist < rad) {
+					if(meta == null || !meta.checkPersistence(worldObj, loc) || (meta.flagX == xCoord && meta.flagY == yCoord && meta.flagZ == zCoord)) {
 						ClowderTerritory.setOwnerForCoord(worldObj, loc, owner, xCoord, yCoord, zCoord, name);
+						TerritoryMeta newMeta = ClowderTerritory.getMetaFromCoords(loc);
+						if(newMeta != null) {
+							newMeta.cityLevel = cityLevel.ordinal();
+							newMeta.cityName = name;
+						}
+					}
+				} else if(meta != null && meta.flagX == xCoord && meta.flagY == yCoord && meta.flagZ == zCoord) {
+					ClowderTerritory.removeZoneForCoord(worldObj, loc);
+				}
 			}
 		}
 	}
@@ -385,7 +380,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 		/*int rad = getRadius();
 		
 		for(int x = -rad; x <= rad; x++) {
-			for(int z = -rad; z <= rad; z++) {
+			for(int z = -CityLevel.maxRadius(); z <= CityLevel.maxRadius(); z++) {
 				
 				double dist = Math.sqrt(Math.pow(x, 2) + Math.pow(z, 2));
 				
@@ -487,6 +482,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 		this.mode = nbt.getInteger("mode");
 		this.timer = nbt.getInteger("timer");
 		this.name = nbt.getString("name");
+		this.cityLevel = CityLevel.byOrdinal(nbt.getInteger("cityLevel"));
 		
 		slots = new ItemStack[getSizeInventory()];
 		
@@ -517,6 +513,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 		nbt.setInteger("mode", mode);
 		nbt.setInteger("timer", timer);
 		nbt.setString("name", name);
+		nbt.setInteger("cityLevel", cityLevel.ordinal());
 		
 		NBTTagList list = new NBTTagList();
 		

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
@@ -7,6 +7,7 @@ import java.util.Random;
 import com.hfr.blocks.ModBlocks;
 import com.hfr.clowder.Clowder;
 import com.hfr.clowder.ClowderFlag;
+import com.hfr.clowder.CityLevel;
 import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.CoordPair;
 import com.hfr.clowder.ClowderTerritory.TerritoryMeta;
@@ -178,8 +179,7 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 
 	@Override
 	public int getRadius() {
-		
-		return 1000;
+		return CityLevel.maxRadius();
 	}
 
 	@Override
@@ -194,12 +194,13 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 		int maxX = Math.max(x1, x2);
 		int maxZ = Math.max(z1, z2);
 		
+		CoordPair origin = ClowderTerritory.getCoordPair(xCoord, zCoord);
 		for(int x = minX; x <= maxX; x += 16) {
-			
 			for(int z = minZ; z <= maxZ; z += 16) {
-				
 				CoordPair coord = ClowderTerritory.getCoordPair(x, z);
-				this.claim.add(coord);
+				double dist = Math.sqrt(Math.pow(origin.x - coord.x, 2) + Math.pow(origin.z - coord.z, 2));
+				if(dist < getRadius())
+					this.claim.add(coord);
 			}
 		}
 

--- a/src/main/resources/assets/hfr/lang/en_US.lang
+++ b/src/main/resources/assets/hfr/lang/en_US.lang
@@ -82,8 +82,8 @@ tile.officer_chest.name=Officer Chest
 
 tile.teleporter.name=Teleporter
 
-tile.clowder_flag.name=Claim Flag
-container.flagPole=Claim Flag
+tile.clowder_flag.name=City Center
+container.flagPole=City Center
 tile.clowder_flag_big.name=Claim Territory Flag
 tile.clowder_cap.name=Claim Cap Point (ALSO DON'T USE THIS ONE AS WELL)
 tile.clowder_conquerer.name=Claim Conquest Flag


### PR DESCRIPTION
### Motivation

- Replace the old free-form claim/flag model with a City Center entity that becomes the authoritative origin for territory owned by a faction.  
- Limit and centralize territory expansion around city centers and enforce placement/spacing rules to avoid overlapping city borders.  
- Add progression and economic costs so cities are meaningful assets (levels, upgrade cost, upkeep).  

### Description

- Add `CityLevel` enum providing Settlement→Town→City→Metropolis→Capital with per-level radius, upgrade cost and upkeep, and helpers (`CityLevel.byOrdinal`, `maxRadius`).  
- Extend `ClowderTerritory.TerritoryMeta` to store `cityId`, `cityName` and `cityLevel`, persist them to NBT, and add helpers in `ClowderTerritory` for city placement validation (`getCityPlacementError`/`canPlaceCityCenter`), city lookups (`getCityClaims`, `getCityByName`) and ownership transfer (`transferCity`).  
- Convert flag tile entity into a City Center flow in `TileEntityFlag`: store a `cityLevel`, use the city level radius for claim generation and upkeep, add `upgradeCity()` to sequentially upgrade levels with prestige and upkeep adjustments, and update `generateClaim()` to mark claimed chunks with city metadata and to enforce non-overlap and max-radius behavior.  
- Change block placement logic in `blocks/clowder/Flag.java` to require a name on placement (the item now carries `cityName`), validate placement spacing before creation, and initialize the City Center claim on placement.  
- Limit broad province-claim behavior in `TileEntityFlagBig` to the City max radius when adding claims.  
- Add UI/command changes: `CommandClowder` now supports ` /c claim <city name>` (gives a named City Center item) and ` /c city upgrade` (upgrades the City Center a level); `cmdRequestPeace` and `cmdAcceptPeace` were extended to allow offering/transferring a specific city during peace, and surrender acceptance now transfers all cities; `cmdInfo` and GUI (`GUIFlag`) and map (`ItemMap`) show city name, level, radius, upkeep and ownership.  
- Localization: rename claim UI text to "City Center" (`en_US.lang`) so item/GUI uses the City Center label.  

### Testing

- Ran repository consistency checks with `git diff --check` and addressed whitespace/format issues (no build-specific git operations described).  
- Performed a local Java syntax/parse check by invoking `javac -source 8 -target 8` on the modified set of Java sources to detect obvious syntax/API issues; this caught no parse errors inside the edited files (note: full type resolution requires the Minecraft/Forge classpath).  
- Attempted project build with Gradle (`gradle compileJava` / `gradle --offline compileJava`), but project configuration failed due to the repository’s older ForgeGradle / Minecraft setup being incompatible with the available Gradle environment in CI (build tooling mismatch), so a full Forge build was not completed in this environment.  

If you want, I can split this into smaller reviewable patches (placement/metadata, tileentity changes, command/UI updates, and war/transfer integration) or add unit-style smoke tests that run on a mocked subset of logic (non-Minecraft classes) to increase automated coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b580c34f88329853ef9d73f5a2098)