### PR TITLE
Enforce unique city names, add territory rename/remove helpers, and show city info on conquer flag placement

### DIFF
--- a/src/main/java/com/hfr/blocks/clowder/Conquerer.java
+++ b/src/main/java/com/hfr/blocks/clowder/Conquerer.java
@@ -3,8 +3,7 @@ package com.hfr.blocks.clowder;
 import com.hfr.blocks.ModBlocks;
 import com.hfr.clowder.Clowder;
 import com.hfr.clowder.ClowderTerritory;
-import com.hfr.clowder.ClowderTerritory.Ownership;
-import com.hfr.clowder.ClowderTerritory.Zone;
+import com.hfr.clowder.ClowderTerritory.TerritoryMeta;
 import com.hfr.command.CommandClowderAdmin;
 import com.hfr.tileentity.clowder.TileEntityConquerer;
 import com.hfr.tileentity.clowder.TileEntityFlag;
@@ -80,7 +79,8 @@ public class Conquerer extends BlockContainer {
 				flag.markDirty();
 				MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(
 						EnumChatFormatting.RED + "[WAR] " + EnumChatFormatting.GOLD + clowder.name +
-						EnumChatFormatting.YELLOW + " placed a claim flag at " + EnumChatFormatting.AQUA + "(" + x + ", " + y + ", " + z + ")"
+						EnumChatFormatting.YELLOW + " placed a claim flag for " + getTargetCityName(x, z) +
+						EnumChatFormatting.YELLOW + " at " + EnumChatFormatting.AQUA + "(" + x + ", " + y + ", " + z + ")"
 				));
 			} else {
 				flag.owner = null;
@@ -112,6 +112,19 @@ public class Conquerer extends BlockContainer {
 
 	}
 	
+	private String getTargetCityName(int x, int z) {
+		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords(x, z);
+		if(meta != null) {
+			String cityName = meta.cityName != null && !meta.cityName.trim().isEmpty() ? meta.cityName : meta.name;
+			if(cityName != null && !cityName.trim().isEmpty()) {
+				String ownerName = meta.owner != null && meta.owner.owner != null ? meta.owner.owner.name + "'s " : "";
+				return EnumChatFormatting.AQUA + ownerName + "city " + cityName.trim();
+			}
+		}
+
+		return EnumChatFormatting.AQUA + "the city at X:" + x + " / Z:" + z;
+	}
+
 	public boolean noProximity(World world, int x, int y, int z) {
 		
 		int range = 4;

--- a/src/main/java/com/hfr/blocks/clowder/Flag.java
+++ b/src/main/java/com/hfr/blocks/clowder/Flag.java
@@ -5,8 +5,6 @@ import com.hfr.clowder.CityLevel;
 import com.hfr.clowder.Clowder;
 import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.CoordPair;
-import com.hfr.clowder.ClowderTerritory.Ownership;
-import com.hfr.clowder.ClowderTerritory.Zone;
 import com.hfr.main.MainRegistry;
 import com.hfr.tileentity.clowder.TileEntityFlag;
 
@@ -99,6 +97,12 @@ public class Flag extends BlockContainer {
 				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "City Centers require a name. Use /c claim <city name>."));
 				return;
 			}
+			cityName = cityName.trim();
+			if(!ClowderTerritory.isCityNameAvailable(cityName, null)) {
+				world.setBlockToAir(x, y, z);
+				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "A city named " + cityName + " already exists."));
+				return;
+			}
 			if(cityError != null) {
 				world.setBlockToAir(x, y, z);
 				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + cityError));
@@ -114,7 +118,7 @@ public class Flag extends BlockContainer {
 					return;
 				}
 				clowder.addPrestige(-foundingCost, world);
-				flag.name = cityName.trim();
+				flag.name = cityName;
 				flag.setOwner(clowder);
 				flag.setMode(1);
 				flag.isClaimed = true;
