### PR TITLE
Add city rename GUI/packets and sync rename flow on conquest and commands

### DIFF
--- a/src/main/java/com/hfr/clowder/ClowderTerritory.java
+++ b/src/main/java/com/hfr/clowder/ClowderTerritory.java
@@ -113,8 +113,15 @@ public class ClowderTerritory {
 				renamed++;
 			}
 		}
-		if(renamed > 0 && world != null)
-			ClowderData.getData(world).markDirty();
+		if(world != null) {
+			TileEntity te = world.getTileEntity(fX, fY, fZ);
+			if(te instanceof TileEntityFlag) {
+				((TileEntityFlag)te).setClaimName(name);
+				te.markDirty();
+			}
+			if(renamed > 0)
+				ClowderData.getData(world).markDirty();
+		}
 		return renamed;
 	}
 

--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -20,7 +20,6 @@ import com.hfr.items.ModItems;
 import com.hfr.main.MainRegistry;
 import com.hfr.packet.PacketDispatcher;
 import com.hfr.packet.effect.ClowderFlagPacket;
-import com.hfr.tileentity.clowder.ITerritoryProvider;
 import com.hfr.tileentity.clowder.TileEntityFlag;
 import com.hfr.tileentity.clowder.TileEntityFlagBig;
 import com.hfr.tileentity.prop.TileEntityProp;
@@ -1763,19 +1762,19 @@ private void cmdCreate(ICommandSender sender, String name) {
 		}
 
 		if(clowder.getPermLevel(player.getDisplayName()) < 2) {
-			sender.addChatMessage(new ChatComponentText(ERROR + "You lack the permissions to rename land!"));
+			sender.addChatMessage(new ChatComponentText(ERROR + "You lack the permissions to rename cities!"));
 			return;
 		}
 
 		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords((int)player.posX, (int)player.posZ);
 
-		if(meta == null || meta.owner == null) {
-			sender.addChatMessage(new ChatComponentText(ERROR + "You are not in any claimed land!"));
+		if(meta == null || meta.owner == null || !meta.isCityClaim()) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "You are not in a city claim!"));
 			return;
 		}
 
 		if(meta.owner.owner != clowder)  {
-			sender.addChatMessage(new ChatComponentText(ERROR + "You cannot rename foreign land!"));
+			sender.addChatMessage(new ChatComponentText(ERROR + "You cannot rename a foreign city!"));
 			return;
 		}
 
@@ -1785,25 +1784,25 @@ private void cmdCreate(ICommandSender sender, String name) {
 		}
 		name = name.trim();
 
-		ITerritoryProvider flag = (ITerritoryProvider) player.worldObj.getTileEntity(meta.flagX, meta.flagY, meta.flagZ);
+		TileEntity tile = player.worldObj.getTileEntity(meta.flagX, meta.flagY, meta.flagZ);
 
-		if(flag == null) {
-			sender.addChatMessage(new ChatComponentText(ERROR + "The flag that is connected to this claim could not be found! Are the chunks unloaded?"));
+		if(!(tile instanceof TileEntityFlag)) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "The City Center that is connected to this city could not be found! Are the chunks unloaded?"));
 			return;
 		}
 
-		if(flag instanceof TileEntityFlag && !ClowderTerritory.isCityNameAvailable(name, meta)) {
+		if(!ClowderTerritory.isCityNameAvailable(name, meta)) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "A city named " + name + " already exists."));
 			return;
 		}
 
-		flag.setClaimName(name);
-		((TileEntity)flag).markDirty();
-		if(flag instanceof TileEntityFlag)
-			ClowderTerritory.renameClaimsForCity(player.worldObj, meta.flagX, meta.flagY, meta.flagZ, name);
+		int renamed = ClowderTerritory.renameClaimsForCity(player.worldObj, meta.flagX, meta.flagY, meta.flagZ, name);
+		if(renamed <= 0) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "No city claims were found for this City Center."));
+			return;
+		}
 
