### PR TITLE
Fix city center conquest claim transfer

### DIFF
--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityConquerer.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityConquerer.java
@@ -156,7 +156,9 @@ public class TileEntityConquerer extends TileEntityMachineBase implements ITerri
 					worldObj.func_147480_a(xCoord, yCoord, zCoord, false);
 					
 				} else if(te instanceof TileEntityFlag) {
-					((TileEntityFlag)te).setOwner(owner);
+					TileEntityFlag city = (TileEntityFlag)te;
+					city.setOwner(owner);
+					city.generateClaim();
 					worldObj.func_147480_a(xCoord, yCoord, zCoord, false);
 					
 				} else if(te instanceof TileEntityConquerer) {


### PR DESCRIPTION
### Motivation
- When a conquest flag overclaims a City Center the tile entity owner was updated but the City Center's claimed chunks were not reassigned, leaving territory ownership inconsistent.

### Description
- When capturing a `TileEntityFlag` in `TileEntityConquerer.conquer()` the code now casts to `TileEntityFlag`, calls `setOwner(owner)`, and then calls `generateClaim()` to regenerate and transfer the City Center's chunks to the conquering faction.
- This matches the existing handling for `TileEntityFlagBig` where `generateClaim()` is invoked after ownership changes, ensuring territory metadata is updated.
- Change location: `src/main/java/com/hfr/tileentity/clowder/TileEntityConquerer.java` inside the `conquer()` method when handling `TileEntityFlag` instances.

### Testing
- Ran `git diff --check` to validate no whitespace errors and it passed.
- Attempted `gradle test` but the build was blocked by external environment/configuration issues and failed with ForgeGradle/proxy errors including `HTTP/1.1 403 Forbidden` and `You must set the Minecraft Version!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bd29465588329be70bf59e3ac70e0)