@@ -158,31 +162,16 @@ public class Flag extends BlockContainer {
 	@Override
 	public void breakBlock(World world, int x, int y, int z, Block b, int i)
 	{
-		Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+		TileEntity tile = world.getTileEntity(x, y, z);
 
-		if (owner != null && owner.zone == Zone.FACTION) {
-			//break
-			TileEntityFlag flag = (TileEntityFlag) world.getTileEntity(x, y, z);
+		if(tile instanceof TileEntityFlag) {
+			TileEntityFlag flag = (TileEntityFlag)tile;
 
-			if (flag != null && flag.owner != null) {
+			if(flag.owner != null)
 				flag.setOwner(null);
-			}
-		} else {
-			if (owner != null && !noProximity(world, x, y, z)) {
-					TileEntityFlag flag = (TileEntityFlag) world.getTileEntity(x, y, z);
 
-					if (flag != null && flag.owner != null) {
-						flag.setOwner(null);
-					}
-					//if this flag is being broken, and it is close to a conquerer, break it
-				flag.height = 0.0F;
-				super.breakBlock(world, x, y, z, b, i);
-			}
-			//do nothing
-			//else {
-			//	//im having a brain fart here
-			//
-			//}
+			flag.height = 0.0F;
+			ClowderTerritory.removeClaimsForCity(world, x, y, z);
 		}
 
 		super.breakBlock(world, x, y, z, b, i);

--- a/src/main/java/com/hfr/clowder/ClowderTerritory.java
+++ b/src/main/java/com/hfr/clowder/ClowderTerritory.java
@@ -78,6 +78,62 @@ public class ClowderTerritory {
 		return null;
 	}
 
+	public static TerritoryMeta getCityByName(String cityName) {
+		if(cityName == null)
+			return null;
+		String trimmed = cityName.trim();
+		if(trimmed.isEmpty())
+			return null;
+		HashMap<String, TerritoryMeta> cities = new HashMap();
+		for(TerritoryMeta meta : territories.values()) {
+			if(meta != null && meta.owner != null && meta.owner.zone == Zone.FACTION && meta.isCityClaim())
+				cities.put(meta.cityId, meta);
+		}
+		for(TerritoryMeta meta : cities.values()) {
+			if(meta.cityName != null && meta.cityName.equalsIgnoreCase(trimmed))
+				return meta;
+		}
+		return null;
+	}
+
+	public static boolean isCityNameAvailable(String cityName, TerritoryMeta ignoredCity) {
+		TerritoryMeta existing = getCityByName(cityName);
+		if(existing == null)
+			return true;
+		return ignoredCity != null && existing.cityId != null && existing.cityId.equals(ignoredCity.cityId);
+	}
+
+	public static int renameClaimsForCity(World world, int fX, int fY, int fZ, String name) {
+		String id = fX + "," + fY + "," + fZ;
+		int renamed = 0;
+		for(TerritoryMeta meta : territories.values()) {
+			if(meta != null && id.equals(meta.cityId)) {
+				meta.name = name;
+				meta.cityName = name;
+				renamed++;
+			}
+		}
+		if(renamed > 0 && world != null)
+			ClowderData.getData(world).markDirty();
+		return renamed;
+	}
+
+	public static int removeClaimsForCity(World world, int fX, int fY, int fZ) {
+		String id = fX + "," + fY + "," + fZ;
+		int removed = 0;
+		List<Long> claims = new ArrayList(territories.keySet());
+		for(Long code : claims) {
+			TerritoryMeta meta = territories.get(code);
+			if(meta != null && id.equals(meta.cityId)) {
+				territories.remove(code);
+				removed++;
+			}
+		}
+		if(removed > 0 && world != null)
+			ClowderData.getData(world).markDirty();
+		return removed;
+	}
+
 	public static int transferCity(World world, TerritoryMeta city, Clowder newOwner) {
 		if(city == null || !city.isCityClaim() || newOwner == null)
 			return 0;

--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -1828,6 +1828,11 @@ private void cmdCreate(ICommandSender sender, String name) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "Usage: /c claim <city name>"));
 			return;
 		}
+		cityName = cityName.trim();
+		if(!ClowderTerritory.isCityNameAvailable(cityName, null)) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "A city named " + cityName + " already exists."));
+			return;
+		}
 
 		if(clowder != null) {
 
@@ -1845,11 +1850,11 @@ private void cmdCreate(ICommandSender sender, String name) {
 
 			ItemStack stack = new ItemStack(ModBlocks.clowder_flag);
 			stack.stackTagCompound = new NBTTagCompound();
-			stack.stackTagCompound.setString("cityName", cityName.trim());
-			stack.setStackDisplayName("City Center: " + cityName.trim());
+			stack.stackTagCompound.setString("cityName", cityName);
+			stack.setStackDisplayName("City Center: " + cityName);
 			player.inventory.addItemStackToInventory(stack);
 			player.inventoryContainer.detectAndSendChanges();
-			sender.addChatMessage(new ChatComponentText(INFO + "Place the City Center to found " + cityName.trim() + ". Founding cost is charged on placement."));
+			sender.addChatMessage(new ChatComponentText(INFO + "Place the City Center to found " + cityName + ". Founding cost is charged on placement."));
 
 		} else {
 			sender.addChatMessage(new ChatComponentText(ERROR + "You are not in any faction!"));
@@ -1990,6 +1995,12 @@ private void cmdCreate(ICommandSender sender, String name) {
 			return;
 		}
 
+		if(name == null || name.trim().isEmpty()) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Claim names cannot be blank."));
+			return;
+		}
+		name = name.trim();
+
 		ITerritoryProvider flag = (ITerritoryProvider) player.worldObj.getTileEntity(meta.flagX, meta.flagY, meta.flagZ);
 
 		if(flag == null) {
@@ -1997,8 +2008,15 @@ private void cmdCreate(ICommandSender sender, String name) {
 			return;
 		}
 
+		if(flag instanceof TileEntityFlag && !ClowderTerritory.isCityNameAvailable(name, meta)) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "A city named " + name + " already exists."));
+			return;
+		}
+
 		flag.setClaimName(name);
 		((TileEntity)flag).markDirty();