-		sender.addChatMessage(new ChatComponentText(INFO + "Your claim has been renamed! It might take a few moments for all chunks to assume the new name."));
-		ClowderData.getData(player.worldObj).markDirty();
+		sender.addChatMessage(new ChatComponentText(INFO + "Your city has been renamed! It might take a few moments for all chunks to assume the new name."));
 	}
 
 	private void cmdDeclareWar(ICommandSender sender, String targetName) {

--- a/src/main/java/com/hfr/inventory/gui/GUICityRename.java
+++ b/src/main/java/com/hfr/inventory/gui/GUICityRename.java
@@ -1,0 +1,90 @@
+package com.hfr.inventory.gui;
+
+import org.lwjgl.input.Keyboard;
+
+import com.hfr.packet.PacketDispatcher;
+import com.hfr.packet.client.CityRenamePacket;
+
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.GuiTextField;
+
+public class GUICityRename extends GuiScreen {
+
+	private final int x;
+	private final int y;
+	private final int z;
+	private final String currentName;
+	private GuiTextField nameField;
+
+	public GUICityRename(int x, int y, int z, String currentName) {
+		this.x = x;
+		this.y = y;
+		this.z = z;
+		this.currentName = currentName == null ? "" : currentName;
+	}
+
+	@Override
+	public void initGui() {
+		Keyboard.enableRepeatEvents(true);
+		this.buttonList.clear();
+		this.nameField = new GuiTextField(this.fontRendererObj, this.width / 2 - 100, this.height / 2 - 10, 200, 20);
+		this.nameField.setFocused(true);
+		this.nameField.setMaxStringLength(32);
+		this.nameField.setText(currentName);
+		this.buttonList.add(new GuiButton(0, this.width / 2 - 100, this.height / 2 + 20, 98, 20, "Rename"));
+		this.buttonList.add(new GuiButton(1, this.width / 2 + 2, this.height / 2 + 20, 98, 20, "Keep Name"));
+	}
+
+	@Override
+	public void onGuiClosed() {
+		Keyboard.enableRepeatEvents(false);
+	}
+
+	@Override
+	protected void actionPerformed(GuiButton button) {
+		if(button.id == 0) {
+			sendRename();
+		} else if(button.id == 1) {
+			this.mc.displayGuiScreen(null);
+		}
+	}
+
+	@Override
+	protected void keyTyped(char typedChar, int keyCode) {
+		if(keyCode == Keyboard.KEY_RETURN || keyCode == Keyboard.KEY_NUMPADENTER) {
+			sendRename();
+			return;
+		}
+		this.nameField.textboxKeyTyped(typedChar, keyCode);
+		super.keyTyped(typedChar, keyCode);
+	}
+
+	@Override
+	protected void mouseClicked(int mouseX, int mouseY, int mouseButton) {
+		super.mouseClicked(mouseX, mouseY, mouseButton);
+		this.nameField.mouseClicked(mouseX, mouseY, mouseButton);
+	}
+
+	@Override
+	public void updateScreen() {
+		super.updateScreen();
+		this.nameField.updateCursorCounter();
+	}
+
+	@Override
+	public void drawScreen(int mouseX, int mouseY, float partialTicks) {
+		this.drawDefaultBackground();
+		this.drawCenteredString(this.fontRendererObj, "Rename Captured City", this.width / 2, this.height / 2 - 42, 0xFFFFFF);
+		this.drawCenteredString(this.fontRendererObj, "Choose a new name for this City Center.", this.width / 2, this.height / 2 - 28, 0xAAAAAA);
+		this.nameField.drawTextBox();
+		super.drawScreen(mouseX, mouseY, partialTicks);
+	}
+
+	private void sendRename() {
+		String newName = this.nameField.getText() == null ? "" : this.nameField.getText().trim();
+		if(!newName.isEmpty())
+			PacketDispatcher.wrapper.sendToServer(new CityRenamePacket(x, y, z, newName));
+		this.mc.displayGuiScreen(null);
+	}
+}

--- a/src/main/java/com/hfr/packet/PacketDispatcher.java
+++ b/src/main/java/com/hfr/packet/PacketDispatcher.java
@@ -41,6 +41,8 @@ public class PacketDispatcher {
 		wrapper.registerMessage(SRadarPacket.Handler.class, SRadarPacket.class, i++, Side.CLIENT);
 		wrapper.registerMessage(AuxGaugePacket.Handler.class, AuxGaugePacket.class, i++, Side.CLIENT);
 		wrapper.registerMessage(CityCenterPacket.Handler.class, CityCenterPacket.class, i++, Side.CLIENT);
+		wrapper.registerMessage(CityRenameGuiPacket.Handler.class, CityRenameGuiPacket.class, i++, Side.CLIENT);
+		wrapper.registerMessage(CityRenamePacket.Handler.class, CityRenamePacket.class, i++, Side.SERVER);
 		wrapper.registerMessage(TESRadarPacket.Handler.class, TESRadarPacket.class, i++, Side.CLIENT);
 		wrapper.registerMessage(RailgunCallbackPacket.Handler.class, RailgunCallbackPacket.class, i++, Side.CLIENT);
 		wrapper.registerMessage(RailgunFirePacket.Handler.class, RailgunFirePacket.class, i++, Side.CLIENT);

--- a/src/main/java/com/hfr/packet/client/CityRenameGuiPacket.java
+++ b/src/main/java/com/hfr/packet/client/CityRenameGuiPacket.java
@@ -1,0 +1,55 @@
+package com.hfr.packet.client;
+
+import com.hfr.inventory.gui.GUICityRename;
+
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.Minecraft;
+
+public class CityRenameGuiPacket implements IMessage {
+
+	private int x;
+	private int y;
+	private int z;
+	private String name;
+
+	public CityRenameGuiPacket() { }
+
+	public CityRenameGuiPacket(int x, int y, int z, String name) {
+		this.x = x;
+		this.y = y;
+		this.z = z;
+		this.name = name == null ? "" : name;
+	}
+
+	@Override
+	public void fromBytes(ByteBuf buf) {
+		x = buf.readInt();
+		y = buf.readInt();
+		z = buf.readInt();
+		name = ByteBufUtils.readUTF8String(buf);
+	}
+
+	@Override
+	public void toBytes(ByteBuf buf) {
+		buf.writeInt(x);
+		buf.writeInt(y);
+		buf.writeInt(z);
+		ByteBufUtils.writeUTF8String(buf, name == null ? "" : name);
+	}
+
+	public static class Handler implements IMessageHandler<CityRenameGuiPacket, IMessage> {
+
+		@Override
+		@SideOnly(Side.CLIENT)
+		public IMessage onMessage(CityRenameGuiPacket m, MessageContext ctx) {
+			Minecraft.getMinecraft().displayGuiScreen(new GUICityRename(m.x, m.y, m.z, m.name));
+			return null;
+		}
+	}
+}

--- a/src/main/java/com/hfr/packet/client/CityRenamePacket.java
+++ b/src/main/java/com/hfr/packet/client/CityRenamePacket.java
@@ -1,0 +1,105 @@
+package com.hfr.packet.client;
+
+import com.hfr.clowder.Clowder;
+import com.hfr.clowder.ClowderTerritory;
+import com.hfr.clowder.ClowderTerritory.TerritoryMeta;
+import com.hfr.tileentity.clowder.TileEntityFlag;
+
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
+
+public class CityRenamePacket implements IMessage {
+
+	private int x;
+	private int y;
+	private int z;
+	private String name;
+
+	public CityRenamePacket() { }
+
+	public CityRenamePacket(int x, int y, int z, String name) {
+		this.x = x;
+		this.y = y;
+		this.z = z;
+		this.name = name == null ? "" : name;
+	}
+
+	@Override
+	public void fromBytes(ByteBuf buf) {
+		x = buf.readInt();
+		y = buf.readInt();
+		z = buf.readInt();
+		name = ByteBufUtils.readUTF8String(buf);
+	}
+
+	@Override
+	public void toBytes(ByteBuf buf) {
+		buf.writeInt(x);
+		buf.writeInt(y);
+		buf.writeInt(z);
+		ByteBufUtils.writeUTF8String(buf, name == null ? "" : name);
+	}
+
+	public static class Handler implements IMessageHandler<CityRenamePacket, IMessage> {
+
+		@Override
+		public IMessage onMessage(CityRenamePacket m, MessageContext ctx) {
+			EntityPlayer player = ctx.getServerHandler().playerEntity;
+			Clowder clowder = Clowder.getClowderFromPlayer(player);
+			String newName = m.name == null ? "" : m.name.trim();
+
+			if(clowder == null) {
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "You are not in any faction!"));
+				return null;
+			}
+
+			if(clowder.getPermLevel(player.getDisplayName()) < 2) {
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "You lack the permissions to rename cities!"));
+				return null;
+			}
+
+			if(newName.isEmpty()) {
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "City names cannot be blank."));
+				return null;
+			}
+
+			TileEntity tile = player.worldObj.getTileEntity(m.x, m.y, m.z);
+			if(!(tile instanceof TileEntityFlag)) {
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "The City Center could not be found."));
+				return null;
+			}
+
+			TileEntityFlag flag = (TileEntityFlag)tile;
+			if(flag.owner != clowder) {
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "You cannot rename a foreign city."));
+				return null;
+			}
+
+			TerritoryMeta meta = ClowderTerritory.getMetaFromCoords(ClowderTerritory.getCoordPair(m.x, m.z));
+			if(meta == null || !meta.isCityClaim() || meta.owner == null || meta.owner.owner != clowder) {
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "No owned city claims were found for this City Center."));
+				return null;
+			}
+
+			if(!ClowderTerritory.isCityNameAvailable(newName, meta)) {
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "A city named " + newName + " already exists."));
+				return null;
+			}
+
+			int renamed = ClowderTerritory.renameClaimsForCity(player.worldObj, m.x, m.y, m.z, newName);
+			if(renamed > 0)
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.GREEN + "City renamed to " + newName + "."));
+			else
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "No city claims were found for this City Center."));
+
+			return null;
+		}
+	}
+}

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityConquerer.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityConquerer.java
@@ -12,11 +12,14 @@ import com.hfr.clowder.ClowderTerritory.Ownership;
 import com.hfr.clowder.ClowderTerritory.TerritoryMeta;
 import com.hfr.clowder.ClowderTerritory.Zone;
 import com.hfr.main.MainRegistry;
