### PR TITLE
Rebalance prestige economy, war costs, and bankruptcy mechanics

### DIFF
--- a/src/main/java/com/hfr/blocks/clowder/Conquerer.java
+++ b/src/main/java/com/hfr/blocks/clowder/Conquerer.java
@@ -92,7 +92,7 @@ public class Conquerer extends BlockContainer {
 
 			if (clowder != null && flag.checkBorder(x, z) && flag.canSeeSky() && noProximity(world, x, y, z)) {
 
-				flag.owner.addPrestigeReq(0.2F, world);
+				flag.owner.addPrestigeReq(Clowder.flagReq, world);
 				flag.markDirty();
 				MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(
 						EnumChatFormatting.RED + "[WAR] " + EnumChatFormatting.GOLD + clowder.name +
@@ -168,7 +168,7 @@ public class Conquerer extends BlockContainer {
     {
 		TileEntityConquerer flag = (TileEntityConquerer)world.getTileEntity(x, y, z);
 		if(flag != null && flag.owner != null) {
-			flag.owner.addPrestigeReq(-0.2F, world);
+			flag.owner.addPrestigeReq(-Clowder.flagReq, world);
 		}
 		
 		super.breakBlock(world, x, y, z, b, i);

--- a/src/main/java/com/hfr/blocks/machine/MachineTemple.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineTemple.java
@@ -2,6 +2,10 @@ package com.hfr.blocks.machine;
 
 import com.hfr.blocks.BlockDummyable;
 import com.hfr.blocks.ModBlocks;
+import com.hfr.clowder.Clowder;
+import com.hfr.clowder.ClowderTerritory;
+import com.hfr.clowder.ClowderTerritory.Ownership;
+import com.hfr.clowder.ClowderTerritory.Zone;
 import com.hfr.main.MainRegistry;
 import com.hfr.tileentity.machine.TileEntityMachineTemple;
 
@@ -9,6 +13,7 @@ import cpw.mods.fml.common.network.internal.FMLNetworkHandler;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.block.Block;
 import net.minecraft.world.World;
 
 public class MachineTemple extends BlockDummyable {
@@ -38,6 +43,20 @@ public class MachineTemple extends BlockDummyable {
 		return 6;
 	}
 	
+	@Override
+	public void breakBlock(World world, int x, int y, int z, Block block, int meta) {
+		if(meta >= 12) {
+			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			TileEntity entity = world.getTileEntity(x, y, z);
+			if(owner != null && owner.zone == Zone.FACTION && entity instanceof TileEntityMachineTemple) {
+				TileEntityMachineTemple temple = (TileEntityMachineTemple)entity;
+				if(temple.owner != null)
+					temple.owner.addPrestigeGen(-Clowder.TempleRate, world);
+			}
+		}
+		super.breakBlock(world, x, y, z, block, meta);
+	}
+
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float hitX, float hitY, float hitZ) {
 		if(world.isRemote)

--- a/src/main/java/com/hfr/blocks/props/PropTent.java
+++ b/src/main/java/com/hfr/blocks/props/PropTent.java
@@ -48,6 +48,7 @@ public class PropTent extends BlockDummyable {
 			
 			if(owner != null && owner.zone == Zone.FACTION) {
 
+				float prestigeRate = this == ModBlocks.med_tent ? Clowder.medTentRate : Clowder.tentRate;
 				TileEntityProp tent = (TileEntityProp)world.getTileEntity(x, y, z);
 				
 				if(this == ModBlocks.tp_tent) {
@@ -58,8 +59,8 @@ public class PropTent extends BlockDummyable {
 					}
 				}
 				
-				if(tent.operational())
-					owner.owner.addPrestigeGen(-Clowder.tentRate, world);
+				if(tent != null && tent.operational())
+					owner.owner.addPrestigeGen(-prestigeRate, world);
 			}
 		}
 		

--- a/src/main/java/com/hfr/clowder/CityLevel.java
+++ b/src/main/java/com/hfr/clowder/CityLevel.java
@@ -1,11 +1,11 @@
 package com.hfr.clowder;
 
 public enum CityLevel {
-	SETTLEMENT("Settlement", 2, 1F, 0.05F),
-	TOWN("Town", 3, 2F, 0.10F),
-	CITY("City", 4, 4F, 0.20F),
-	METROPOLIS("Metropolis", 5, 7F, 0.35F),
-	CAPITAL("Capital", 6, 11F, 0.50F);
+	SETTLEMENT("Settlement", 2, 75F, 10F),
+	TOWN("Town", 3, 150F, 25F),
+	CITY("City", 4, 300F, 50F),
+	METROPOLIS("Metropolis", 5, 600F, 90F),
+	CAPITAL("Capital", 6, 1000F, 140F);
 
 	public final String displayName;
 	public final int radius;

--- a/src/main/java/com/hfr/clowder/Clowder.java
+++ b/src/main/java/com/hfr/clowder/Clowder.java
@@ -35,8 +35,8 @@ public class Clowder {
 
 	public static HashSet<Integer> colours = new HashSet<Integer>();
 
-	private static float prestigeCap = 1000F;
-	private static float prestigeGenCap = 500F;
+	private static float prestigeCap = 10000F;
+	private static float prestigeGenCap = 2500F;
 
 	public String uuid;
 	public String name;
@@ -150,6 +150,9 @@ public class Clowder {
 	public int allyWarpZ;
 	public long buildGraceUntil = 0L;
 	public boolean buildGraceUsed = false;
+	public String surrenderTributeTo = "";
+	public long surrenderTributeUntil = 0L;
+	private int lastBankruptcyStage = 0;
 
 	public static List<Clowder> clowders = new ArrayList();
 	public static HashMap<String, Clowder> inverseMap = new HashMap();
@@ -166,14 +169,25 @@ public class Clowder {
 	private float canDeclareTime = 0;
 	private float warTime = 0;
 
-	public static final float tentRate = -0.8F;
-	public static final float BlastRate = 0.3F;
-	public static final float GrainRate = 0.2F;
-	public static final float UniRate = 0.6F;
-	public static final float FedRate = 0.2F;
-	public static final float statueRate = 0.5F;
-	public static final float flagRate = 0.1F;
-	public static final float flagReq = 1.0F;
+	public static final float STARTING_PRESTIGE = 250F;
+	public static final float BASE_PRESTIGE_GEN = 25F;
+	public static final float WAR_DECLARATION_COST = 150F;
+	public static final float WAR_UPKEEP = 75F;
+	public static final float SURRENDER_TRIBUTE_RATE = 0.50F;
+	public static final long SURRENDER_TRIBUTE_TIME = 84L * 60L * 60L * 1000L;
+	public static final float FINANCIAL_CRISIS_UPKEEP_MULT = 1.25F;
+	public static final float NATIONAL_COLLAPSE_UPKEEP_MULT = 1.50F;
+	public static final float FALLEN_NATION_UPKEEP_MULT = 2.00F;
+	public static final float tentRate = -20F;
+	public static final float medTentRate = 10F;
+	public static final float BlastRate = 20F;
+	public static final float GrainRate = 15F;
+	public static final float UniRate = 60F;
+	public static final float FedRate = 30F;
+	public static final float TempleRate = 90F;
+	public static final float statueRate = 40F;
+	public static final float flagRate = 0F;
+	public static final float flagReq = 10F;
 
 	//this mod is so fucking retarded I guarantee you theres like 16 different ways this shit can be exploited
 	//or is just SHIT coding. and that's coming from a MCHELI developer.
@@ -1288,12 +1302,7 @@ public class Clowder {
 
 	public void addPrestige(float f, World world) {
 
-
-			prestige += f;
-
-			if (prestige < 0)
-				prestige = 0F;
-
+		prestige += f;
 		prestige = Math.min(prestige, prestigeCap);
 		this.save(world);
 	}
@@ -1321,11 +1330,127 @@ public class Clowder {
 		prestige *= f;
 		prestige = (float)(Math.floor(prestige * 10D) / 10D);
 
-		if(prestige < 0)
-			prestige = 0;
-
 		this.save(world);
 	}
+
+	public int getBankruptcyStage() {
+		if(prestige < -1000F)
+			return 3;
+		if(prestige < -500F)
+			return 2;
+		if(prestige < 0F)
+			return 1;
+		return 0;
+	}
+
+	public String getBankruptcyStageName() {
+		switch(getBankruptcyStage()) {
+		case 3: return "Fallen Nation";
+		case 2: return "National Collapse";
+		case 1: return "Financial Crisis";
+		default: return "Stable Nation";
+		}
+	}
+
+	public boolean isInFinancialCrisis() {
+		return getBankruptcyStage() >= 1;
+	}
+
+	public boolean areWarpsDisabled() {
+		return getBankruptcyStage() >= 2;
+	}
+
+	public boolean areAllyWarpsDisabled() {
+		return getBankruptcyStage() >= 1;
+	}
+
+	public boolean isInfrastructureDisabled() {
+		return getBankruptcyStage() >= 3;
+	}
+
+	public float getUpkeepMultiplier() {
+		switch(getBankruptcyStage()) {
+		case 3: return FALLEN_NATION_UPKEEP_MULT;
+		case 2: return NATIONAL_COLLAPSE_UPKEEP_MULT;
+		case 1: return FINANCIAL_CRISIS_UPKEEP_MULT;
+		default: return 1F;
+		}
+	}
+
+	public float getHourlyWarCost() {
+		return activeWars.size() * WAR_UPKEEP;
+	}
+
+	public float getHourlyUpkeepCost() {
+		return prestigeReq * getUpkeepMultiplier();
+	}
+
+	public float getHourlyNetPrestige() {
+		float effectiveGeneration = isInfrastructureDisabled() ? 0F : prestigeGen;
+		return effectiveGeneration - getHourlyUpkeepCost() - getHourlyWarCost();
+	}
+
+	public void beginSurrenderTribute(Clowder winner, World world) {
+		if(winner == null)
+			return;
+		surrenderTributeTo = winner.name;
+		surrenderTributeUntil = System.currentTimeMillis() + SURRENDER_TRIBUTE_TIME;
+		save(world);
+	}
+
+	public Clowder getSurrenderTributeTarget() {
+		if(surrenderTributeTo == null || surrenderTributeTo.isEmpty() || surrenderTributeUntil <= System.currentTimeMillis())
+			return null;
+		return getClowderFromName(surrenderTributeTo);
+	}
+
+	private void notifyBankruptcyStage(World world, int oldStage, int newStage) {
+		if(oldStage == newStage)
+			return;
+
+		String status = getBankruptcyStageName();
+		notifyAll(world, new ChatComponentText(CommandClowder.CRITICAL + "Prestige status changed to " + status + " (" + round(prestige) + " prestige)."));
+
+		if(newStage >= 1)
+			notifyAll(world, new ChatComponentText(CommandClowder.ERROR + "Financial Crisis: ally warps are disabled and upkeep costs are increased."));
+		if(newStage >= 2)
+			MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(EnumChatFormatting.DARK_RED + "[PRESTIGE] " + name + " has entered National Collapse. Warps are disabled."));
+		if(newStage >= 3)
+			MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(EnumChatFormatting.DARK_RED + "[PRESTIGE] " + name + " has become a Fallen Nation. Infrastructure and claim building are disabled."));
+	}
+
+	public void updatePrestigeEconomy(World world) {
+		int oldStage = lastBankruptcyStage;
+		float net = getHourlyNetPrestige();
+		Clowder tributeTarget = getSurrenderTributeTarget();
+
+		if(tributeTarget != null) {
+			float tribute = Math.max(0F, isInfrastructureDisabled() ? 0F : prestigeGen) * SURRENDER_TRIBUTE_RATE;
+			net -= tribute;
+			tributeTarget.addPrestige(tribute, world);
+		} else if(surrenderTributeUntil > 0L && surrenderTributeUntil <= System.currentTimeMillis()) {
+			surrenderTributeTo = "";
+			surrenderTributeUntil = 0L;
+		}
+
+		addPrestige(net, world);
+		lastBankruptcyStage = getBankruptcyStage();
+		notifyBankruptcyStage(world, oldStage, lastBankruptcyStage);
+
+		if(lastBankruptcyStage == 1)
+			notifyAll(world, new ChatComponentText(CommandClowder.ERROR + "Prestige warning: net prestige is " + round(getHourlyNetPrestige()) + "/h. Reduce upkeep or end wars before collapse."));
+	}
+
+	public void clearWarStateWith(Clowder target) {
+		if(target == null)
+			return;
+		activeWars.remove(target.name);
+		warDeclaredAt.remove(target.name);
+		peaceRequests.remove(target.name);
+		ceasefireRequests.remove(target.name);
+		surrenderRequests.remove(target.name);
+	}
+
 
 	//war time goes to 10 for retreat bonus level
 	public boolean isBuildGraceActive() {
@@ -1413,6 +1538,9 @@ public class Clowder {
 		nbt.setLong(i + "_belowOnlineSince", this.belowOnlineThresholdSince);
 		nbt.setLong(i + "_buildGraceUntil", this.buildGraceUntil);
 		nbt.setBoolean(i + "_buildGraceUsed", this.buildGraceUsed);
+		nbt.setString(i + "_surrenderTributeTo", this.surrenderTributeTo == null ? "" : this.surrenderTributeTo);
+		nbt.setLong(i + "_surrenderTributeUntil", this.surrenderTributeUntil);
+		nbt.setInteger(i + "_lastBankruptcyStage", this.lastBankruptcyStage);
 
 		///poorly coded "treaty" system///
 		//nbt.setString(i + "_treaty1", this.treaty1);
@@ -1510,11 +1638,11 @@ public class Clowder {
 		c.allyWarpX = nbt.getInteger(i + "_allyWarpX");
 		c.allyWarpY = nbt.getInteger(i + "_allyWarpY");
 		c.allyWarpZ = nbt.getInteger(i + "_allyWarpZ");
-		c.prestige = Math.max(nbt.getFloat(i + "_prestige"), 1F);
+		c.prestige = nbt.getFloat(i + "_prestige");
 		c.canDeclareTime = Math.max(nbt.getFloat(i + "_canDeclareTime"), 0F);
 		c.fabricateTime = Math.max(nbt.getFloat(i + "_fabricateTime"), 0F);
 		c.warTime = Math.max(nbt.getFloat(i + "_warTime"), 0F);
-		c.prestigeGen = Math.max(nbt.getFloat(i + "_prestigeGen"), 0F);
+		c.prestigeGen = nbt.getFloat(i + "_prestigeGen");
 		c.prestigeReq = Math.max(nbt.getFloat(i + "_prestigeReq"), 0F);
 		//c.peaceTreaty = Math.max(nbt.getFloat(i + "_peaceTreaty"), 0F);
 		c.flags = nbt.getInteger(i + "_flags");
@@ -1579,6 +1707,9 @@ public class Clowder {
 		c.belowOnlineThresholdSince = nbt.getLong(i + "_belowOnlineSince");
 		c.buildGraceUntil = nbt.getLong(i + "_buildGraceUntil");
 		c.buildGraceUsed = nbt.getBoolean(i + "_buildGraceUsed");
+		c.surrenderTributeTo = nbt.getString(i + "_surrenderTributeTo");
+		c.surrenderTributeUntil = nbt.getLong(i + "_surrenderTributeUntil");
+		c.lastBankruptcyStage = nbt.hasKey(i + "_lastBankruptcyStage") ? nbt.getInteger(i + "_lastBankruptcyStage") : c.getBankruptcyStage();
 
 		for (int j = 0; j < count; j++)
 			c.members.put(nbt.getString(i + "_" + j), time());
@@ -1786,8 +1917,8 @@ public class Clowder {
 		c.motd = "Message of the day!";
 		c.flag = ClowderFlag.TRICOLOR;
 
-		c.prestige = 25;
-		c.addPrestigeGen(3, player.worldObj);
+		c.prestige = STARTING_PRESTIGE;
+		c.addPrestigeGen(BASE_PRESTIGE_GEN, player.worldObj);
 
 		clowders.add(c);
 		inverseMap.put(leader, c);
@@ -1802,7 +1933,7 @@ public class Clowder {
 		for (Clowder clowder : clowders) {
 			if (clowder.valid()) {
 				//if (clowder.getPrestigeGen() > 0 && clowder.getPrestige() < clowder.getPrestigeReq()) {
-				clowder.addPrestige(clowder.getPrestigeGen(), world);
+				clowder.updatePrestigeEconomy(world);
 				//}
 				// ... prestige math ...
 			}

--- a/src/main/java/com/hfr/clowder/ClowderEvents.java
+++ b/src/main/java/com/hfr/clowder/ClowderEvents.java
@@ -374,12 +374,20 @@ public void handleChatServer(ServerChatEvent event) {
 		if(player.inventory.hasItem(ModItems.debug))
 			return true;
 
+		if(owner == null)
+			return true;
+
 		if(owner.zone == Zone.SAFEZONE || owner.zone == Zone.WARZONE)
 			return false;
 
 
 		if(owner.zone == Zone.FACTION) {
-			
+
+			if(clowder == owner.owner && owner.owner.isInfrastructureDisabled()) {
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Your faction is a Fallen Nation; breaking blocks in claimed land is disabled."));
+				return false;
+			}
+
 			if(clowder != owner.owner) {
 				if(clowder != null && !clowder.isRaidable())
 					return false;
@@ -422,15 +430,23 @@ public void handleChatServer(ServerChatEvent event) {
 		if(player.inventory.hasItem(ModItems.debug))
 			return true;
 
+		if(owner == null)
+			return true;
+
 		if(owner.zone == Zone.SAFEZONE || owner.zone == Zone.WARZONE)
 			return false;
 		
 		if(owner.zone == Zone.FACTION) {
-			
+
+			if(clowder == owner.owner && owner.owner.isInfrastructureDisabled()) {
+				player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Your faction is a Fallen Nation; placing blocks in claimed land is disabled."));
+				return false;
+			}
+
 			if(ItemMace.placeOverride.contains(b))
 				return true;
 			
-			if(clowder != owner.owner && !clowder.isRaidable())
+			if(clowder != owner.owner && (clowder == null || !clowder.isRaidable()))
 				return false;
 
 			if (player.worldObj.getBlock(x, y, z) != ModBlocks.clowder_flag) {
@@ -563,7 +579,13 @@ public void handleChatServer(ServerChatEvent event) {
 		
 		if(player.inventory.hasItem(ModItems.debug))
 			return true;
-		
+
+		if(owner == null)
+			return true;
+
+		if(owner.zone == Zone.FACTION && clowder == owner.owner && owner.owner.isInfrastructureDisabled())
+			return false;
+
 		if(owner.zone == Zone.FACTION && clowder != owner.owner) {
 			
 			if(clowder == null || !clowder.isRaidable() || !owner.owner.isRaidable())

--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -1227,6 +1227,11 @@ private void cmdCreate(ICommandSender sender, String name) {
 
 		if(clowder != null) {
 
+			if(clowder.areWarpsDisabled()) {
+				sender.addChatMessage(new ChatComponentText(ERROR + "Warps are disabled while your faction is in " + clowder.getBankruptcyStageName() + "."));
+				return;
+			}
+
 			Ownership owner = ClowderTerritory.getOwnerFromInts((int)player.posX, (int)player.posZ);
 
 			if(owner != null && (owner.zone == Zone.WARZONE || (owner.zone == Zone.FACTION && (owner.owner != clowder && clowder.allies.get(owner.owner) == null) ) ) ) { //allow warp from allied territory
@@ -1251,7 +1256,15 @@ private void cmdCreate(ICommandSender sender, String name) {
 		Clowder ally = Clowder.getClowderFromName(name);
 
 		if (clowder != null) {
+			if(clowder.areAllyWarpsDisabled()) {
+				sender.addChatMessage(new ChatComponentText(ERROR + "Ally warps are disabled while your faction is in " + clowder.getBankruptcyStageName() + "."));
+				return;
+			}
 			if (ally != null) {
+				if(ally.areAllyWarpsDisabled()) {
+					sender.addChatMessage(new ChatComponentText(ERROR + ally.name + " cannot receive ally warps while in " + ally.getBankruptcyStageName() + "."));
+					return;
+				}
 
 				Ownership owner = ClowderTerritory.getOwnerFromInts((int) player.posX, (int) player.posZ);
 
@@ -1299,6 +1312,11 @@ private void cmdCreate(ICommandSender sender, String name) {
 		Clowder clowder = Clowder.getClowderFromPlayer(player);
 
 		if(clowder != null) {
+
+			if(clowder.areWarpsDisabled()) {
+				sender.addChatMessage(new ChatComponentText(ERROR + "Warps are disabled while your faction is in " + clowder.getBankruptcyStageName() + "."));
+				return;
+			}
 
 			if(clowder.warps.containsKey(name)) {
 				sender.addChatMessage(new ChatComponentText(ERROR + "This warp already exists!"));
@@ -1353,6 +1371,11 @@ private void cmdCreate(ICommandSender sender, String name) {
 		Clowder clowder = Clowder.getClowderFromPlayer(player);
 
 		if (clowder != null) {
+
+			if(clowder.areWarpsDisabled()) {
+				sender.addChatMessage(new ChatComponentText(ERROR + "Warps are disabled while your faction is in " + clowder.getBankruptcyStageName() + "."));
+				return;
+			}
 
 			if (clowder.warps.containsKey(name)) {
 
@@ -1448,10 +1471,9 @@ private void cmdCreate(ICommandSender sender, String name) {
 
 		if(clowder != null) {
 
-			if(clowder.getPrestige() > 0)
-				sender.addChatMessage(new ChatComponentText(INFO + "Current prestige balance: " + LIST + clowder.getPrestige()));
-			else
-				sender.addChatMessage(new ChatComponentText(INFO + "It seems like you're bankrupt."));
+			sender.addChatMessage(new ChatComponentText(INFO + "Current prestige balance: " + LIST + Clowder.round(clowder.getPrestige()) + TITLE + " (" + clowder.getBankruptcyStageName() + ")"));
+			sender.addChatMessage(new ChatComponentText(INFO + "Generation: " + LIST + Clowder.round(clowder.getPrestigeGen()) + "/h" + TITLE + ", upkeep: " + LIST + Clowder.round(clowder.getHourlyUpkeepCost()) + "/h" + TITLE + ", war: " + LIST + Clowder.round(clowder.getHourlyWarCost()) + "/h"));
+			sender.addChatMessage(new ChatComponentText(INFO + "Net prestige: " + LIST + Clowder.round(clowder.getHourlyNetPrestige()) + "/h"));
 
 		} else {
 			sender.addChatMessage(new ChatComponentText(ERROR + "You are not in any faction!"));
@@ -1830,6 +1852,12 @@ private void cmdCreate(ICommandSender sender, String name) {
 			Long allyCd = me.formerAllyNoWarUntil.get(target.name);
 			if (allyCd != null && allyCd > now) return;
 		}
+		if(me.isInfrastructureDisabled()) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Fallen Nations cannot declare war."));
+			return;
+		}
+		me.addPrestige(-Clowder.WAR_DECLARATION_COST, player.worldObj);
+		sender.addChatMessage(new ChatComponentText(CRITICAL + "Declaring war cost " + Clowder.WAR_DECLARATION_COST + " prestige. Each active war costs " + Clowder.WAR_UPKEEP + " prestige per hour."));
 		me.activeWars.add(target.name);
 		target.activeWars.add(me.name);
 		me.warDeclaredAt.put(target.name, now);
@@ -1887,7 +1915,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 				target.peaceRequests.remove(request);
 			}
 		}
-		me.activeWars.remove(target.name); target.activeWars.remove(me.name);
+		me.clearWarStateWith(target); target.clearWarStateWith(me);
 		if(!CommandClowderAdmin.WAR_COOLDOWNS_DISABLED) {
 			long until = System.currentTimeMillis() + 84L * 60L * 60L * 1000L;
 			me.noWarUntil.put(target.name, until); target.noWarUntil.put(me.name, until);
@@ -1918,7 +1946,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 		if (me == null || target == null || me == target || me.getPermLevel(player.getDisplayName()) < 3) return;
 		if(!target.ceasefireRequests.contains(me.name)) return;
 		target.ceasefireRequests.remove(me.name);
-		me.activeWars.remove(target.name); target.activeWars.remove(me.name);
+		me.clearWarStateWith(target); target.clearWarStateWith(me);
 		if(!CommandClowderAdmin.WAR_COOLDOWNS_DISABLED) {
 			long until = System.currentTimeMillis() + 24L * 60L * 60L * 1000L;
 			me.noWarUntil.put(target.name, until); target.noWarUntil.put(me.name, until);
@@ -1952,12 +1980,13 @@ private void cmdCreate(ICommandSender sender, String name) {
 			TerritoryMeta city = (TerritoryMeta)cityObj;
 			ClowderTerritory.transferCity(player.worldObj, city, me);
 		}
-		me.activeWars.remove(target.name); target.activeWars.remove(me.name);
+		target.beginSurrenderTribute(me, player.worldObj);
+		me.clearWarStateWith(target); target.clearWarStateWith(me);
 		if(!CommandClowderAdmin.WAR_COOLDOWNS_DISABLED) {
 			long until = System.currentTimeMillis() + 84L * 60L * 60L * 1000L;
 			me.noWarUntil.put(target.name, until); target.noWarUntil.put(me.name, until);
 		}
-		MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(EnumChatFormatting.GREEN + "[WAR] " + me.name + " accepted " + target.name + "'s surrender."));
+		MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(EnumChatFormatting.GREEN + "[WAR] " + me.name + " accepted " + target.name + "'s surrender. " + target.name + " will pay 50% of prestige generation to " + me.name + " for 84 hours."));
 	}
 
 	private void cmdDefendAlly(ICommandSender sender, String allyName) {
@@ -1971,8 +2000,12 @@ private void cmdCreate(ICommandSender sender, String name) {
 		for (String enemyName : ally.activeWars) {
 			if (!enemyName.equals(me.name)) {
 				me.activeWars.add(enemyName);
+				me.warDeclaredAt.put(enemyName, System.currentTimeMillis());
 				Clowder enemy = Clowder.getClowderFromName(enemyName);
-				if (enemy != null) enemy.activeWars.add(me.name);
+				if (enemy != null) {
+					enemy.activeWars.add(me.name);
+					enemy.warDeclaredAt.put(me.name, System.currentTimeMillis());
+				}
 				joined++;
 			}
 		}

--- a/src/main/java/com/hfr/items/ItemBlockLore.java
+++ b/src/main/java/com/hfr/items/ItemBlockLore.java
@@ -95,6 +95,10 @@ public class ItemBlockLore extends ItemBlock {
 			list.add("Smelts iron ingots and ore into steel");
 			list.add(Clowder.BlastRate + " prestige gen / hour");
 		}
+		if(field_150939_a == ModBlocks.machine_temple) {
+			list.add("Generates scrolls over time");
+			list.add(Clowder.TempleRate + " prestige gen / hour");
+		}
 		if(field_150939_a == ModBlocks.machine_coalmine) {
 			list.add("Requires sky access and foundation");
 			list.add("Uses miners and supplies to generate coal");
@@ -126,7 +130,7 @@ public class ItemBlockLore extends ItemBlock {
 		if(field_150939_a == ModBlocks.med_tent) {
 			list.add("Requires sky access and foundation");
 			list.add("Generates healing aura");
-			list.add("+0.1 prestige gen / hour");
+			list.add(Clowder.medTentRate + " prestige gen / hour");
 		}
 		if(field_150939_a == ModBlocks.tp_tent) {
 			list.add("Requires sky access and foundation");

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -211,7 +211,7 @@ public class MainRegistry
 	public static boolean enableStocks = true;
 	public static boolean enableRadar = false;
 
-	public static int warpCost = 25;
+	public static int warpCost = 125;
 	public static int territoryDelay = 5;
 	public static int territoryAmount = 50;
 	public static int prestigeDelay = 60 * 60 * 20;
@@ -1478,7 +1478,7 @@ public class MainRegistry
     	EnumHelper.addEnum(ClowderFlag.class, "GETTY", new Class[] { String.class, boolean.class }, new Object[] {"getty", false} );
     	EnumHelper.addEnum(ClowderFlag.class, "COMRADES", new Class[] { String.class, boolean.class }, new Object[] {"comrades", false} );
 
-        warpCost = createConfigInt(config, "CLOWDER", "warpCost", "How much prestige a warp point costs to create", 25);
+        warpCost = createConfigInt(config, "CLOWDER", "warpCost", "How much prestige a warp point costs to create", 125);
         territoryDelay = createConfigInt(config, "CLOWDER", "territoryDelay", "How many ticks inbetween territory validation operations", 5);
         territoryAmount = createConfigInt(config, "CLOWDER", "territoryAmount", "How many chunks are checked each operation", 50);
         prestigeDelay = createConfigInt(config, "CLOWDER", "prestigeDelay", "How many ticks inbetween prestige updates (1h per default)", 60 * 60 * 20);

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineTemple.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineTemple.java
@@ -1,11 +1,18 @@
 package com.hfr.tileentity.machine;
 
+import com.hfr.clowder.Clowder;
+import com.hfr.clowder.ClowderTerritory;
+import com.hfr.clowder.ClowderTerritory.Ownership;
+import com.hfr.clowder.ClowderTerritory.Zone;
 import com.hfr.items.ModItems;
 import com.hfr.main.MainRegistry;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 
 public class TileEntityMachineTemple extends TileEntityMachineBase {
+
+	public Clowder owner = null;
 
 	public TileEntityMachineTemple() {
 		super(1);
@@ -21,6 +28,21 @@ public class TileEntityMachineTemple extends TileEntityMachineBase {
 		
 		if(!worldObj.isRemote) {
 
+			Ownership o = ClowderTerritory.getOwnerFromInts(xCoord, zCoord);
+			if(o != null && o.zone == Zone.FACTION) {
+				if(owner != o.owner) {
+					if(owner != null)
+						owner.addPrestigeGen(-Clowder.TempleRate, worldObj);
+					owner = o.owner;
+					owner.addPrestigeGen(Clowder.TempleRate, worldObj);
+					this.markDirty();
+				}
+			} else if(owner != null) {
+				owner.addPrestigeGen(-Clowder.TempleRate, worldObj);
+				owner = null;
+				this.markDirty();
+			}
+
 			if(worldObj.rand.nextInt(MainRegistry.temple * 20) == 0) {
 				
 				if(slots[0] == null) {
@@ -33,4 +55,16 @@ public class TileEntityMachineTemple extends TileEntityMachineBase {
 		}
 	}
 
+	@Override
+	public void readFromNBT(NBTTagCompound nbt) {
+		super.readFromNBT(nbt);
+		owner = Clowder.getClowderFromName(nbt.getString("owner"));
+	}
+
+	@Override
+	public void writeToNBT(NBTTagCompound nbt) {
+		super.writeToNBT(nbt);
+		if(owner != null)
+			nbt.setString("owner", owner.name);
+	}
 }

--- a/src/main/java/com/hfr/tileentity/prop/TileEntityProp.java
+++ b/src/main/java/com/hfr/tileentity/prop/TileEntityProp.java
@@ -92,37 +92,30 @@ public class TileEntityProp extends TileEntity {
 			//FOR TENTS RETARD
 			if(this.getBlockType() == ModBlocks.tp_tent || this.getBlockType() == ModBlocks.med_tent) {
 				
+				float prestigeRate = this.getBlockType() == ModBlocks.med_tent ? Clowder.medTentRate : Clowder.tentRate;
+
 				if(this.operational()) {
-					
-					if(owner != o.owner) {
-						
+
+					Clowder currentOwner = o != null && o.zone == Zone.FACTION ? o.owner : null;
+					if(owner != currentOwner) {
+
 						if(owner != null) {
-							
 							//doesn't need a call of the save method because it will always save in the statements below
 							owner.warps.remove(warp);
 							warp = "";
+							owner.addPrestigeGen(-prestigeRate, worldObj);
 						}
-						
-						if(o != null && o.zone == Zone.FACTION) {
-							if(owner != null)
-								owner.addPrestigeGen(-Clowder.tentRate, worldObj);
-							owner = o.owner;
-							owner.addPrestigeGen(Clowder.tentRate, worldObj);
-							
-						} else {
-							
-							if(owner != null)
-								owner.addPrestigeGen(-Clowder.tentRate, worldObj);
-							
-							owner = null;
-						}
-						
+
+						owner = currentOwner;
+						if(owner != null)
+							owner.addPrestigeGen(prestigeRate, worldObj);
+
 						this.markDirty();
 					}
 				} else {
 					
 					if(owner != null) {
-						owner.addPrestigeGen(-Clowder.tentRate, worldObj);
+						owner.addPrestigeGen(-prestigeRate, worldObj);
 						owner = null;
 						
 						this.markDirty();


### PR DESCRIPTION
### Motivation
- Make prestige a meaningful, game-defining resource so wars are costly and long drawn-out conflicts are discouraged.
- Provide clear negative consequences for poor prestige management via multi-stage bankruptcy thresholds and temporary surrender tributes.
- Rebalance building generation/upkeep and city upgrade costs to operate at the new prestige scale.

### Description
- Centralized and increased prestige constants and caps, added starting prestige and base generation, war declaration cost, hourly war upkeep, surrender tribute parameters, and bankruptcy multipliers in `Clowder` (prestige math and economy moved into new helpers such as `getHourlyNetPrestige`, `updatePrestigeEconomy`, and bankruptcy stage helpers). 
- Implemented staged bankruptcy consequences (Financial Crisis, National Collapse, Fallen Nation) that affect ally/warp availability, upkeep multipliers, public notifications, and disable infrastructure/claim build in `Clowder` and enforced in `ClowderEvents` and command checks. 
- Made surrender acceptance start an 84-hour 50%-generation tribute from loser to winner and wire tribute flow into the hourly prestige update path. 
- Added war declaration prestige cost and per-war upkeep and surfaced those costs to leaders when declaring war via `CommandClowder`. 
- Rebalanced building prestige rates and city tier costs/upkeep: updated `CityLevel` tier costs/upkeep, increased `warpCost` default in `MainRegistry`, made temples generate prestige and persist ownership in `TileEntityMachineTemple`, and separated tent behaviour so medical tents generate prestige while warp tents consume it (prop/tent handling in `TileEntityProp`/`PropTent`). 
- Updated claim/flag upkeep to use shared `flagReq`, adjusted flag placement/break handling in `Conquerer`, and updated in-game lore in `ItemBlockLore`. 
- Minor safety/guard changes: checks preventing Fallen Nations from declaring wars or performing build/break actions in claimed land, ally-warp/warp creation blocked when the faction is in a disallowed bankruptcy stage, and clearer `/c balance` output including stage, generation, upkeep, war cost, and net prestige. 

### Testing
- Ran `git diff --check` to validate whitespace and basic diffs (no blocking warnings remain after cleanup). (succeeded)
- Performed a local syntax smoke-check with `javac -proc:none -source 8 -target 8 ...` to surface obvious Java errors; this produced many symbol errors because the project depends on Minecraft/Forge classes that are not available in this environment, so the failures are expected and not changes-related. (syntax-smoke produced expected Minecraft/Forge dependency errors)
- Attempted `gradle --offline compileJava` to compile with project build tooling, but the build cannot complete in this environment due to ForgeGradle/Minecraft version metadata and proxy-related resolution issues; this prevented a full compile/test run here. (blocked by environment/ForgeGradle and Minecraft version resolution)

If you want, I can split any specific change into a separate PR, add unit-testable helpers, or prepare a short playtest checklist for server operators to exercise the new bankruptcy and surrender flows on a staging server.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cefedab948329bc1245f65e0be3cf)