+		if(flag instanceof TileEntityFlag)
+			ClowderTerritory.renameClaimsForCity(player.worldObj, meta.flagX, meta.flagY, meta.flagZ, name);
 
 		sender.addChatMessage(new ChatComponentText(INFO + "Your claim has been renamed! It might take a few moments for all chunks to assume the new name."));
 		ClowderData.getData(player.worldObj).markDirty();


### PR DESCRIPTION
### Motivation

- Prevent duplicate city names and ensure city-related claims are updated/removed consistently when cities are renamed or destroyed.
- Improve player feedback by showing the target city (and owner) in the conquerer flag placement message.
- Simplify and harden flag placement/break logic to use territory metadata and avoid stale claim entries.

### Description

- Added territory helper APIs in `ClowderTerritory`: `getCityByName(String)`, `isCityNameAvailable(String, TerritoryMeta)`, `renameClaimsForCity(World, int, int, int, String)`, and `removeClaimsForCity(World, int, int, int)` to find, validate, rename, and remove city-linked claims respectively.
- Validated and trimmed city names on claim creation and flag placement by checking `isCityNameAvailable(...)` and rejecting duplicates in `Flag.onBlockPlacedBy` and `CommandClowder.cmdClaim`, and prevented blank names in the rename command.
- When a city flag is broken, updated `Flag.breakBlock` to operate on the `TileEntityFlag` instance and call `ClowderTerritory.removeClaimsForCity(...)` to purge associated claims.
- Added `Conquerer.getTargetCityName(...)` and wired it into the conquerer placement chat message to display the city name and owner when applicable.

### Testing

- Ran a full project build with `./gradlew build` and executed the automated test suite with `./gradlew test`, and the build and automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b9c8568c883298a50d32c189810f9)