+import com.hfr.packet.PacketDispatcher;
+import com.hfr.packet.client.CityRenameGuiPacket;
 import com.hfr.tileentity.machine.TileEntityMachineBase;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
@@ -156,7 +159,10 @@ public class TileEntityConquerer extends TileEntityMachineBase implements ITerri
 					worldObj.func_147480_a(xCoord, yCoord, zCoord, false);
 					
 				} else if(te instanceof TileEntityFlag) {
-					((TileEntityFlag)te).setOwner(owner);
+					TileEntityFlag city = (TileEntityFlag)te;
+					city.setOwner(owner);
+					city.generateClaim();
+					promptCityRename(city);
 					worldObj.func_147480_a(xCoord, yCoord, zCoord, false);
 					
 				} else if(te instanceof TileEntityConquerer) {
@@ -172,6 +178,23 @@ public class TileEntityConquerer extends TileEntityMachineBase implements ITerri
 		}
 	}
 	
+	private void promptCityRename(TileEntityFlag city) {
+		int range = 32;
+		List<EntityPlayer> entities = worldObj.getEntitiesWithinAABB(EntityPlayer.class,
+				AxisAlignedBB.getBoundingBox(
+						xCoord + 0.5 - range,
+						yCoord - 2,
+						zCoord + 0.5 - range,
+						xCoord + 0.5 + range,
+						yCoord + 4,
+						zCoord + 0.5 + range));
+
+		for(EntityPlayer player : entities) {
+			if(player instanceof EntityPlayerMP && Clowder.getClowderFromPlayer(player) == owner && owner.getPermLevel(player.getDisplayName()) >= 2)
+				PacketDispatcher.wrapper.sendTo(new CityRenameGuiPacket(city.xCoord, city.yCoord, city.zCoord, city.name), (EntityPlayerMP)player);
+		}
+	}
+
 	public boolean checkBorder(int x, int z) {
 
 		CoordPair loc = ClowderTerritory.getCoordPair(x, z);


### PR DESCRIPTION
### Motivation

- Provide a player-facing way to rename cities when they are conquered or via command and ensure territory metadata and tile entities stay synchronized.
- Prompt eligible nearby faction members after a conquest so they can immediately choose a name for the new city.

### Description

- Added a client GUI `GUICityRename` to enter a new city name and send it to the server via `CityRenamePacket`.
- Added `CityRenameGuiPacket` (client) and `CityRenamePacket` (server) handlers and registered both packets in `PacketDispatcher`.
- Implemented server-side validation in `CityRenamePacket` for faction membership, permission level, ownership, non-empty name, and uniqueness using `ClowderTerritory.isCityNameAvailable`, and called `ClowderTerritory.renameClaimsForCity` to perform the rename.
- Updated `ClowderTerritory.renameClaimsForCity` to update the `TileEntityFlag` (`setClaimName`), mark the tile entity dirty, and mark `ClowderData` dirty only when claims were actually renamed.
- Modified `CommandClowder` to enforce city-specific rename rules, adjust messages, and use the `renameClaimsForCity` flow instead of directly mutating tile entities.
- Modified `TileEntityConquerer` to call `generateClaim()` on captured `TileEntityFlag`, and to prompt nearby eligible faction members (permission level >= 2) by sending them a `CityRenameGuiPacket` so they can rename the new city immediately.

### Testing

- Ran an automated project build with `./gradlew build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bd29465588329be70bf59e3ac70e0)