### PR TITLE
Add custom faction flag import, validation, caching and client texture manager

### DIFF
--- a/src/main/java/com/hfr/client/flag/FactionFlagTextureManager.java
+++ b/src/main/java/com/hfr/client/flag/FactionFlagTextureManager.java
@@ -1,0 +1,150 @@
+package com.hfr.client.flag;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+
+import com.hfr.clowder.Clowder;
+import com.hfr.packet.PacketDispatcher;
+import com.hfr.packet.effect.FactionFlagMetadataPacket;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.util.ResourceLocation;
+
+@SideOnly(Side.CLIENT)
+public class FactionFlagTextureManager {
+
+	private static final Map<String, String> HASHES = new HashMap<String, String>();
+	private static final Map<String, ResourceLocation> TEXTURES = new HashMap<String, ResourceLocation>();
+	private static final ResourceLocation FALLBACK = new ResourceLocation("hfr:textures/flags/flag_tri.png");
+
+	public static ResourceLocation getFlagTexture(Clowder faction) {
+		if(faction == null)
+			return FALLBACK;
+		return getFlagTexture(faction.name);
+	}
+
+	public static ResourceLocation getFlagTexture(String factionName) {
+		ResourceLocation texture = TEXTURES.get(factionName);
+		return texture == null ? FALLBACK : texture;
+	}
+
+	public static void requestFlagIfMissing(Clowder faction) {
+		if(faction != null)
+			requestFlagIfMissing(faction.name);
+	}
+
+	public static void requestFlagIfMissing(String factionName) {
+		String hash = HASHES.get(factionName);
+		if(hash != null && hash.length() > 0 && !TEXTURES.containsKey(factionName))
+			PacketDispatcher.wrapper.sendToServer(new FactionFlagMetadataPacket(factionName, hash));
+	}
+
+	public static void clearFlag(Clowder faction) {
+		if(faction != null)
+			clearFlag(faction.name);
+	}
+
+	public static void clearFlag(String factionName) {
+		HASHES.remove(factionName);
+		TEXTURES.remove(factionName);
+		File file = getCacheFile(factionName);
+		if(file.exists())
+			file.delete();
+	}
+
+	public static void handleMetadata(String factionName, String hash) {
+		if(factionName == null || factionName.length() == 0)
+			return;
+		if(hash == null || hash.length() == 0) {
+			clearFlag(factionName);
+			return;
+		}
+		String old = HASHES.get(factionName);
+		HASHES.put(factionName, hash);
+		if(old == null || !old.equals(hash))
+			TEXTURES.remove(factionName);
+		if(!loadCached(factionName, hash))
+			requestFlagIfMissing(factionName);
+	}
+
+	public static void handleBytes(String factionName, String hash, byte[] png) {
+		if(factionName == null || hash == null || png == null || png.length == 0)
+			return;
+		try {
+			if(!hash.equals(sha256(png)))
+				return;
+			HASHES.put(factionName, hash);
+			BufferedImage image = ImageIO.read(new ByteArrayInputStream(png));
+			if(image == null)
+				return;
+			File dir = getCacheDir();
+			if(!dir.exists())
+				dir.mkdirs();
+			FileOutputStream out = new FileOutputStream(getCacheFile(factionName));
+			try {
+				out.write(png);
+			} finally {
+				out.close();
+			}
+			registerTexture(factionName, image);
+		} catch(Exception e) { }
+	}
+
+	private static boolean loadCached(String factionName, String hash) {
+		try {
+			File file = getCacheFile(factionName);
+			if(!file.exists())
+				return false;
+			if(!file.getName().equals(safe(factionName) + "." + safe(hash) + ".png"))
+				return false;
+			BufferedImage image = ImageIO.read(file);
+			if(image == null)
+				return false;
+			registerTexture(factionName, image);
+			return true;
+		} catch(Exception e) {
+			return false;
+		}
+	}
+
+	private static void registerTexture(String factionName, BufferedImage image) {
+		DynamicTexture dynamic = new DynamicTexture(image);
+		ResourceLocation location = Minecraft.getMinecraft().getTextureManager().getDynamicTextureLocation("xenofactions_flag_" + safe(factionName), dynamic);
+		TEXTURES.put(factionName, location);
+	}
+
+	private static File getCacheDir() {
+		return new File(Loader.instance().getConfigDir(), "xenofactions/flag_cache");
+	}
+
+	private static File getCacheFile(String factionName) {
+		String hash = HASHES.get(factionName);
+		if(hash == null || hash.length() == 0)
+			hash = "unknown";
+		return new File(getCacheDir(), safe(factionName) + "." + safe(hash) + ".png");
+	}
+
+	private static String safe(String value) {
+		return value == null ? "unknown" : value.replaceAll("[^A-Za-z0-9_.-]", "_");
+	}
+
+	private static String sha256(byte[] data) throws Exception {
+		MessageDigest digest = MessageDigest.getInstance("SHA-256");
+		byte[] hash = digest.digest(data);
+		StringBuilder sb = new StringBuilder();
+		for(int i = 0; i < hash.length; i++)
+			sb.append(String.format("%02x", hash[i] & 0xff));
+		return sb.toString();
+	}
+}

--- a/src/main/java/com/hfr/clowder/Clowder.java
+++ b/src/main/java/com/hfr/clowder/Clowder.java
@@ -45,6 +45,7 @@ public class Clowder {
 	public int color;
 	public boolean canChangeColour = true;
 	public boolean canDisband = false;
+	public String customFlagHash = "";
 
 	public int homeX;
 	public int homeY;
@@ -1515,6 +1516,7 @@ public class Clowder {
 		nbt.setInteger(i + "_color", this.color);
 		nbt.setBoolean(i + "_canChange", canChangeColour);
 		nbt.setBoolean(i + "_canDisband", canDisband);
+		nbt.setString(i + "_customFlagHash", this.customFlagHash == null ? "" : this.customFlagHash);
 		nbt.setInteger(i + "_homeX", this.homeX);
 		nbt.setInteger(i + "_homeY", this.homeY);
 		nbt.setInteger(i + "_homeZ", this.homeZ);
@@ -1661,6 +1663,7 @@ public class Clowder {
 		c.color = nbt.getInteger(i + "_color");
 		c.canChangeColour = nbt.getBoolean(i + "_canChange");
 		c.canDisband = nbt.getBoolean(i + "_canDisband");
+		c.customFlagHash = nbt.getString(i + "_customFlagHash");
 		c.homeX = nbt.getInteger(i + "_homeX");
 		c.homeY = nbt.getInteger(i + "_homeY");
 		c.homeZ = nbt.getInteger(i + "_homeZ");
@@ -1915,7 +1918,7 @@ public class Clowder {
 		uuid = uuid.toLowerCase();
 
 		for (Clowder clowder : clowders) {
-			if (clowder.uuid.toLowerCase().equals(uuid))
+			if (clowder.uuid != null && clowder.uuid.toLowerCase().equals(uuid))
 				return clowder;
 		}
 

--- a/src/main/java/com/hfr/clowder/flag/CustomFlagService.java
+++ b/src/main/java/com/hfr/clowder/flag/CustomFlagService.java
@@ -1,0 +1,367 @@
+package com.hfr.clowder.flag;
+
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.imageio.ImageIO;
+import javax.net.ssl.HttpsURLConnection;
+
+import com.hfr.clowder.Clowder;
+import com.hfr.command.CommandClowder;
+import com.hfr.data.ClowderData;
+import com.hfr.main.MainRegistry;
+import com.hfr.packet.PacketDispatcher;
+import com.hfr.packet.effect.FactionFlagBytesPacket;
+import com.hfr.packet.effect.FactionFlagMetadataPacket;
+
+import cpw.mods.fml.common.Loader;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.world.World;
+
+public class CustomFlagService {
+
+	public static final int FLAG_SIZE = 64;
+	private static final int MAX_DIMENSION = 1024;
+	private static final int MAX_DOWNLOAD = 1024 * 1024;
+	private static final int TIMEOUT_MS = 5000;
+	private static final int MAX_REDIRECTS = 3;
+	private static final long RATE_LIMIT_MS = 60000L;
+	private static final String[] ALLOWED_HOSTS = new String[] { "postimages.org", "i.postimg.cc" };
+	private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+	private static final Queue<Runnable> MAIN_THREAD_CALLBACKS = new LinkedList<Runnable>();
+	private static final Map<String, Long> RATE_LIMITS = new HashMap<String, Long>();
+
+	public static File getServerFlagDir() {
+		return new File(Loader.instance().getConfigDir(), "xenofactions/flags");
+	}
+
+	public static File getFlagFile(Clowder clowder) {
+		return new File(getServerFlagDir(), getFactionFileKey(clowder) + ".png");
+	}
+
+	public static String getFactionFileKey(Clowder clowder) {
+		String key = clowder.uuid == null || clowder.uuid.length() == 0 ? clowder.name : clowder.uuid;
+		return key.replaceAll("[^A-Za-z0-9_.-]", "_");
+	}
+
+	public static void tickMainThread() {
+		while(true) {
+			Runnable runnable;
+			synchronized(MAIN_THREAD_CALLBACKS) {
+				runnable = MAIN_THREAD_CALLBACKS.poll();
+			}
+			if(runnable == null)
+				return;
+			runnable.run();
+		}
+	}
+
+	public static void importUrl(final EntityPlayerMP player, final Clowder clowder, final String urlText) {
+		final String key = getFactionFileKey(clowder) + ":" + player.getDisplayName();
+		long now = System.currentTimeMillis();
+		Long next = RATE_LIMITS.get(key);
+		if(next != null && next.longValue() > now) {
+			player.addChatMessage(new ChatComponentText(CommandClowder.ERROR + "Please wait before importing another faction flag."));
+			return;
+		}
+		RATE_LIMITS.put(key, Long.valueOf(now + RATE_LIMIT_MS));
+		player.addChatMessage(new ChatComponentText(CommandClowder.INFO + "Importing faction flag from HTTPS. The server will validate and cache it first."));
+
+		EXECUTOR.submit(new Runnable() {
+			@Override
+			public void run() {
+				ImportResult result;
+				try {
+					result = importAndSave(clowder, urlText);
+				} catch(FlagImportException e) {
+					MainRegistry.logger.warn("Rejected faction flag for " + clowder.name + ": " + e.getMessage());
+					result = new ImportResult(e.getMessage(), null, null);
+				} catch(Exception e) {
+					MainRegistry.logger.warn("Failed to import faction flag for " + clowder.name + ": " + e.getMessage());
+					result = new ImportResult("failed to decode image", null, null);
+				}
+				final ImportResult finalResult = result;
+				enqueueMainThread(new Runnable() {
+					@Override
+					public void run() {
+						EntityPlayerMP livePlayer = MinecraftServer.getServer().getConfigurationManager().func_152612_a(player.getDisplayName());
+						Clowder liveClowder = Clowder.getClowderFromUUID(clowder.uuid);
+						if(liveClowder == null)
+							return;
+						if(finalResult.success()) {
+							liveClowder.customFlagHash = finalResult.hash;
+							World world = livePlayer != null ? livePlayer.worldObj : MinecraftServer.getServer().worldServers[0];
+							ClowderData.getData(world).markDirty();
+							broadcastMetadata(liveClowder);
+							if(livePlayer != null)
+								livePlayer.addChatMessage(new ChatComponentText(CommandClowder.INFO + "Custom faction flag imported."));
+						} else if(livePlayer != null) {
+							livePlayer.addChatMessage(new ChatComponentText(CommandClowder.ERROR + finalResult.message));
+						}
+					}
+				});
+			}
+		});
+	}
+
+	public static void clearFlag(EntityPlayerMP player, Clowder clowder) {
+		File file = getFlagFile(clowder);
+		if(file.exists() && !file.delete())
+			MainRegistry.logger.warn("Could not delete custom faction flag " + file.getName());
+		clowder.customFlagHash = "";
+		clowder.save(player.worldObj);
+		broadcastMetadata(clowder);
+		player.addChatMessage(new ChatComponentText(CommandClowder.INFO + "Custom faction flag cleared."));
+	}
+
+	public static void reloadFlag(EntityPlayerMP player, Clowder clowder) {
+		try {
+			File file = getFlagFile(clowder);
+			if(!file.exists()) {
+				clowder.customFlagHash = "";
+			} else {
+				clowder.customFlagHash = sha256(readFile(file));
+			}
+			clowder.save(player.worldObj);
+			broadcastMetadata(clowder);
+			player.addChatMessage(new ChatComponentText(CommandClowder.INFO + "Custom faction flag metadata reloaded."));
+		} catch(IOException e) {
+			player.addChatMessage(new ChatComponentText(CommandClowder.ERROR + "failed to decode image"));
+			MainRegistry.logger.warn("Could not reload faction flag: " + e.getMessage());
+		}
+	}
+
+	public static void broadcastMetadata(Clowder clowder) {
+		PacketDispatcher.wrapper.sendToAll(new FactionFlagMetadataPacket(clowder.name, clowder.customFlagHash));
+	}
+
+	public static void sendFlagBytes(EntityPlayerMP player, Clowder clowder) {
+		if(clowder == null || clowder.customFlagHash == null || clowder.customFlagHash.length() == 0)
+			return;
+		try {
+			File file = getFlagFile(clowder);
+			if(file.exists())
+				PacketDispatcher.wrapper.sendTo(new FactionFlagBytesPacket(clowder.name, clowder.customFlagHash, readFile(file)), player);
+		} catch(IOException e) {
+			MainRegistry.logger.warn("Could not send faction flag bytes for " + clowder.name + ": " + e.getMessage());
+		}
+	}
+
+	private static void enqueueMainThread(Runnable runnable) {
+		synchronized(MAIN_THREAD_CALLBACKS) {
+			MAIN_THREAD_CALLBACKS.add(runnable);
+		}
+	}
+
+	private static ImportResult importAndSave(Clowder clowder, String urlText) throws Exception {
+		URL url = validateUrl(urlText);
+		byte[] downloaded = download(url, 0);
+		BufferedImage input = ImageIO.read(new ByteArrayInputStream(downloaded));
+		if(input == null)
+			return new ImportResult("failed to decode image", null, null);
+		if(input.getWidth() > MAX_DIMENSION || input.getHeight() > MAX_DIMENSION)
+			return new ImportResult("image too large", null, null);
+		BufferedImage output = resizeToFlag(input);
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		ImageIO.write(output, "png", out);
+		byte[] png = out.toByteArray();
+		String hash = sha256(png);
+		File dir = getServerFlagDir();
+		if(!dir.exists())
+			dir.mkdirs();
+		File finalFile = getFlagFile(clowder);
+		File tmp = new File(dir, finalFile.getName() + ".tmp");
+		FileOutputStream fos = new FileOutputStream(tmp);
+		try {
+			fos.write(png);
+		} finally {
+			fos.close();
+		}
+		if(finalFile.exists() && !finalFile.delete())
+			throw new IOException("could not replace old flag");
+		if(!tmp.renameTo(finalFile))
+			throw new IOException("could not move temporary flag into place");
+		return new ImportResult(null, hash, png);
+	}
+
+	private static URL validateUrl(String urlText) throws Exception {
+		URI uri = new URI(urlText);
+		if(uri.getUserInfo() != null)
+			throw new FlagImportException("invalid URL");
+		if(uri.getScheme() == null || !"https".equalsIgnoreCase(uri.getScheme()))
+			throw new FlagImportException("invalid URL");
+		if(uri.getHost() == null)
+			throw new FlagImportException("invalid URL");
+		if(!isAllowedHost(uri.getHost()))
+			throw new FlagImportException("unsupported image host");
+		validateHost(uri.getHost());
+		return uri.toURL();
+	}
+
+	private static byte[] download(URL url, int redirects) throws Exception {
+		URL safeUrl = validateUrl(url.toString());
+		HttpURLConnection conn = (HttpURLConnection)safeUrl.openConnection();
+		if(!(conn instanceof HttpsURLConnection))
+			throw new FlagImportException("invalid URL");
+		conn.setInstanceFollowRedirects(false);
+		conn.setConnectTimeout(TIMEOUT_MS);
+		conn.setReadTimeout(TIMEOUT_MS);
+		conn.setRequestProperty("User-Agent", "XenofactionsFlagImporter/1.0");
+		try {
+			int code = conn.getResponseCode();
+			if(code >= 300 && code <= 399) {
+				if(redirects >= MAX_REDIRECTS)
+					throw new FlagImportException("invalid URL");
+				String location = conn.getHeaderField("Location");
+				if(location == null)
+					throw new FlagImportException("invalid URL");
+				URL next = new URL(safeUrl, location);
+				if(!"https".equalsIgnoreCase(next.getProtocol()))
+					throw new FlagImportException("invalid URL");
+				return download(next, redirects + 1);
+			}
+			String contentType = conn.getContentType();
+			if(contentType != null) {
+				String lower = contentType.toLowerCase();
+				if(!lower.startsWith("image/png") && !lower.startsWith("image/jpeg") && !lower.startsWith("image/jpg"))
+					throw new FlagImportException("unsupported image type");
+			}
+			if(code < 200 || code >= 300)
+				throw new FlagImportException("invalid URL");
+			int length = conn.getContentLength();
+			if(length > MAX_DOWNLOAD)
+				throw new FlagImportException("image too large");
+			return readLimited(conn.getInputStream(), MAX_DOWNLOAD);
+		} catch(java.net.SocketTimeoutException e) {
+			throw new FlagImportException("download timed out");
+		} catch(FlagImportException e) {
+			throw e;
+		} catch(IOException e) {
+			throw new FlagImportException("failed to decode image");
+		} finally {
+			conn.disconnect();
+		}
+	}
+
+	private static boolean isAllowedHost(String host) {
+		if(host == null)
+			return false;
+		String normalized = host.toLowerCase();
+		if(normalized.endsWith("."))
+			normalized = normalized.substring(0, normalized.length() - 1);
+		for(int i = 0; i < ALLOWED_HOSTS.length; i++) {
+			if(ALLOWED_HOSTS[i].equals(normalized))
+				return true;
+		}
+		return false;
+	}
+
+	private static void validateHost(String host) throws Exception {
+		InetAddress[] addresses = InetAddress.getAllByName(host);
+		if(addresses == null || addresses.length == 0)
+			throw new FlagImportException("unsafe host");
+		for(int i = 0; i < addresses.length; i++) {
+			if(isUnsafeAddress(addresses[i]))
+				throw new FlagImportException("unsafe host");
+		}
+	}
+
+	public static boolean isUnsafeAddress(InetAddress address) {
+		if(address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress() || address.isSiteLocalAddress() || address.isMulticastAddress())
+			return true;
+		byte[] b = address.getAddress();
+		if(b.length == 16) {
+			int first = b[0] & 0xff;
+			return (first & 0xfe) == 0xfc;
+		}
+		return false;
+	}
+
+	private static byte[] readLimited(InputStream input, int max) throws IOException {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		byte[] buf = new byte[8192];
+		int total = 0;
+		while(true) {
+			int read = input.read(buf);
+			if(read < 0)
+				break;
+			total += read;
+			if(total > max)
+				throw new FlagImportException("image too large");
+			out.write(buf, 0, read);
+		}
+		return out.toByteArray();
+	}
+
+	private static byte[] readFile(File file) throws IOException {
+		if(file.length() > MAX_DOWNLOAD)
+			throw new EOFException("flag file too large");
+		FileInputStream in = new FileInputStream(file);
+		try {
+			return readLimited(in, MAX_DOWNLOAD);
+		} finally {
+			in.close();
+		}
+	}
+
+	private static BufferedImage resizeToFlag(BufferedImage input) {
+		BufferedImage output = new BufferedImage(FLAG_SIZE, FLAG_SIZE, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g = output.createGraphics();
+		try {
+			g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+			g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+			int w = input.getWidth();
+			int h = input.getHeight();
+			int size = Math.min(w, h);
+			int sx = (w - size) / 2;
+			int sy = (h - size) / 2;
+			g.drawImage(input, 0, 0, FLAG_SIZE, FLAG_SIZE, sx, sy, sx + size, sy + size, null);
+		} finally {
+			g.dispose();
+		}
+		return output;
+	}
+
+	private static String sha256(byte[] data) throws Exception {
+		MessageDigest digest = MessageDigest.getInstance("SHA-256");
+		byte[] hash = digest.digest(data);
+		StringBuilder sb = new StringBuilder();
+		for(int i = 0; i < hash.length; i++)
+			sb.append(String.format("%02x", hash[i] & 0xff));
+		return sb.toString();
+	}
+
+	private static class ImportResult {
+		String message;
+		String hash;
+		byte[] bytes;
+		ImportResult(String message, String hash, byte[] bytes) { this.message = message; this.hash = hash; this.bytes = bytes; }
+		boolean success() { return hash != null && hash.length() > 0; }
+	}
+
+	private static class FlagImportException extends IOException {
+		FlagImportException(String message) { super(message); }
+	}
+}

--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -10,6 +10,7 @@ import com.hfr.blocks.ModBlocks;
 import com.hfr.clowder.Clowder;
 import com.hfr.clowder.Clowder.ScheduledTeleport;
 import com.hfr.clowder.ClowderFlag;
+import com.hfr.clowder.flag.CustomFlagService;
 import com.hfr.clowder.CityLevel;
 import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.Ownership;
@@ -182,7 +183,7 @@ public class CommandClowder extends CommandBase {
 			return;
 		}
 
-		if(cmd.equals("flag")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdFlag(sender, args[1]); return; }
+		if(cmd.equals("flag")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdFlag(sender, args); return; }
 		if(cmd.equals("retreat")) { cmdRetreat(sender); return; }
 		if(cmd.equals("sethome")) { cmdSethome(sender); return; }
 		if(cmd.equals("setallywarp")) { cmdSetAllyWarp(sender); return; }
@@ -254,7 +255,7 @@ public class CommandClowder extends CommandBase {
 		if(cmd.equals("deny")) return "/c deny <player>";
 		if(cmd.equals("kick")) return "/c kick <player>";
 		if(cmd.equals("unfriend") || cmd.equals("unally")) return "/c unfriend <faction>";
-		if(cmd.equals("flag")) return "/c flag <flag>";
+		if(cmd.equals("flag")) return "/c flag <flag>|seturl <postimages URL>|clear|reload";
 		if(cmd.equals("allywarp")) return "/c allywarp <faction>";
 		if(cmd.equals("addwarp") || cmd.equals("setwarp")) return "/c setwarp <name>";
 		if(cmd.equals("delwarp")) return "/c delwarp <name>";
@@ -319,6 +320,7 @@ public class CommandClowder extends CommandBase {
 			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-motd <message>" + TITLE + " - Sets the faction MotD"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-listflags {page}" + TITLE + " - Lists available flags"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-flag <flag>" + TITLE + " - Sets the faction flag"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-flag seturl <postimages URL>" + TITLE + " - Imports a safe custom faction flag"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-gracebuild" + TITLE + " - Activates one-time 48h faction build grace"));
 			sender.addChatMessage(new ChatComponentText(INFO + "/clowder help 4"));
 		}
@@ -1087,14 +1089,25 @@ private void cmdCreate(ICommandSender sender, String name) {
 
 	}
 
-	private void cmdFlag(ICommandSender sender, String flag) {
+	private void cmdFlag(ICommandSender sender, String[] args) {
 
 		EntityPlayer player = getCommandSenderAsPlayer(sender);
 		Clowder clowder = Clowder.getClowderFromPlayer(player);
 
 		if(clowder != null) {
 
-			if(clowder.getPermLevel(player.getDisplayName()) > 1) {
+			if(clowder.getPermLevel(player.getDisplayName()) > 1 || canUseCommand(sender)) {
+
+				String flag = args[1];
+				if(flag.equalsIgnoreCase("seturl")) {
+					if(args.length < 3) { sender.addChatMessage(new ChatComponentText(ERROR + "Invalid format. Usage: /c flag seturl <https://i.postimg.cc/...>")); return; }
+					// Clients must never load arbitrary remote URLs directly. The server imports, validates, strips metadata,
+					// caches and syncs sanitized PNG bytes so malicious URLs cannot target every client.
+					CustomFlagService.importUrl((EntityPlayerMP)player, clowder, args[2]);
+					return;
+				}
+				if(flag.equalsIgnoreCase("clear")) { CustomFlagService.clearFlag((EntityPlayerMP)player, clowder); return; }
+				if(flag.equalsIgnoreCase("reload")) { CustomFlagService.reloadFlag((EntityPlayerMP)player, clowder); return; }
 
 				ClowderFlag f = ClowderFlag.getFromName(flag.toLowerCase());
 

--- a/src/main/java/com/hfr/main/CommonEventHandler.java
+++ b/src/main/java/com/hfr/main/CommonEventHandler.java
@@ -16,6 +16,7 @@ import com.hfr.command.CommandClowderChat;
 import com.hfr.command.IgnoreManager;
 import com.hfr.command.Mute;
 import com.hfr.command.MuteManager;
+import com.hfr.clowder.flag.CustomFlagService;
 import com.hfr.data.AntiMobData;
 import com.hfr.data.OutOfBoundsData;
 import com.hfr.data.CBTData;
@@ -678,6 +679,7 @@ public class CommonEventHandler {
 		if (event.phase != Phase.START) return;      // run once per tick (start)
 
 		World world = event.world;
+		CustomFlagService.tickMainThread();
 		handleOutOfBoundsRegions(world);
 
 		// --------------------

--- a/src/main/java/com/hfr/packet/PacketDispatcher.java
+++ b/src/main/java/com/hfr/packet/PacketDispatcher.java
@@ -56,6 +56,9 @@ public class PacketDispatcher {
 		wrapper.registerMessage(SLBMCommandPacket.Handler.class, SLBMCommandPacket.class, i++, Side.SERVER);
 		wrapper.registerMessage(SLBMOfferPacket.Handler.class, SLBMOfferPacket.class, i++, Side.CLIENT);
 		wrapper.registerMessage(ClowderFlagPacket.Handler.class, ClowderFlagPacket.class, i++, Side.CLIENT);
+		wrapper.registerMessage(FactionFlagMetadataPacket.ClientHandler.class, FactionFlagMetadataPacket.class, i++, Side.CLIENT);
+		wrapper.registerMessage(FactionFlagMetadataPacket.ServerHandler.class, FactionFlagMetadataPacket.class, i++, Side.SERVER);
+		wrapper.registerMessage(FactionFlagBytesPacket.Handler.class, FactionFlagBytesPacket.class, i++, Side.CLIENT);
 		wrapper.registerMessage(ClowderBorderPacket.Handler.class, ClowderBorderPacket.class, i++, Side.CLIENT);
 		wrapper.registerMessage(ExplosionSoundPacket.Handler.class, ExplosionSoundPacket.class, i++, Side.CLIENT);
 		//wrapper.registerMessage(OfferPacket.Handler.class, OfferPacket.class, i++, Side.CLIENT);

--- a/src/main/java/com/hfr/packet/effect/FactionFlagBytesPacket.java
+++ b/src/main/java/com/hfr/packet/effect/FactionFlagBytesPacket.java
@@ -1,0 +1,57 @@
+package com.hfr.packet.effect;
+
+import com.hfr.client.flag.FactionFlagTextureManager;
+
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+
+public class FactionFlagBytesPacket implements IMessage {
+
+	public String factionName;
+	public String hash;
+	public byte[] png;
+
+	public FactionFlagBytesPacket() { }
+
+	public FactionFlagBytesPacket(String factionName, String hash, byte[] png) {
+		this.factionName = factionName == null ? "" : factionName;
+		this.hash = hash == null ? "" : hash;
+		this.png = png == null ? new byte[0] : png;
+	}
+
+	@Override
+	public void fromBytes(ByteBuf buf) {
+		factionName = ByteBufUtils.readUTF8String(buf);
+		hash = ByteBufUtils.readUTF8String(buf);
+		int len = buf.readInt();
+		if(len < 0 || len > 1024 * 1024) {
+			png = new byte[0];
+			return;
+		}
+		png = new byte[len];
+		buf.readBytes(png);
+	}
+
+	@Override
+	public void toBytes(ByteBuf buf) {
+		ByteBufUtils.writeUTF8String(buf, factionName == null ? "" : factionName);
+		ByteBufUtils.writeUTF8String(buf, hash == null ? "" : hash);
+		buf.writeInt(png == null ? 0 : png.length);
+		if(png != null)
+			buf.writeBytes(png);
+	}
+
+	public static class Handler implements IMessageHandler<FactionFlagBytesPacket, IMessage> {
+		@Override
+		@SideOnly(Side.CLIENT)
+		public IMessage onMessage(FactionFlagBytesPacket m, MessageContext ctx) {
+			FactionFlagTextureManager.handleBytes(m.factionName, m.hash, m.png);
+			return null;
+		}
+	}
+}

--- a/src/main/java/com/hfr/packet/effect/FactionFlagMetadataPacket.java
+++ b/src/main/java/com/hfr/packet/effect/FactionFlagMetadataPacket.java
@@ -1,0 +1,59 @@
+package com.hfr.packet.effect;
+
+import com.hfr.client.flag.FactionFlagTextureManager;
+import com.hfr.clowder.Clowder;
+import com.hfr.clowder.flag.CustomFlagService;
+
+import cpw.mods.fml.common.network.ByteBufUtils;
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+public class FactionFlagMetadataPacket implements IMessage {
+
+	public String factionName;
+	public String hash;
+
+	public FactionFlagMetadataPacket() { }
+
+	public FactionFlagMetadataPacket(String factionName, String hash) {
+		this.factionName = factionName == null ? "" : factionName;
+		this.hash = hash == null ? "" : hash;
+	}
+
+	@Override
+	public void fromBytes(ByteBuf buf) {
+		factionName = ByteBufUtils.readUTF8String(buf);
+		hash = ByteBufUtils.readUTF8String(buf);
+	}
+
+	@Override
+	public void toBytes(ByteBuf buf) {
+		ByteBufUtils.writeUTF8String(buf, factionName == null ? "" : factionName);
+		ByteBufUtils.writeUTF8String(buf, hash == null ? "" : hash);
+	}
+
+	public static class ClientHandler implements IMessageHandler<FactionFlagMetadataPacket, IMessage> {
+		@Override
+		@SideOnly(Side.CLIENT)
+		public IMessage onMessage(FactionFlagMetadataPacket m, MessageContext ctx) {
+			FactionFlagTextureManager.handleMetadata(m.factionName, m.hash);
+			return null;
+		}
+	}
+
+	public static class ServerHandler implements IMessageHandler<FactionFlagMetadataPacket, IMessage> {
+		@Override
+		public IMessage onMessage(FactionFlagMetadataPacket m, MessageContext ctx) {
+			EntityPlayerMP player = ctx.getServerHandler().playerEntity;
+			Clowder clowder = Clowder.getClowderFromName(m.factionName);
+			if(player != null && m.hash != null && m.hash.length() > 0 && clowder != null && clowder.customFlagHash != null && clowder.customFlagHash.equals(m.hash))
+				CustomFlagService.sendFlagBytes(player, clowder);
+			return null;
+		}
+	}
+}

--- a/src/main/java/com/hfr/packet/tile/CityCenterPacket.java
+++ b/src/main/java/com/hfr/packet/tile/CityCenterPacket.java
@@ -1,5 +1,6 @@
 package com.hfr.packet.tile;
 
+import com.hfr.client.flag.FactionFlagTextureManager;
 import com.hfr.tileentity.clowder.TileEntityFlag;
 
 import cpw.mods.fml.common.network.ByteBufUtils;
@@ -14,11 +15,12 @@ import net.minecraft.tileentity.TileEntity;
 
 public class CityCenterPacket implements IMessage {
 
-	int x;
-	int y;
-	int z;
-	String cityName;
-	String ownerName;
+	public int x;
+	public int y;
+	public int z;
+	public String cityName;
+	public String ownerName;
+	public String flagHash;
 
 	public CityCenterPacket() { }
 
@@ -28,6 +30,7 @@ public class CityCenterPacket implements IMessage {
 		this.z = z;
 		this.cityName = cityName == null ? "" : cityName;
 		this.ownerName = ownerName == null ? "" : ownerName;
+		this.flagHash = "";
 	}
 
 	@Override
@@ -37,6 +40,7 @@ public class CityCenterPacket implements IMessage {
 		z = buf.readInt();
 		cityName = ByteBufUtils.readUTF8String(buf);
 		ownerName = ByteBufUtils.readUTF8String(buf);
+		flagHash = ByteBufUtils.readUTF8String(buf);
 	}
 
 	@Override
@@ -46,6 +50,7 @@ public class CityCenterPacket implements IMessage {
 		buf.writeInt(z);
 		ByteBufUtils.writeUTF8String(buf, cityName == null ? "" : cityName);
 		ByteBufUtils.writeUTF8String(buf, ownerName == null ? "" : ownerName);
+		ByteBufUtils.writeUTF8String(buf, flagHash == null ? "" : flagHash);
 	}
 
 	public static class Handler implements IMessageHandler<CityCenterPacket, IMessage> {
@@ -59,6 +64,9 @@ public class CityCenterPacket implements IMessage {
 					TileEntityFlag flag = (TileEntityFlag)te;
 					flag.name = m.cityName == null ? "" : m.cityName;
 					flag.ownerName = m.ownerName == null ? "" : m.ownerName;
+					flag.customFlagHash = m.flagHash == null ? "" : m.flagHash;
+					if(flag.ownerName.length() > 0 && flag.customFlagHash.length() > 0)
+						FactionFlagTextureManager.handleMetadata(flag.ownerName, flag.customFlagHash);
 				}
 			} catch(Exception e) { }
 			return null;

--- a/src/main/java/com/hfr/render/tileentity/RenderConquerer.java
+++ b/src/main/java/com/hfr/render/tileentity/RenderConquerer.java
@@ -2,6 +2,7 @@ package com.hfr.render.tileentity;
 
 import org.lwjgl.opengl.GL11;
 
+import com.hfr.client.flag.FactionFlagTextureManager;
 import com.hfr.clowder.ClowderFlag;
 import com.hfr.main.ResourceManager;
 import com.hfr.tileentity.clowder.TileEntityConquerer;
@@ -66,13 +67,18 @@ public class RenderConquerer extends TileEntitySpecialRenderer {
         OpenGlHelper.glBlendFunc(770, 771, 1, 0);
         GL11.glDisable(GL11.GL_ALPHA_TEST);
         
-        bindTexture(flag.getFlag());
+        boolean hasCustomFlag = flagpole.customFlagHash != null && flagpole.customFlagHash.length() > 0;
+        if(hasCustomFlag)
+            FactionFlagTextureManager.handleMetadata(flagpole.ownerName, flagpole.customFlagHash);
+        bindTexture(hasCustomFlag ? FactionFlagTextureManager.getFlagTexture(flagpole.ownerName) : flag.getFlag());
         GL11.glColor3b((byte)r, (byte)g, (byte)b);
         ResourceManager.flag.renderOnly("Flag");
 
-	    bindTexture(flag.getFlagOverlay());
-	    GL11.glColor3b((byte)127, (byte)127, (byte)127);
-	    ResourceManager.flag.renderOnly("Flag");
+        if(!hasCustomFlag) {
+            bindTexture(flag.getFlagOverlay());
+            GL11.glColor3b((byte)127, (byte)127, (byte)127);
+            ResourceManager.flag.renderOnly("Flag");
+        }
 	    GL11.glPopMatrix();
 	    
 	    if(flagpole.height < 1) {

--- a/src/main/java/com/hfr/render/tileentity/RenderFlag.java
+++ b/src/main/java/com/hfr/render/tileentity/RenderFlag.java
@@ -2,6 +2,7 @@ package com.hfr.render.tileentity;
 
 import org.lwjgl.opengl.GL11;
 
+import com.hfr.client.flag.FactionFlagTextureManager;
 import com.hfr.clowder.ClowderFlag;
 import com.hfr.main.ResourceManager;
 import com.hfr.tileentity.clowder.TileEntityFlag;
@@ -64,13 +65,18 @@ public class RenderFlag extends TileEntitySpecialRenderer {
         OpenGlHelper.glBlendFunc(770, 771, 1, 0);
         GL11.glDisable(GL11.GL_ALPHA_TEST);
         
-        bindTexture(flag.getFlag());
+        boolean hasCustomFlag = flagpole.customFlagHash != null && flagpole.customFlagHash.length() > 0;
+        if(hasCustomFlag)
+            FactionFlagTextureManager.handleMetadata(flagpole.ownerName, flagpole.customFlagHash);
+        bindTexture(hasCustomFlag ? FactionFlagTextureManager.getFlagTexture(flagpole.ownerName) : flag.getFlag());
         GL11.glColor3b((byte)r, (byte)g, (byte)b);
         ResourceManager.flag.renderOnly("Flag");
 
-	    bindTexture(flag.getFlagOverlay());
-	    GL11.glColor3b((byte)127, (byte)127, (byte)127);
-	    ResourceManager.flag.renderOnly("Flag");
+        if(!hasCustomFlag) {
+            bindTexture(flag.getFlagOverlay());
+            GL11.glColor3b((byte)127, (byte)127, (byte)127);
+            ResourceManager.flag.renderOnly("Flag");
+        }
 	    
         GL11.glEnable(GL11.GL_ALPHA_TEST);
         GL11.glDisable(GL11.GL_BLEND);

--- a/src/main/java/com/hfr/render/tileentity/RenderFlagBig.java
+++ b/src/main/java/com/hfr/render/tileentity/RenderFlagBig.java
@@ -2,6 +2,7 @@ package com.hfr.render.tileentity;
 
 import org.lwjgl.opengl.GL11;
 
+import com.hfr.client.flag.FactionFlagTextureManager;
 import com.hfr.clowder.ClowderFlag;
 import com.hfr.main.ResourceManager;
 import com.hfr.tileentity.clowder.TileEntityFlagBig;
@@ -64,13 +65,18 @@ public class RenderFlagBig extends TileEntitySpecialRenderer {
         OpenGlHelper.glBlendFunc(770, 771, 1, 0);
         GL11.glDisable(GL11.GL_ALPHA_TEST);
         
-        bindTexture(flag.getFlag());
+        boolean hasCustomFlag = flagpole.customFlagHash != null && flagpole.customFlagHash.length() > 0;
+        if(hasCustomFlag)
+            FactionFlagTextureManager.handleMetadata(flagpole.ownerName, flagpole.customFlagHash);
+        bindTexture(hasCustomFlag ? FactionFlagTextureManager.getFlagTexture(flagpole.ownerName) : flag.getFlag());
         GL11.glColor3b((byte)r, (byte)g, (byte)b);
         ResourceManager.flag_big.renderOnly("Flag");
 
-	    bindTexture(flag.getFlagOverlay());
-	    GL11.glColor3b((byte)127, (byte)127, (byte)127);
-	    ResourceManager.flag_big.renderOnly("Flag");
+        if(!hasCustomFlag) {
+            bindTexture(flag.getFlagOverlay());
+            GL11.glColor3b((byte)127, (byte)127, (byte)127);
+            ResourceManager.flag_big.renderOnly("Flag");
+        }
 	    
         GL11.glEnable(GL11.GL_ALPHA_TEST);
         GL11.glDisable(GL11.GL_BLEND);

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityConquerer.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityConquerer.java
@@ -35,6 +35,10 @@ public class TileEntityConquerer extends TileEntityMachineBase implements ITerri
 	public ClowderFlag flag;
 	@SideOnly(Side.CLIENT)
 	public int color;
+	@SideOnly(Side.CLIENT)
+	public String ownerName = "";
+	@SideOnly(Side.CLIENT)
+	public String customFlagHash = "";
 
 	public TileEntityConquerer() {
 		super(0);
@@ -112,6 +116,8 @@ public class TileEntityConquerer extends TileEntityMachineBase implements ITerri
 			
 			this.updateGauge(owner.flag.ordinal(), 0, 250);
 			this.updateGauge(owner.color, 1, 250);
+			ownerName = owner.name;
+			customFlagHash = owner.customFlagHash;
 			this.updateGauge((int) (height * 100F), 2, 100);
 		}
 	}

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -49,6 +49,8 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	public float prestige;
 	@SideOnly(Side.CLIENT)
 	public float prestigeReq;
+	@SideOnly(Side.CLIENT)
+	public String customFlagHash = "";
 
 	public TileEntityFlag() {
 		super(0);
@@ -197,7 +199,11 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 			
 			ownerName = owner == null ? "" : owner.name;
 			if(worldObj.getTotalWorldTime() % 20 == 0)
-				PacketDispatcher.wrapper.sendToAllAround(new CityCenterPacket(xCoord, yCoord, zCoord, name, ownerName), new TargetPoint(this.worldObj.provider.dimensionId, xCoord, yCoord, zCoord, 250));
+				{
+					CityCenterPacket packet = new CityCenterPacket(xCoord, yCoord, zCoord, name, ownerName);
+					packet.flagHash = owner == null ? "" : owner.customFlagHash;
+					PacketDispatcher.wrapper.sendToAllAround(packet, new TargetPoint(this.worldObj.provider.dimensionId, xCoord, yCoord, zCoord, 250));
+				}
 
 			if(owner != null) {
 				this.updateGauge(owner.flag.ordinal(), 0, 250);

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
@@ -41,6 +41,10 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 	public ClowderFlag flag;
 	@SideOnly(Side.CLIENT)
 	public int color;
+	@SideOnly(Side.CLIENT)
+	public String ownerName = "";
+	@SideOnly(Side.CLIENT)
+	public String customFlagHash = "";
 	public String provinceName = "";
 
 	public TileEntityFlagBig() {
@@ -145,9 +149,13 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 			if(owner != null) {
 				this.updateGauge(owner.flag.ordinal(), 0, 100);
 				this.updateGauge(owner.color, 1, 100);
+				ownerName = owner.name;
+				customFlagHash = owner.customFlagHash;
 			} else {
 				this.updateGauge(ClowderFlag.NONE.ordinal(), 0, 100);
 				this.updateGauge(0xFFFFFF, 1, 100);
+				ownerName = "";
+				customFlagHash = "";
 			}
 			
 		} else {


### PR DESCRIPTION
### Motivation

- Allow server operators/players to set safe custom faction flags hosted on approved HTTPS image hosts while ensuring clients are never forced to load arbitrary remote URLs.
- Provide a secure server-side import/validation pipeline that strips metadata, resizes and caches images, and synchronizes sanitized bytes to clients via hashed metadata.
- Provide client-side texture management to verify, cache and display custom flags with a fallback when no custom flag is present.

### Description

- Added a server-side `CustomFlagService` that validates `https` URLs (allowed hosts), prevents SSRF by DNS/address checks, enforces timeouts/size/redirect limits, resizes images to `64x64`, strips/rewrites PNG bytes, computes `SHA-256` hashes, rate-limits imports, and caches files under the server config dir via `getServerFlagDir()`.
- Added `customFlagHash` to `Clowder` with NBT save/load support and exposed server APIs `importUrl`, `clearFlag`, `reloadFlag`, `broadcastMetadata`, and `sendFlagBytes` to manage imported flags and send sanitized bytes to requesting clients.
- Implemented network messages `FactionFlagMetadataPacket` and `FactionFlagBytesPacket` with handlers and registered them in `PacketDispatcher`; metadata packets drive client requests to the server and the server only replies with bytes when hashes match server-side `customFlagHash`.
- Implemented client-side `FactionFlagTextureManager` to verify received PNG bytes via SHA-256, cache sanitized bytes to disk, register dynamic textures with Minecraft, and provide `getFlagTexture`/`requestFlagIfMissing`/`handleMetadata`/`handleBytes` APIs and a local cache directory.
- Integrated custom flag flow into rendering and tile entities: `TileEntityFlag`, `TileEntityFlagBig`, and `TileEntityConquerer` now include `ownerName`/`customFlagHash` client fields and include the hash in `CityCenterPacket`; renderers (`RenderFlag`, `RenderFlagBig`, `RenderConquerer`) call the texture manager to show custom flags and skip overlay rendering when a custom flag is used.
- Extended `CommandClowder` to expose `flag seturl <url>` (imports via `CustomFlagService.importUrl`), `flag clear`, and `flag reload` subcommands and updated usages and permission checks to allow admins/owners to use import/clear/reload operations.
- Added server main-thread callback pumping via `CustomFlagService.tickMainThread()` invoked from `CommonEventHandler.onWorldTick` to apply asynchronous import results back to live players and clowder state.

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e98806e3c832993e2a70efead8a66)