### PR TITLE
Add XFConfig central configuration and wire module toggles + prestige/claims/war/new-player/flag/dynmap options

### DIFF
--- a/src/main/java/com/hfr/blocks/clowder/Conquerer.java
+++ b/src/main/java/com/hfr/blocks/clowder/Conquerer.java
@@ -92,7 +92,7 @@ public class Conquerer extends BlockContainer {
 
 			if (clowder != null && flag.checkBorder(x, z) && flag.canSeeSky() && noProximity(world, x, y, z)) {
 
-				flag.owner.addPrestigeReq(Clowder.flagReq, world);
+				flag.owner.addPrestigeReq(Clowder.flagReq(), world);
 				flag.markDirty();
 				MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(
 						EnumChatFormatting.RED + "[WAR] " + EnumChatFormatting.GOLD + clowder.name +
@@ -168,7 +168,7 @@ public class Conquerer extends BlockContainer {
     {
 		TileEntityConquerer flag = (TileEntityConquerer)world.getTileEntity(x, y, z);
 		if(flag != null && flag.owner != null) {
-			flag.owner.addPrestigeReq(-Clowder.flagReq, world);
+			flag.owner.addPrestigeReq(-Clowder.flagReq(), world);
 		}
 		
 		super.breakBlock(world, x, y, z, b, i);

--- a/src/main/java/com/hfr/blocks/clowder/Flag.java
+++ b/src/main/java/com/hfr/blocks/clowder/Flag.java
@@ -119,7 +119,7 @@ public class Flag extends BlockContainer {
 
 			if(clowder != null && flag.canSeeSky()) {
 				float foundingCost = clowder.getCityFoundingCost();
-				float foundingUpkeep = CityLevel.SETTLEMENT.upkeep;
+				float foundingUpkeep = CityLevel.SETTLEMENT.configuredUpkeep();
 				if(clowder.getPrestige() < foundingCost || clowder.getPrestigeReq() + foundingUpkeep > clowder.getPrestige() - foundingCost) {
 					world.setBlockToAir(x, y, z);
 					entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Founding a City Center requires " + foundingCost + " prestige and " + foundingUpkeep + " upkeep capacity."));

--- a/src/main/java/com/hfr/blocks/machine/MachineBlastFurnace.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineBlastFurnace.java
@@ -146,7 +146,7 @@ public class MachineBlastFurnace extends BlockDummyable {
 				TileEntityMachineBlastFurnace statue = (TileEntityMachineBlastFurnace)world.getTileEntity(x, y, z);
 				
 				if(statue.operational())
-					owner.owner.addPrestigeGen(-Clowder.BlastRate, world);
+					owner.owner.addPrestigeGen(-Clowder.BlastRate(), world);
 			}
 		}
 

--- a/src/main/java/com/hfr/blocks/machine/MachineCoalMine.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineCoalMine.java
@@ -139,7 +139,7 @@ public class MachineCoalMine extends BlockDummyable {
 				TileEntityMachineBlastFurnace statue = (TileEntityMachineBlastFurnace)world.getTileEntity(x, y, z);
 				
 				if(statue.operational())
-					owner.owner.addPrestigeGen(-Clowder.tentRate, world);
+					owner.owner.addPrestigeGen(-Clowder.tentRate(), world);
 			}
 		}*/
 

--- a/src/main/java/com/hfr/blocks/machine/MachineFed.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineFed.java
@@ -152,7 +152,7 @@ public class MachineFed extends BlockDummyable {
                 TileEntityMachineFederalReserve statue = (TileEntityMachineFederalReserve) world.getTileEntity(x, y, z);
 
                 if(statue.operational())
-                    owner.owner.addPrestigeGen(-Clowder.UniRate, world);
+                    owner.owner.addPrestigeGen(-Clowder.UniRate(), world);
             }
         }
 

--- a/src/main/java/com/hfr/blocks/machine/MachineGrainmill.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineGrainmill.java
@@ -143,7 +143,7 @@ public class MachineGrainmill extends BlockDummyable {
 				TileEntityMachineGrainmill statue = (TileEntityMachineGrainmill)world.getTileEntity(x, y, z);
 				
 				if(statue.operational())
-					owner.owner.addPrestigeGen(-Clowder.GrainRate, world);
+					owner.owner.addPrestigeGen(-Clowder.GrainRate(), world);
 			}
 		}
 

--- a/src/main/java/com/hfr/blocks/machine/MachineTemple.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineTemple.java
@@ -51,7 +51,7 @@ public class MachineTemple extends BlockDummyable {
 			if(owner != null && owner.zone == Zone.FACTION && entity instanceof TileEntityMachineTemple) {
 				TileEntityMachineTemple temple = (TileEntityMachineTemple)entity;
 				if(temple.owner != null)
-					temple.owner.addPrestigeGen(-Clowder.TempleRate, world);
+					temple.owner.addPrestigeGen(-Clowder.TempleRate(), world);
 			}
 		}
 		super.breakBlock(world, x, y, z, block, meta);

--- a/src/main/java/com/hfr/blocks/machine/MachineUni.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineUni.java
@@ -152,7 +152,7 @@ public class MachineUni extends BlockDummyable {
 				TileEntityMachineUni statue = (TileEntityMachineUni)world.getTileEntity(x, y, z);
 				
 				if(statue.operational())
-					owner.owner.addPrestigeGen(-Clowder.UniRate, world);
+					owner.owner.addPrestigeGen(-Clowder.UniRate(), world);
 			}
 		}
 

--- a/src/main/java/com/hfr/blocks/props/PropStatue.java
+++ b/src/main/java/com/hfr/blocks/props/PropStatue.java
@@ -50,7 +50,7 @@ public class PropStatue extends BlockDummyable {
 				TileEntityStatue statue = (TileEntityStatue)world.getTileEntity(x, y, z);
 				
 				if(statue.operational())
-					owner.owner.addPrestigeGen(-Clowder.statueRate, world);
+					owner.owner.addPrestigeGen(-Clowder.statueRate(), world);
 			}
 		}
 		

--- a/src/main/java/com/hfr/blocks/props/PropTent.java
+++ b/src/main/java/com/hfr/blocks/props/PropTent.java
@@ -48,7 +48,7 @@ public class PropTent extends BlockDummyable {
 			
 			if(owner != null && owner.zone == Zone.FACTION) {
 
-				float prestigeRate = this == ModBlocks.med_tent ? Clowder.medTentRate : Clowder.tentRate;
+				float prestigeRate = this == ModBlocks.med_tent ? Clowder.medTentRate() : Clowder.tentRate();
 				TileEntityProp tent = (TileEntityProp)world.getTileEntity(x, y, z);
 				
 				if(this == ModBlocks.tp_tent) {

--- a/src/main/java/com/hfr/clowder/CityLevel.java
+++ b/src/main/java/com/hfr/clowder/CityLevel.java
@@ -1,5 +1,7 @@
 package com.hfr.clowder;
 
+import com.hfr.config.XFConfig;
+
 public enum CityLevel {
 	SETTLEMENT("Settlement", 2, 75F, 10F),
 	TOWN("Town", 3, 150F, 25F),

--- a/src/main/java/com/hfr/clowder/Clowder.java
+++ b/src/main/java/com/hfr/clowder/Clowder.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import com.hfr.blocks.BlockDummyable;
 import com.hfr.blocks.ModBlocks;
 import com.hfr.command.CommandClowder;
+import com.hfr.config.XFConfig;
 import com.hfr.data.ClowderData;
 //import com.hfr.data.MarketData.Offer;
 import com.hfr.main.MainRegistry;
@@ -194,6 +195,17 @@ public class Clowder {
 	public static final float statueRate = 15F;
 	public static final float flagRate = 0F;
 	public static final float flagReq = 10F;
+
+	public static float tentRate() { return -XFConfig.warpTentUpkeep; }
+	public static float medTentRate() { return -XFConfig.medTentUpkeep; }
+	public static float BlastRate() { return XFConfig.blastFurnacePrestige; }
+	public static float GrainRate() { return XFConfig.grainmillPrestige; }
+	public static float UniRate() { return XFConfig.universityPrestige; }
+	public static float FedRate() { return XFConfig.federalReservePrestige; }
+	public static float TempleRate() { return XFConfig.templePrestige; }
+	public static float statueRate() { return XFConfig.statuePrestige; }
+	public static float flagRate() { return XFConfig.cityCenterPrestige; }
+	public static float flagReq() { return XFConfig.cityClaimUpkeep; }
 
 	//this mod is so fucking retarded I guarantee you theres like 16 different ways this shit can be exploited
 	//or is just SHIT coding. and that's coming from a MCHELI developer.
@@ -895,13 +907,13 @@ public class Clowder {
 	public boolean isRaidableAgainst(Clowder aggressor) {
 		long now = System.currentTimeMillis();
 		int online = getOnlineMemberCount();
-		if (online >= 2) {
+		if (online >= XFConfig.warOnlinePlayerThreshold) {
 			belowOnlineThresholdSince = 0L;
 			return true;
 		}
 		if (belowOnlineThresholdSince <= 0L)
 			belowOnlineThresholdSince = now;
-		if (now - belowOnlineThresholdSince <= 30L * 60L * 1000L)
+		if (now - belowOnlineThresholdSince <= XFConfig.raidGraceAfterOnlineDropMs)
 			return true;
 
 		if(aggressor != null) {
@@ -1263,13 +1275,13 @@ public class Clowder {
 			return true;
 
 		int online = getOnlineMemberCount();
-		if (online >= 2) {
+		if (online >= XFConfig.warOnlinePlayerThreshold) {
 			belowOnlineThresholdSince = 0L;
 			return true;
 		}
 		if (belowOnlineThresholdSince <= 0L)
 			belowOnlineThresholdSince = System.currentTimeMillis();
-		return System.currentTimeMillis() - belowOnlineThresholdSince <= 30L * 60L * 1000L;
+		return System.currentTimeMillis() - belowOnlineThresholdSince <= XFConfig.raidGraceAfterOnlineDropMs;
 	}
 
 	public int getOnlineMemberCount() {
@@ -1318,7 +1330,7 @@ public class Clowder {
 		if (prestigeGen < 0)
 			prestigeGen = 0F;
 
-		prestigeGen = Math.min(prestigeGen, prestigeGenCap);
+		prestigeGen = Math.min(prestigeGen, XFConfig.prestigeGenCap);
 		this.save(world);
 	}
 
@@ -1339,11 +1351,13 @@ public class Clowder {
 	}
 
 	public int getBankruptcyStage() {
-		if(prestige < -1000F)
+		if(!XFConfig.enableNegativePrestigePenalties)
+			return 0;
+		if(prestige < XFConfig.fallenNationThreshold)
 			return 3;
-		if(prestige < -500F)
+		if(prestige < XFConfig.nationalCollapseThreshold)
 			return 2;
-		if(prestige < 0F)
+		if(prestige < XFConfig.financialCrisisThreshold)
 			return 1;
 		return 0;
 	}
@@ -1375,20 +1389,20 @@ public class Clowder {
 
 	public float getUpkeepMultiplier() {
 		switch(getBankruptcyStage()) {
-		case 3: return FALLEN_NATION_UPKEEP_MULT;
-		case 2: return NATIONAL_COLLAPSE_UPKEEP_MULT;
-		case 1: return FINANCIAL_CRISIS_UPKEEP_MULT;
+		case 3: return XFConfig.fallenNationUpkeepMult;
+		case 2: return XFConfig.nationalCollapseUpkeepMult;
+		case 1: return XFConfig.financialCrisisUpkeepMult;
 		default: return 1F;
 		}
 	}
 
 	public float getWarDeclarationCost(Clowder target) {
 		float targetPrestige = target == null ? 0F : Math.max(0F, target.getPrestige());
-		return WAR_DECLARATION_COST + targetPrestige * WAR_DECLARATION_TARGET_PRESTIGE_FACTOR;
+		return XFConfig.warDeclarationBaseCost + targetPrestige * XFConfig.warDeclarationTargetPrestigeFactor;
 	}
 
 	public float getCityFoundingCost() {
-		return CityLevel.SETTLEMENT.upgradeCost * (1F + Math.max(0, citiesFounded) * CITY_FOUNDING_COST_GROWTH);
+		return XFConfig.cityUpgradeCost(CityLevel.SETTLEMENT) * (1F + Math.max(0, citiesFounded) * XFConfig.cityFoundingCostGrowth);
 	}
 
 	public void markCityFounded(World world) {
@@ -1403,8 +1417,8 @@ public class Clowder {
 		for(String enemyName : activeWars) {
 			Long declaredAt = warDeclaredAt.get(enemyName);
 			long hours = declaredAt == null ? 0L : Math.max(0L, (now - declaredAt) / (60L * 60L * 1000L));
-			float multiplier = 1F + hours * WAR_UPKEEP_HOURLY_GROWTH + hours * hours * WAR_UPKEEP_HOURLY_GROWTH_SQUARED;
-			cost += WAR_UPKEEP * multiplier;
+			float multiplier = 1F + hours * XFConfig.warUpkeepHourlyGrowth + hours * hours * XFConfig.warUpkeepHourlyGrowthSquared;
+			cost += XFConfig.activeWarUpkeep * multiplier;
 		}
 
 		return cost;
@@ -1423,7 +1437,7 @@ public class Clowder {
 		if(winner == null)
 			return;
 		surrenderTributeTo = winner.name;
-		surrenderTributeUntil = System.currentTimeMillis() + SURRENDER_TRIBUTE_TIME;
+		surrenderTributeUntil = System.currentTimeMillis() + XFConfig.surrenderTributeDurationMs;
 		save(world);
 	}
 
@@ -1454,7 +1468,7 @@ public class Clowder {
 		Clowder tributeTarget = getSurrenderTributeTarget();
 
 		if(tributeTarget != null) {
-			float tribute = Math.max(0F, isInfrastructureDisabled() ? 0F : prestigeGen) * SURRENDER_TRIBUTE_RATE;
+			float tribute = Math.max(0F, isInfrastructureDisabled() ? 0F : prestigeGen) * XFConfig.surrenderPrestigeTransferPercent;
 			net -= tribute;
 			tributeTarget.addPrestige(tribute, world);
 		} else if(surrenderTributeUntil > 0L && surrenderTributeUntil <= System.currentTimeMillis()) {
@@ -1950,8 +1964,8 @@ public class Clowder {
 		c.motd = "Message of the day!";
 		c.flag = ClowderFlag.TRICOLOR;
 
-		c.prestige = STARTING_PRESTIGE;
-		c.addPrestigeGen(BASE_PRESTIGE_GEN, player.worldObj);
+		c.prestige = XFConfig.startingPrestige;
+		c.addPrestigeGen(XFConfig.basePrestigeGen, player.worldObj);
 
 		clowders.add(c);
 		inverseMap.put(leader, c);

--- a/src/main/java/com/hfr/clowder/ClowderEvents.java
+++ b/src/main/java/com/hfr/clowder/ClowderEvents.java
@@ -17,6 +17,7 @@ import com.hfr.command.CommandClowderChat;
 import com.hfr.command.Mute;
 import com.hfr.command.MuteManager;
 import com.hfr.command.*;
+import com.hfr.config.XFConfig;
 import com.hfr.data.ClowderData;
 import com.hfr.handler.BobbyBreaker;
 import com.hfr.handler.ExplosionSound;
@@ -958,7 +959,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 	@SubscribeEvent
 	public void onPlayerLogin(PlayerLoggedInEvent event) {
 
-		if(!newPlayerProtectionEnabled || event.player == null)
+		if(!XFConfig.enableNewPlayerProtection || !newPlayerProtectionEnabled || event.player == null)
 			return;
 
 		PlayerProtectionData.load();
@@ -974,14 +975,14 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 			long now = System.currentTimeMillis();
 
 			entry = new PlayerProtectionData.ProtectionEntry(
-					now + 4L * 60L * 60L * 1000L,
-					now + 24L * 60L * 60L * 1000L
+					now + XFConfig.pvpGraceDurationMs,
+					now + XFConfig.keepInventoryDurationMs
 			);
 
 			PlayerProtectionData.set(uuid, entry);
 
 			event.player.addChatMessage(new ChatComponentText(
-					CommandClowder.INFO + "New-player protection enabled: 4h PvP grace, 24h keep-inventory."
+					CommandClowder.INFO + "New-player protection enabled: " + (XFConfig.pvpGraceDurationMs / (60L * 60L * 1000L)) + "h PvP grace, " + (XFConfig.keepInventoryDurationMs / (60L * 60L * 1000L)) + "h keep-inventory."
 			));
 		}
 	}
@@ -1000,7 +1001,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 		EntityPlayer attacker = event.source.getEntity() instanceof EntityPlayer ? (EntityPlayer)event.source.getEntity() : null;
 		EntityPlayer victim = e instanceof EntityPlayer ? (EntityPlayer)e : null;
 
-		if(attacker != null && victim != null){
+		if(XFConfig.enableNewPlayerProtection && newPlayerProtectionEnabled && attacker != null && victim != null){
 
 			long now = System.currentTimeMillis();
 

--- a/src/main/java/com/hfr/clowder/ClowderTerritory.java
+++ b/src/main/java/com/hfr/clowder/ClowderTerritory.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import com.hfr.config.XFConfig;
 import com.hfr.data.ClowderData;
 import com.hfr.main.MainRegistry;
 import com.hfr.tileentity.clowder.ITerritoryProvider;
@@ -51,7 +52,7 @@ public class ClowderTerritory {
 			if(meta != null && meta.owner != null && meta.owner.zone == Zone.FACTION && meta.isCityClaim()) {
 				CoordPair other = getCoordPair(meta.flagX, meta.flagZ);
 				double dist = Math.sqrt(Math.pow(chunkX - other.x, 2) + Math.pow(chunkZ - other.z, 2));
-				int required = CityLevel.maxRadius() * 2 + 1;
+				int required = XFConfig.minCitySpacingChunks;
 				if(dist < required)
 					return "City Center is too close to " + meta.cityName + ". City centers must be at least " + required + " chunks apart to make sure claims do not overlap.";
 			}

--- a/src/main/java/com/hfr/clowder/flag/CustomFlagService.java
+++ b/src/main/java/com/hfr/clowder/flag/CustomFlagService.java
@@ -28,6 +28,7 @@ import javax.net.ssl.HttpsURLConnection;
 
 import com.hfr.clowder.Clowder;
 import com.hfr.command.CommandClowder;
+import com.hfr.config.XFConfig;
 import com.hfr.data.ClowderData;
 import com.hfr.main.MainRegistry;
 import com.hfr.packet.PacketDispatcher;
@@ -81,12 +82,16 @@ public class CustomFlagService {
 	public static void importUrl(final EntityPlayerMP player, final Clowder clowder, final String urlText) {
 		final String key = getFactionFileKey(clowder) + ":" + player.getDisplayName();
 		long now = System.currentTimeMillis();
+		if(!XFConfig.enableCustomFactionFlags) {
+			player.addChatMessage(new ChatComponentText(CommandClowder.ERROR + "Custom faction flags are disabled on this server."));
+			return;
+		}
 		Long next = RATE_LIMITS.get(key);
 		if(next != null && next.longValue() > now) {
 			player.addChatMessage(new ChatComponentText(CommandClowder.ERROR + "Please wait before importing another faction flag."));
 			return;
 		}
-		RATE_LIMITS.put(key, Long.valueOf(now + RATE_LIMIT_MS));
+		RATE_LIMITS.put(key, Long.valueOf(now + XFConfig.customFlagRateLimitMs));
 		player.addChatMessage(new ChatComponentText(CommandClowder.INFO + "Importing faction flag from HTTPS. The server will validate and cache it first."));
 
 		EXECUTOR.submit(new Runnable() {
@@ -140,7 +145,8 @@ public class CustomFlagService {
 		try {
 			File file = getFlagFile(clowder);
 			if(!file.exists()) {
-				clowder.customFlagHash = "";
+				if(XFConfig.customFlagReloadMissingClearsMetadata)
+					clowder.customFlagHash = "";
 			} else {
 				clowder.customFlagHash = sha256(readFile(file));
 			}
@@ -181,7 +187,7 @@ public class CustomFlagService {
 		BufferedImage input = ImageIO.read(new ByteArrayInputStream(downloaded));
 		if(input == null)
 			return new ImportResult("failed to decode image", null, null);
-		if(input.getWidth() > MAX_DIMENSION || input.getHeight() > MAX_DIMENSION)
+		if(input.getWidth() > XFConfig.customFlagMaxWidth || input.getHeight() > XFConfig.customFlagMaxHeight)
 			return new ImportResult("image too large", null, null);
 		BufferedImage output = resizeToFlag(input);
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -226,13 +232,13 @@ public class CustomFlagService {
 		if(!(conn instanceof HttpsURLConnection))
 			throw new FlagImportException("invalid URL");
 		conn.setInstanceFollowRedirects(false);
-		conn.setConnectTimeout(TIMEOUT_MS);
-		conn.setReadTimeout(TIMEOUT_MS);
+		conn.setConnectTimeout(XFConfig.customFlagTimeoutMs);
+		conn.setReadTimeout(XFConfig.customFlagTimeoutMs);
 		conn.setRequestProperty("User-Agent", "XenofactionsFlagImporter/1.0");
 		try {
 			int code = conn.getResponseCode();
 			if(code >= 300 && code <= 399) {
-				if(redirects >= MAX_REDIRECTS)
+				if(redirects >= XFConfig.customFlagMaxRedirects)
 					throw new FlagImportException("invalid URL");
 				String location = conn.getHeaderField("Location");
 				if(location == null)
@@ -251,9 +257,9 @@ public class CustomFlagService {
 			if(code < 200 || code >= 300)
 				throw new FlagImportException("invalid URL");
 			int length = conn.getContentLength();
-			if(length > MAX_DOWNLOAD)
+			if(length > XFConfig.customFlagMaxFileSizeBytes)
 				throw new FlagImportException("image too large");
-			return readLimited(conn.getInputStream(), MAX_DOWNLOAD);
+			return readLimited(conn.getInputStream(), XFConfig.customFlagMaxFileSizeBytes);
 		} catch(java.net.SocketTimeoutException e) {
 			throw new FlagImportException("download timed out");
 		} catch(FlagImportException e) {
@@ -271,11 +277,7 @@ public class CustomFlagService {
 		String normalized = host.toLowerCase();
 		if(normalized.endsWith("."))
 			normalized = normalized.substring(0, normalized.length() - 1);
-		for(int i = 0; i < ALLOWED_HOSTS.length; i++) {
-			if(ALLOWED_HOSTS[i].equals(normalized))
-				return true;
-		}
-		return false;
+		return XFConfig.customFlagAllowedHostSet.contains(normalized);
 	}
 
 	private static void validateHost(String host) throws Exception {
@@ -316,11 +318,11 @@ public class CustomFlagService {
 	}
 
 	private static byte[] readFile(File file) throws IOException {
-		if(file.length() > MAX_DOWNLOAD)
+		if(file.length() > XFConfig.customFlagMaxFileSizeBytes)
 			throw new EOFException("flag file too large");
 		FileInputStream in = new FileInputStream(file);
 		try {
-			return readLimited(in, MAX_DOWNLOAD);
+			return readLimited(in, XFConfig.customFlagMaxFileSizeBytes);
 		} finally {
 			in.close();
 		}

--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -11,6 +11,7 @@ import com.hfr.clowder.Clowder;
 import com.hfr.clowder.Clowder.ScheduledTeleport;
 import com.hfr.clowder.ClowderFlag;
 import com.hfr.clowder.flag.CustomFlagService;
+import com.hfr.config.XFConfig;
 import com.hfr.clowder.CityLevel;
 import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.Ownership;
@@ -374,11 +375,12 @@ public class CommandClowder extends CommandBase {
 		Clowder clowder = Clowder.getClowderFromPlayer(player);
 		if(clowder == null) { sender.addChatMessage(new ChatComponentText(ERROR + "You are not in any faction!")); return; }
 		if(clowder.getPermLevel(player.getDisplayName()) <= 2) { sender.addChatMessage(new ChatComponentText(ERROR + "Only faction leaders can activate build grace!")); return; }
-		if(clowder.buildGraceUsed) { sender.addChatMessage(new ChatComponentText(ERROR + "This faction already used build grace.")); return; }
+		if(!XFConfig.graceBuildEnabled) { sender.addChatMessage(new ChatComponentText(ERROR + "Build grace is disabled on this server.")); return; }
+		if(XFConfig.graceBuildOneTimeUse && clowder.buildGraceUsed) { sender.addChatMessage(new ChatComponentText(ERROR + "This faction already used build grace.")); return; }
 		if(!clowder.activeWars.isEmpty()) { sender.addChatMessage(new ChatComponentText(ERROR + "Cannot activate while in active war.")); return; }
 		clowder.buildGraceUsed = true;
-		clowder.buildGraceUntil = System.currentTimeMillis() + 48L * 60L * 60L * 1000L;
-		clowder.notifyAll(player.worldObj, new ChatComponentText(INFO + "Build grace activated for 48 hours."));
+		clowder.buildGraceUntil = System.currentTimeMillis() + XFConfig.graceBuildDurationMs;
+		clowder.notifyAll(player.worldObj, new ChatComponentText(INFO + "Build grace activated for " + (XFConfig.graceBuildDurationMs / (60L * 60L * 1000L)) + " hours."));
 		clowder.save(player.worldObj);
 	}
 private void cmdCreate(ICommandSender sender, String name) {
@@ -693,7 +695,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 							formerFriend.notifyAll(player.worldObj, new ChatComponentText(INFO + clowder.name + " has cancelled our alliance!"));
 							clowder.removeAlly(player.worldObj, kickee);
 							formerFriend.removeAlly(player.worldObj, clowder.name);
-							long until = System.currentTimeMillis() + 24L * 60L * 60L * 1000L;
+							long until = System.currentTimeMillis() + XFConfig.allianceBreakCooldownMs;
 							clowder.formerAllyNoWarUntil.put(formerFriend.name, until);
 							formerFriend.formerAllyNoWarUntil.put(clowder.name, until);
 							// modid instead of modname
@@ -765,7 +767,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 			sender.addChatMessage(new ChatComponentText(LIST + "Cities: " + ClowderTerritory.getCityClaims(clowder).size()));
 			for(Object cityObj : ClowderTerritory.getCityClaims(clowder)) {
 				TerritoryMeta city = (TerritoryMeta)cityObj;
-				sender.addChatMessage(new ChatComponentText(LIST + " - " + city.cityName + " [" + city.getCityLevel().displayName + "] center X:" + city.flagX + " Y:" + city.flagY + " Z:" + city.flagZ + " radius " + city.getCityLevel().radius + " upkeep " + city.getCityLevel().upkeep));
+				sender.addChatMessage(new ChatComponentText(LIST + " - " + city.cityName + " [" + city.getCityLevel().displayName + "] center X:" + city.flagX + " Y:" + city.flagY + " Z:" + city.flagZ + " radius " + city.getCityLevel().configuredRadius() + " upkeep " + city.getCityLevel().configuredUpkeep()));
 			}
 
 		} else {
@@ -789,7 +791,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 			sender.addChatMessage(new ChatComponentText(LIST + "Cities: " + ClowderTerritory.getCityClaims(clowder).size()));
 			for(Object cityObj : ClowderTerritory.getCityClaims(clowder)) {
 				TerritoryMeta city = (TerritoryMeta)cityObj;
-				sender.addChatMessage(new ChatComponentText(LIST + " - " + city.cityName + " [" + city.getCityLevel().displayName + "] center X:" + city.flagX + " Y:" + city.flagY + " Z:" + city.flagZ + " radius " + city.getCityLevel().radius + " upkeep " + city.getCityLevel().upkeep));
+				sender.addChatMessage(new ChatComponentText(LIST + " - " + city.cityName + " [" + city.getCityLevel().displayName + "] center X:" + city.flagX + " Y:" + city.flagY + " Z:" + city.flagZ + " radius " + city.getCityLevel().configuredRadius() + " upkeep " + city.getCityLevel().configuredUpkeep()));
 			}
 
 		} else {
@@ -1103,11 +1105,12 @@ private void cmdCreate(ICommandSender sender, String name) {
 					if(args.length < 3) { sender.addChatMessage(new ChatComponentText(ERROR + "Invalid format. Usage: /c flag seturl <https://i.postimg.cc/...>")); return; }
 					// Clients must never load arbitrary remote URLs directly. The server imports, validates, strips metadata,
 					// caches and syncs sanitized PNG bytes so malicious URLs cannot target every client.
+					if(!XFConfig.enableCustomFactionFlags) { sender.addChatMessage(new ChatComponentText(ERROR + "Custom faction flags are disabled on this server.")); return; }
 					CustomFlagService.importUrl((EntityPlayerMP)player, clowder, args[2]);
 					return;
 				}
-				if(flag.equalsIgnoreCase("clear")) { CustomFlagService.clearFlag((EntityPlayerMP)player, clowder); return; }
-				if(flag.equalsIgnoreCase("reload")) { CustomFlagService.reloadFlag((EntityPlayerMP)player, clowder); return; }
+				if(flag.equalsIgnoreCase("clear")) { if(!XFConfig.enableCustomFactionFlags) { sender.addChatMessage(new ChatComponentText(ERROR + "Custom faction flags are disabled on this server.")); return; } CustomFlagService.clearFlag((EntityPlayerMP)player, clowder); return; }
+				if(flag.equalsIgnoreCase("reload")) { if(!XFConfig.enableCustomFactionFlags) { sender.addChatMessage(new ChatComponentText(ERROR + "Custom faction flags are disabled on this server.")); return; } CustomFlagService.reloadFlag((EntityPlayerMP)player, clowder); return; }
 
 				ClowderFlag f = ClowderFlag.getFromName(flag.toLowerCase());
 
@@ -1339,8 +1342,8 @@ private void cmdCreate(ICommandSender sender, String name) {
 				return;
 			}
 
-			if(clowder.getPrestige() < MainRegistry.warpCost) {
-				sender.addChatMessage(new ChatComponentText(ERROR + "You need at least " + MainRegistry.warpCost + " prestige to create a warp!"));
+			if(clowder.getPrestige() < XFConfig.warpCost) {
+				sender.addChatMessage(new ChatComponentText(ERROR + "You need at least " + Clowder.round(XFConfig.warpCost) + " prestige to create a warp!"));
 				return;
 			}
 
@@ -1348,7 +1351,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 
 			if(code == 0) {
 				clowder.notifyAll(player.worldObj, new ChatComponentText(INFO + "Created warp " + name + "!"));
-				clowder.addPrestige(-MainRegistry.warpCost, player.worldObj);
+				clowder.addPrestige(-XFConfig.warpCost, player.worldObj);
 				clowder.save(player.worldObj);
 			} else if(code == 1) {
 				sender.addChatMessage(new ChatComponentText(ERROR + "Cannot create warp outside of your territory!"));
@@ -1650,7 +1653,11 @@ private void cmdCreate(ICommandSender sender, String name) {
 			return;
 		}
 		cityName = cityName.trim();
-		if(!ClowderTerritory.isCityNameAvailable(cityName, null)) {
+		if(cityName.length() < XFConfig.claimNameMinLength || cityName.length() > XFConfig.claimNameMaxLength) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "City names must be " + XFConfig.claimNameMinLength + "-" + XFConfig.claimNameMaxLength + " characters."));
+			return;
+		}
+		if(XFConfig.claimNameRequireUnique && !ClowderTerritory.isCityNameAvailable(cityName, null)) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "A city named " + cityName + " already exists."));
 			return;
 		}
@@ -1658,7 +1665,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 		if(clowder != null) {
 
 			float foundingCost = clowder.getCityFoundingCost();
-			float foundingUpkeep = CityLevel.SETTLEMENT.upkeep;
+			float foundingUpkeep = XFConfig.cityUpkeep(CityLevel.SETTLEMENT);
 			if(clowder.getPrestige() < foundingCost || clowder.getPrestigeReq() + foundingUpkeep > clowder.getPrestige() - foundingCost) {
 				sender.addChatMessage(new ChatComponentText(ERROR + "Founding a City Center requires " + foundingCost + " prestige and " + foundingUpkeep + " upkeep capacity."));
 				return;
@@ -1714,16 +1721,16 @@ private void cmdCreate(ICommandSender sender, String name) {
 		long now = System.currentTimeMillis();
 		if(confirmUntil == null || confirmUntil < now) {
 			CITY_UPGRADE_CONFIRMATIONS.put(confirmKey, now + 10000L);
-			sender.addChatMessage(new ChatComponentText(INFO + "Upgrade " + city.name + " to " + next.displayName + " for " + next.upgradeCost + " prestige."));
-			sender.addChatMessage(new ChatComponentText(INFO + "New city level will be " + next.level() + " with radius " + next.radius + " and " + next.upkeep + " upkeep. Run /c city upgrade again within 10 seconds to confirm."));
+			sender.addChatMessage(new ChatComponentText(INFO + "Upgrade " + city.name + " to " + next.displayName + " for " + next.configuredUpgradeCost() + " prestige."));
+			sender.addChatMessage(new ChatComponentText(INFO + "New city level will be " + next.level() + " with radius " + next.configuredRadius() + " and " + next.configuredUpkeep() + " upkeep. Run /c city upgrade again within 10 seconds to confirm."));
 			return;
 		}
 
 		CITY_UPGRADE_CONFIRMATIONS.remove(confirmKey);
 		if(city.upgradeCity())
-			sender.addChatMessage(new ChatComponentText(INFO + city.name + " upgraded to " + city.cityLevel.displayName + " (level " + city.cityLevel.level() + ", radius " + city.cityLevel.radius + ", upkeep " + city.cityLevel.upkeep + ")."));
+			sender.addChatMessage(new ChatComponentText(INFO + city.name + " upgraded to " + city.cityLevel.displayName + " (level " + city.cityLevel.level() + ", radius " + city.cityLevel.configuredRadius() + ", upkeep " + city.cityLevel.configuredUpkeep() + ")."));
 		else
-			sender.addChatMessage(new ChatComponentText(ERROR + "Upgrade requires " + next.upgradeCost + " prestige and sequential upkeep capacity."));
+			sender.addChatMessage(new ChatComponentText(ERROR + "Upgrade requires " + next.configuredUpgradeCost() + " prestige and sequential upkeep capacity."));
 	}
 
 	//I have no idea how territories work, but it looks retarded
@@ -1811,7 +1818,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 			return;
 		}
 
-		if(clowder.getPermLevel(player.getDisplayName()) < 2) {
+		if(clowder.getPermLevel(player.getDisplayName()) < (XFConfig.claimRenameOfficersAllowed ? 2 : 3)) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "You lack the permissions to rename cities!"));
 			return;
 		}
@@ -1833,6 +1840,10 @@ private void cmdCreate(ICommandSender sender, String name) {
 			return;
 		}
 		name = name.trim();
+		if(name.length() < XFConfig.claimNameMinLength || name.length() > XFConfig.claimNameMaxLength) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Claim names must be " + XFConfig.claimNameMinLength + "-" + XFConfig.claimNameMaxLength + " characters."));
+			return;
+		}
 
 		TileEntity tile = player.worldObj.getTileEntity(meta.flagX, meta.flagY, meta.flagZ);
 
@@ -1841,7 +1852,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 			return;
 		}
 
-		if(!ClowderTerritory.isCityNameAvailable(name, meta)) {
+		if(XFConfig.claimNameRequireUnique && !ClowderTerritory.isCityNameAvailable(name, meta)) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "A city named " + name + " already exists."));
 			return;
 		}
@@ -1865,11 +1876,11 @@ private void cmdCreate(ICommandSender sender, String name) {
 		Clowder target = Clowder.getClowderFromName(targetName);
 		if (me == null || target == null || me == target) return;
 		if (me.getPermLevel(player.getDisplayName()) < 3) return;
-		if(!(CommandClowderAdmin.LEGACY_WAR_ENABLED || CommandClowderAdmin.WAR_ONLINE_CHECK_DISABLED) && target.getOnlineMemberCount() < 2 && !Clowder.forceOnline) {
-			sender.addChatMessage(new ChatComponentText(ERROR + "You can only declare war on factions that are currently online (2+ members)."));
+		if(!(CommandClowderAdmin.LEGACY_WAR_ENABLED || CommandClowderAdmin.WAR_ONLINE_CHECK_DISABLED) && target.getOnlineMemberCount() < XFConfig.warOnlinePlayerThreshold && !Clowder.forceOnline) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "You can only declare war on factions that are currently online (" + XFConfig.warOnlinePlayerThreshold + "+ members)."));
 			return;
 		}
-		if (me.allies.containsKey(target)) {
+		if (!XFConfig.alliesCanDeclareWarOnEachOther && me.allies.containsKey(target)) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "You can not declare war on an ally."));
 			return;
 		}
@@ -1886,7 +1897,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 		}
 		float declarationCost = me.getWarDeclarationCost(target);
 		me.addPrestige(-declarationCost, player.worldObj);
-		sender.addChatMessage(new ChatComponentText(CRITICAL + "Declaring war on " + target.name + " cost " + Clowder.round(declarationCost) + " prestige. War upkeep starts at " + Clowder.WAR_UPKEEP + " prestige per hour and rises every hour."));
+		sender.addChatMessage(new ChatComponentText(CRITICAL + "Declaring war on " + target.name + " cost " + Clowder.round(declarationCost) + " prestige. War upkeep starts at " + Clowder.round(XFConfig.activeWarUpkeep) + " prestige per hour and rises every hour."));
 		me.activeWars.add(target.name);
 		target.activeWars.add(me.name);
 		me.warDeclaredAt.put(target.name, now);
@@ -1908,6 +1919,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 		if (me.getPermLevel(player.getDisplayName()) < 3) return;
 		me.peaceRequests.add(target.name);
 		if(transferCity != null && !transferCity.trim().isEmpty()) {
+			if(!XFConfig.peaceCityTransfersEnabled) { sender.addChatMessage(new ChatComponentText(ERROR + "Peace city transfers are disabled on this server.")); return; }
 			TerritoryMeta city = ClowderTerritory.getCityByName(me, transferCity.trim());
 			if(city == null) {
 				sender.addChatMessage(new ChatComponentText(ERROR + "Unknown city: " + transferCity));
@@ -1935,6 +1947,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 		for(Object requestObj : new ArrayList(target.peaceRequests)) {
 			String request = (String)requestObj;
 			if(request.startsWith(prefix)) {
+				if(!XFConfig.peaceCityTransfersEnabled) { target.peaceRequests.remove(request); continue; }
 				String cityName = request.substring(prefix.length());
 				TerritoryMeta city = ClowderTerritory.getCityByName(target, cityName);
 				if(city != null) {
@@ -1946,7 +1959,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 		}
 		me.clearWarStateWith(target); target.clearWarStateWith(me);
 		if(!CommandClowderAdmin.WAR_COOLDOWNS_DISABLED) {
-			long until = System.currentTimeMillis() + 84L * 60L * 60L * 1000L;
+			long until = System.currentTimeMillis() + XFConfig.peaceCooldownMs;
 			me.noWarUntil.put(target.name, until); target.noWarUntil.put(me.name, until);
 		}
 		MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(EnumChatFormatting.GREEN + "[WAR] " + me.name + " and " + target.name + " have agreed to peace."));
@@ -1977,7 +1990,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 		target.ceasefireRequests.remove(me.name);
 		me.clearWarStateWith(target); target.clearWarStateWith(me);
 		if(!CommandClowderAdmin.WAR_COOLDOWNS_DISABLED) {
-			long until = System.currentTimeMillis() + 24L * 60L * 60L * 1000L;
+			long until = System.currentTimeMillis() + XFConfig.ceasefireCooldownMs;
 			me.noWarUntil.put(target.name, until); target.noWarUntil.put(me.name, until);
 		}
 	}
@@ -2005,20 +2018,23 @@ private void cmdCreate(ICommandSender sender, String name) {
 		if (me == null || target == null || me == target || me.getPermLevel(player.getDisplayName()) < 3) return;
 		if(!target.surrenderRequests.contains(me.name)) return;
 		target.surrenderRequests.remove(me.name);
-		for(Object cityObj : ClowderTerritory.getCityClaims(target)) {
-			TerritoryMeta city = (TerritoryMeta)cityObj;
-			ClowderTerritory.transferCity(player.worldObj, city, me);
+		if(XFConfig.surrenderTransfersCities) {
+			for(Object cityObj : ClowderTerritory.getCityClaims(target)) {
+				TerritoryMeta city = (TerritoryMeta)cityObj;
+				ClowderTerritory.transferCity(player.worldObj, city, me);
+			}
 		}
 		target.beginSurrenderTribute(me, player.worldObj);
 		me.clearWarStateWith(target); target.clearWarStateWith(me);
 		if(!CommandClowderAdmin.WAR_COOLDOWNS_DISABLED) {
-			long until = System.currentTimeMillis() + 84L * 60L * 60L * 1000L;
+			long until = System.currentTimeMillis() + XFConfig.surrenderCooldownMs;
 			me.noWarUntil.put(target.name, until); target.noWarUntil.put(me.name, until);
 		}
-		MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(EnumChatFormatting.GREEN + "[WAR] " + me.name + " accepted " + target.name + "'s surrender. " + target.name + " will pay 50% of prestige generation to " + me.name + " for 84 hours."));
+		MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(EnumChatFormatting.GREEN + "[WAR] " + me.name + " accepted " + target.name + "'s surrender. " + target.name + " will pay " + Math.round(XFConfig.surrenderPrestigeTransferPercent * 100F) + "% of prestige generation to " + me.name + " for " + (XFConfig.surrenderTributeDurationMs / (60L * 60L * 1000L)) + " hours."));
 	}
 
 	private void cmdDefendAlly(ICommandSender sender, String allyName) {
+		if(!XFConfig.alliesCanJoinWars) { sender.addChatMessage(new ChatComponentText(ERROR + "Allies joining wars is disabled on this server.")); return; }
 		EntityPlayer player = getCommandSenderAsPlayer(sender);
 		Clowder me = Clowder.getClowderFromPlayer(player);
 		Clowder ally = Clowder.getClowderFromName(allyName);

--- a/src/main/java/com/hfr/command/CommandClowderAdmin.java
+++ b/src/main/java/com/hfr/command/CommandClowderAdmin.java
@@ -10,6 +10,7 @@ import com.hfr.clowder.ClowderTerritory.CoordPair;
 import com.hfr.clowder.ClowderTerritory.Zone;
 import com.hfr.clowder.ClowderEvents;
 import com.hfr.clowder.PlayerProtectionData;
+import com.hfr.config.XFConfig;
 import com.hfr.data.ClowderData;
 import com.hfr.packet.PacketDispatcher;
 import com.hfr.packet.effect.ClowderFlagPacket;
@@ -135,7 +136,7 @@ public class CommandClowderAdmin extends CommandBase {
 			return;
 		}
 
-		if(cmd.equals("newplayerprotection")) { ClowderEvents.newPlayerProtectionEnabled = !ClowderEvents.newPlayerProtectionEnabled; sender.addChatMessage(new ChatComponentText(INFO + "New player protection is now " + (ClowderEvents.newPlayerProtectionEnabled ? "enabled" : "disabled") + ".")); return; }
+		if(cmd.equals("newplayerprotection")) { if(!XFConfig.enableNewPlayerProtection) { sender.addChatMessage(new ChatComponentText(ERROR + "New-player protection module is disabled in the config.")); return; } ClowderEvents.newPlayerProtectionEnabled = !ClowderEvents.newPlayerProtectionEnabled; sender.addChatMessage(new ChatComponentText(INFO + "New player protection is now " + (ClowderEvents.newPlayerProtectionEnabled ? "enabled" : "disabled") + ".")); return; }
 		if(cmd.equals("resetnewplayerprotection")) { cmdResetNewPlayerProtection(sender); return; }
 		if(cmd.equals("endnewplayerprotection")) { cmdEndNewPlayerProtection(sender); return; }
 		if(cmd.equals("skipwarcooldowns")) { WAR_COOLDOWNS_DISABLED = !WAR_COOLDOWNS_DISABLED; sender.addChatMessage(new ChatComponentText(INFO + "War cooldown skipping is now " + (WAR_COOLDOWNS_DISABLED ? "ENABLED" : "DISABLED") + ".")); return; }
@@ -525,8 +526,8 @@ public class CommandClowderAdmin extends CommandBase {
 
 		for(PlayerProtectionData.ProtectionEntry entry : PlayerProtectionData.getAll().values()) {
 
-			entry.pvpGraceUntil = now + 4L * 60L * 60L * 1000L;
-			entry.keepInvUntil = now + 24L * 60L * 60L * 1000L;
+			entry.pvpGraceUntil = now + XFConfig.pvpGraceDurationMs;
+			entry.keepInvUntil = now + XFConfig.keepInventoryDurationMs;
 		}
 
 		PlayerProtectionData.save();

--- a/src/main/java/com/hfr/command/CommandXFlags.java
+++ b/src/main/java/com/hfr/command/CommandXFlags.java
@@ -1,6 +1,7 @@
 package com.hfr.command;
 
 import com.hfr.blocks.ModBlocks;
+import com.hfr.config.XFConfig;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -34,7 +35,7 @@ public class CommandXFlags extends CommandBase {
 
     @Override
     public void processCommand(ICommandSender sender, String[] args) {
-        if (sender instanceof EntityPlayerMP && CommandClowderAdmin.WARENABLED ) { // declaration system enabled
+        if (sender instanceof EntityPlayerMP && XFConfig.enableConquestFlagsCommand && CommandClowderAdmin.WARENABLED ) { // declaration system enabled
             EntityPlayerMP player = (EntityPlayerMP) sender;
             ItemStack map = new ItemStack(ModBlocks.clowder_conquerer, 64);
             player.inventory.addItemStackToInventory(map);

--- a/src/main/java/com/hfr/config/XFConfig.java
+++ b/src/main/java/com/hfr/config/XFConfig.java
@@ -1,0 +1,250 @@
+package com.hfr.config;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.hfr.clowder.CityLevel;
+import com.hfr.command.CommandClowderAdmin;
+import com.hfr.main.MainRegistry;
+
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.common.config.Property;
+
+/**
+ * Central server-owner configuration for Xenofactions gameplay systems.
+ *
+ * Defaults intentionally mirror the pre-2.1 hardcoded values so existing worlds keep behaving the same
+ * until a server owner opts into changes.
+ */
+public final class XFConfig {
+
+	private XFConfig() { }
+
+	public static boolean enableDynmapIntegration = true;
+	public static boolean enableTDM = true;
+	public static boolean enableCustomFactionFlags = true;
+	public static boolean enableNewPlayerProtection = false;
+	public static boolean enableConquestFlagsCommand = true;
+	public static boolean warEnabledDefault = false;
+
+	public static float startingPrestige = 250F;
+	public static float basePrestigeGen = 25F;
+	public static float prestigeGenCap = 2500F;
+	public static float warpCost = 125F;
+	public static float warpTentUpkeep = 75F;
+	public static float medTentUpkeep = 5F;
+	public static float blastFurnacePrestige = 5F;
+	public static float grainmillPrestige = 3F;
+	public static float universityPrestige = 60F;
+	public static float federalReservePrestige = 30F;
+	public static float templePrestige = 90F;
+	public static float statuePrestige = 15F;
+	public static float cityCenterPrestige = 0F;
+	public static float claimFlagUpkeep = 1F;
+	public static float cityClaimUpkeep = 10F;
+	public static float warDeclarationBaseCost = 150F;
+	public static float warDeclarationTargetPrestigeFactor = 0.15F;
+	public static float activeWarUpkeep = 75F;
+	public static float warUpkeepHourlyGrowth = 0.25F;
+	public static float warUpkeepHourlyGrowthSquared = 0.05F;
+	public static float surrenderPrestigeTransferPercent = 0.50F;
+	public static long surrenderTributeDurationMs = 84L * 60L * 60L * 1000L;
+	public static boolean enableNegativePrestigePenalties = true;
+	public static float financialCrisisThreshold = 0F;
+	public static float nationalCollapseThreshold = -500F;
+	public static float fallenNationThreshold = -1000F;
+	public static float financialCrisisUpkeepMult = 1.25F;
+	public static float nationalCollapseUpkeepMult = 1.50F;
+	public static float fallenNationUpkeepMult = 2.00F;
+
+	public static int maxCityRadius = 6;
+	public static int minCitySpacingChunks = 13;
+	public static int claimNameMinLength = 1;
+	public static int claimNameMaxLength = 32;
+	public static boolean claimNameRequireUnique = true;
+	public static boolean claimRenameOfficersAllowed = true;
+	public static boolean peaceCityTransfersEnabled = true;
+	public static boolean surrenderTransfersCities = true;
+	public static int[] cityRadii = new int[] { 2, 3, 4, 5, 6 };
+	public static float[] cityUpgradeCosts = new float[] { 75F, 150F, 300F, 600F, 1000F };
+	public static float[] cityUpkeep = new float[] { 10F, 25F, 50F, 90F, 140F };
+	public static float cityFoundingCostGrowth = 0.50F;
+
+	public static int warOnlinePlayerThreshold = 2;
+	public static long raidGraceAfterOnlineDropMs = 30L * 60L * 1000L;
+	public static long surrenderCooldownMs = 84L * 60L * 60L * 1000L;
+	public static long peaceCooldownMs = 84L * 60L * 60L * 1000L;
+	public static long ceasefireCooldownMs = 24L * 60L * 60L * 1000L;
+	public static long allianceBreakCooldownMs = 24L * 60L * 60L * 1000L;
+	public static boolean alliesCanJoinWars = true;
+	public static boolean alliesCanDeclareWarOnEachOther = false;
+
+	public static long pvpGraceDurationMs = 4L * 60L * 60L * 1000L;
+	public static long keepInventoryDurationMs = 24L * 60L * 60L * 1000L;
+	public static boolean graceBuildEnabled = true;
+	public static boolean graceBuildOneTimeUse = true;
+	public static long graceBuildDurationMs = 48L * 60L * 60L * 1000L;
+
+	public static String[] customFlagAllowedHosts = new String[] { "postimages.org", "i.postimg.cc" };
+	public static Set<String> customFlagAllowedHostSet = new HashSet<String>();
+	public static int customFlagMaxWidth = 1024;
+	public static int customFlagMaxHeight = 1024;
+	public static int customFlagMaxFileSizeBytes = 1024 * 1024;
+	public static int customFlagTimeoutMs = 5000;
+	public static int customFlagMaxRedirects = 3;
+	public static long customFlagRateLimitMs = 60000L;
+	public static boolean customFlagReloadMissingClearsMetadata = true;
+
+	public static String dynmapMarkerSetId = "xenofactions_cities";
+	public static String dynmapMarkerSetLabel = "Faction Cities";
+	public static int dynmapUpdateIntervalTicks = 20 * 30;
+	public static double dynmapClaimFillOpacity = 0.18D;
+	public static double dynmapBorderLineOpacity = 0.9D;
+	public static int dynmapBorderLineWeight = 3;
+	public static double dynmapClaimLineOpacity = 0.0D;
+	public static int dynmapClaimLineWeight = 0;
+	public static boolean dynmapShowCityCenterMarkers = true;
+	public static boolean dynmapShowClaimDetails = true;
+	public static boolean dynmapShowPrestigeDetails = true;
+
+	public static void load(Configuration config) {
+		String modules = "XENOFACTIONS_MODULES";
+		enableDynmapIntegration = bool(config, modules, "enableDynmapIntegration", enableDynmapIntegration, "Enables optional Dynmap markers. Safe no-op when Dynmap is absent.");
+		enableTDM = bool(config, modules, "enableTDM", enableTDM, "Enables Xenofactions TDM commands and event hooks.");
+		enableCustomFactionFlags = bool(config, modules, "enableCustomFactionFlags", enableCustomFactionFlags, "Enables imported custom faction flags via /c flag seturl.");
+		enableNewPlayerProtection = bool(config, modules, "enableNewPlayerProtection", enableNewPlayerProtection, "Enables starter PvP/keep-inventory protection for first-time players.");
+		enableConquestFlagsCommand = bool(config, modules, "enableConquestFlagsCommand", enableConquestFlagsCommand, "Enables the /xflags command that grants conquest flags while wars are enabled.");
+
+		String econ = "XENOFACTIONS_PRESTIGE_ECONOMY";
+		startingPrestige = flt(config, econ, "startingPrestige", startingPrestige, 0F, 1000000F, "Prestige granted to newly-created factions.");
+		basePrestigeGen = flt(config, econ, "basePrestigeGeneration", basePrestigeGen, 0F, 100000F, "Base hourly prestige generation for factions.");
+		prestigeGenCap = flt(config, econ, "prestigeGenerationCap", prestigeGenCap, 0F, 1000000F, "Maximum hourly prestige generation counted for a faction.");
+		warpCost = flt(config, econ, "warpCreationCost", warpCost, 0F, 100000F, "Prestige cost to create a faction warp.");
+		warpTentUpkeep = flt(config, econ, "warpTentUpkeep", warpTentUpkeep, 0F, 100000F, "Hourly prestige upkeep consumed by warp tents.");
+		medTentUpkeep = flt(config, econ, "medicalTentUpkeep", medTentUpkeep, 0F, 100000F, "Hourly prestige upkeep consumed by medical tents.");
+		blastFurnacePrestige = flt(config, econ, "blastFurnacePrestigeGeneration", blastFurnacePrestige, 0F, 100000F, "Hourly prestige generated by blast furnaces.");
+		grainmillPrestige = flt(config, econ, "grainmillPrestigeGeneration", grainmillPrestige, 0F, 100000F, "Hourly prestige generated by grainmills.");
+		universityPrestige = flt(config, econ, "universityPrestigeGeneration", universityPrestige, 0F, 100000F, "Hourly prestige generated by universities.");
+		federalReservePrestige = flt(config, econ, "federalReservePrestigeGeneration", federalReservePrestige, 0F, 100000F, "Hourly prestige generated by federal reserves.");
+		templePrestige = flt(config, econ, "templePrestigeGeneration", templePrestige, 0F, 100000F, "Hourly prestige generated by temples.");
+		statuePrestige = flt(config, econ, "statuePrestigeGeneration", statuePrestige, 0F, 100000F, "Hourly prestige generated by statues.");
+		cityCenterPrestige = flt(config, econ, "cityCenterPrestigeGeneration", cityCenterPrestige, 0F, 100000F, "Hourly prestige generated by city centers.");
+		claimFlagUpkeep = flt(config, econ, "claimFlagUpkeep", claimFlagUpkeep, 0F, 100000F, "Hourly upkeep per legacy conquest claim flag cost unit.");
+		cityClaimUpkeep = flt(config, econ, "settlementCityUpkeep", cityClaimUpkeep, 0F, 100000F, "Hourly upkeep for settlement city centers; per-level values are in the claims category.");
+		warDeclarationBaseCost = flt(config, econ, "warDeclarationBaseCost", warDeclarationBaseCost, 0F, 1000000F, "Base prestige cost to declare war.");
+		warDeclarationTargetPrestigeFactor = flt(config, econ, "warDeclarationTargetPrestigeFactor", warDeclarationTargetPrestigeFactor, 0F, 10F, "Extra war declaration cost as a fraction of target prestige.");
+		activeWarUpkeep = flt(config, econ, "activeWarUpkeep", activeWarUpkeep, 0F, 1000000F, "Starting hourly prestige upkeep per active war.");
+		warUpkeepHourlyGrowth = flt(config, econ, "warUpkeepHourlyGrowth", warUpkeepHourlyGrowth, 0F, 100F, "Linear hourly growth multiplier for active war upkeep.");
+		warUpkeepHourlyGrowthSquared = flt(config, econ, "warUpkeepHourlyGrowthSquared", warUpkeepHourlyGrowthSquared, 0F, 100F, "Quadratic hourly growth multiplier for active war upkeep.");
+		surrenderPrestigeTransferPercent = flt(config, econ, "surrenderPrestigeTransferPercent", surrenderPrestigeTransferPercent, 0F, 1F, "Fraction of surrendered faction generation paid as tribute.");
+		surrenderTributeDurationMs = hours(config, econ, "surrenderTributeDurationHours", 84D, 0D, 24D * 365D, "Duration of surrender tribute in hours.");
+		enableNegativePrestigePenalties = bool(config, econ, "enableNegativePrestigePenalties", enableNegativePrestigePenalties, "Enables bankruptcy/collapse/fallen-nation penalties.");
+		financialCrisisThreshold = flt(config, econ, "financialCrisisThreshold", financialCrisisThreshold, -1000000F, 1000000F, "Prestige threshold for Financial Crisis.");
+		nationalCollapseThreshold = flt(config, econ, "nationalCollapseThreshold", nationalCollapseThreshold, -1000000F, 1000000F, "Prestige threshold for National Collapse.");
+		fallenNationThreshold = flt(config, econ, "fallenNationThreshold", fallenNationThreshold, -1000000F, 1000000F, "Prestige threshold for Fallen Nation.");
+		financialCrisisUpkeepMult = flt(config, econ, "financialCrisisUpkeepMultiplier", financialCrisisUpkeepMult, 0F, 100F, "Upkeep multiplier during Financial Crisis.");
+		nationalCollapseUpkeepMult = flt(config, econ, "nationalCollapseUpkeepMultiplier", nationalCollapseUpkeepMult, 0F, 100F, "Upkeep multiplier during National Collapse.");
+		fallenNationUpkeepMult = flt(config, econ, "fallenNationUpkeepMultiplier", fallenNationUpkeepMult, 0F, 100F, "Upkeep multiplier during Fallen Nation.");
+
+		String claims = "XENOFACTIONS_CLAIMS_CITIES";
+		maxCityRadius = integer(config, claims, "maxCityRadius", maxCityRadius, 1, 32, "Maximum city radius in chunks. Existing claims are not deleted when lowered.");
+		minCitySpacingChunks = integer(config, claims, "minimumCitySpacingChunks", minCitySpacingChunks, 0, 128, "Minimum chunk distance between city centers to prevent overlap.");
+		claimNameMinLength = integer(config, claims, "claimNameMinLength", claimNameMinLength, 1, 64, "Minimum city/claim name length.");
+		claimNameMaxLength = integer(config, claims, "claimNameMaxLength", claimNameMaxLength, claimNameMinLength, 64, "Maximum city/claim name length.");
+		claimNameRequireUnique = bool(config, claims, "claimNameRequireUnique", claimNameRequireUnique, "Requires city names to be unique server-wide.");
+		claimRenameOfficersAllowed = bool(config, claims, "claimRenameOfficersAllowed", claimRenameOfficersAllowed, "Allows officers to rename city claims; false restricts to leaders/admins.");
+		peaceCityTransfersEnabled = bool(config, claims, "peaceCityTransfersEnabled", peaceCityTransfersEnabled, "Allows peace offers to include a city transfer.");
+		surrenderTransfersCities = bool(config, claims, "surrenderTransfersCities", surrenderTransfersCities, "Transfers all loser cities to victor when surrender is accepted.");
+		cityFoundingCostGrowth = flt(config, claims, "cityFoundingCostGrowth", cityFoundingCostGrowth, 0F, 100F, "Additional settlement founding cost per previously-founded city.");
+		cityRadii = intList(config, claims, "cityRadii", cityRadii, 1, maxCityRadius, "City radii by level: settlement,town,city,metropolis,capital.");
+		cityUpgradeCosts = floatList(config, claims, "cityUpgradeCosts", cityUpgradeCosts, 0F, 1000000F, "City upgrade/founding prestige costs by level.");
+		cityUpkeep = floatList(config, claims, "cityUpkeep", cityUpkeep, 0F, 1000000F, "Hourly city upkeep by level.");
+
+		String war = "XENOFACTIONS_WAR_DIPLOMACY";
+		warEnabledDefault = bool(config, war, "warEnabledDefault", warEnabledDefault, "Whether war declarations start enabled after server boot.");
+		warOnlinePlayerThreshold = integer(config, war, "onlinePlayerThreshold", warOnlinePlayerThreshold, 0, 100, "Online target faction members required for war/raid eligibility.");
+		raidGraceAfterOnlineDropMs = minutes(config, war, "raidGraceAfterOnlineDropMinutes", 30D, 0D, 24D * 60D, "How long a faction remains raidable after dropping below the online threshold.");
+		surrenderCooldownMs = hours(config, war, "surrenderCooldownHours", 84D, 0D, 24D * 365D, "No-war cooldown after accepted surrender.");
+		peaceCooldownMs = hours(config, war, "peaceCooldownHours", 84D, 0D, 24D * 365D, "No-war cooldown after accepted peace.");
+		ceasefireCooldownMs = hours(config, war, "ceasefireCooldownHours", 24D, 0D, 24D * 365D, "No-war cooldown after accepted ceasefire.");
+		allianceBreakCooldownMs = hours(config, war, "allianceBreakCooldownHours", 24D, 0D, 24D * 365D, "No-war cooldown after breaking an alliance.");
+		alliesCanJoinWars = bool(config, war, "alliesCanJoinWars", alliesCanJoinWars, "Allows /c defendally to join active wars for allies.");
+		alliesCanDeclareWarOnEachOther = bool(config, war, "alliesCanDeclareWarOnEachOther", alliesCanDeclareWarOnEachOther, "Allows allied factions to declare war on each other. Default false.");
+
+		String prot = "XENOFACTIONS_NEW_PLAYER_PROTECTION";
+		pvpGraceDurationMs = hours(config, prot, "pvpGraceDurationHours", 4D, 0D, 24D * 365D, "PvP grace duration for first-time players.");
+		keepInventoryDurationMs = hours(config, prot, "keepInventoryDurationHours", 24D, 0D, 24D * 365D, "Keep-inventory duration recorded for first-time players.");
+		graceBuildEnabled = bool(config, prot, "graceBuildEnabled", graceBuildEnabled, "Enables /c gracebuild.");
+		graceBuildOneTimeUse = bool(config, prot, "graceBuildOneTimeUse", graceBuildOneTimeUse, "Restricts build grace to one activation per faction.");
+		graceBuildDurationMs = hours(config, prot, "graceBuildDurationHours", 48D, 0D, 24D * 365D, "Build grace duration in hours.");
+
+		String flags = "XENOFACTIONS_CUSTOM_FLAGS";
+		customFlagAllowedHosts = stringList(config, flags, "allowedImageHosts", customFlagAllowedHosts, "HTTPS image host whitelist. Defaults preserve Postimages/i.postimg.cc behavior.");
+		rebuildHostSet();
+		customFlagMaxWidth = integer(config, flags, "maxImageWidth", customFlagMaxWidth, 1, 4096, "Maximum imported image width in pixels.");
+		customFlagMaxHeight = integer(config, flags, "maxImageHeight", customFlagMaxHeight, 1, 4096, "Maximum imported image height in pixels.");
+		customFlagMaxFileSizeBytes = integer(config, flags, "maxFileSizeBytes", customFlagMaxFileSizeBytes, 1024, 8 * 1024 * 1024, "Maximum downloaded image size in bytes.");
+		customFlagTimeoutMs = integer(config, flags, "downloadTimeoutMs", customFlagTimeoutMs, 500, 60000, "HTTP connect/read timeout for flag imports.");
+		customFlagMaxRedirects = integer(config, flags, "maxRedirects", customFlagMaxRedirects, 0, 10, "Maximum HTTPS redirects while importing a flag.");
+		customFlagRateLimitMs = seconds(config, flags, "importRateLimitSeconds", 60D, 0D, 3600D, "Per-player per-faction flag import rate limit.");
+		customFlagReloadMissingClearsMetadata = bool(config, flags, "reloadMissingFileClearsMetadata", customFlagReloadMissingClearsMetadata, "When /c flag reload finds no cached file, clear stale metadata.");
+
+		String dynmap = "XENOFACTIONS_DYNMAP";
+		dynmapMarkerSetId = string(config, dynmap, "markerSetId", dynmapMarkerSetId, "Dynmap marker set ID.");
+		dynmapMarkerSetLabel = string(config, dynmap, "markerSetLabel", dynmapMarkerSetLabel, "Dynmap marker set label.");
+		dynmapUpdateIntervalTicks = integer(config, dynmap, "updateIntervalTicks", dynmapUpdateIntervalTicks, 20, 20 * 60 * 60, "Dynmap marker update interval in ticks.");
+		dynmapClaimFillOpacity = dbl(config, dynmap, "claimFillOpacity", dynmapClaimFillOpacity, 0D, 1D, "Claim area fill opacity.");
+		dynmapClaimLineOpacity = dbl(config, dynmap, "claimLineOpacity", dynmapClaimLineOpacity, 0D, 1D, "Per-claim outline opacity; default hidden.");
+		dynmapClaimLineWeight = integer(config, dynmap, "claimLineWeight", dynmapClaimLineWeight, 0, 10, "Per-claim outline weight; default 0.");
+		dynmapBorderLineOpacity = dbl(config, dynmap, "borderLineOpacity", dynmapBorderLineOpacity, 0D, 1D, "City border line opacity.");
+		dynmapBorderLineWeight = integer(config, dynmap, "borderLineWeight", dynmapBorderLineWeight, 0, 10, "City border line weight.");
+		dynmapShowCityCenterMarkers = bool(config, dynmap, "showCityCenterMarkers", dynmapShowCityCenterMarkers, "Shows a marker at each City Center.");
+		dynmapShowClaimDetails = bool(config, dynmap, "showClaimDetailsInLabels", dynmapShowClaimDetails, "Includes city/claim chunk details in Dynmap labels.");
+		dynmapShowPrestigeDetails = bool(config, dynmap, "showPrestigeDetailsInLabels", dynmapShowPrestigeDetails, "Includes prestige/upkeep details in Dynmap labels.");
+
+		MainRegistry.warpCost = Math.round(warpCost);
+		CommandClowderAdmin.WARENABLED = warEnabledDefault;
+		com.hfr.clowder.ClowderEvents.newPlayerProtectionEnabled = enableNewPlayerProtection;
+	}
+
+	public static int cityRadius(CityLevel level) { return cityRadii[index(level)]; }
+	public static float cityUpgradeCost(CityLevel level) { return cityUpgradeCosts[index(level)]; }
+	public static float cityUpkeep(CityLevel level) { return cityUpkeep[index(level)]; }
+	private static int index(CityLevel level) { int i = level == null ? 0 : level.ordinal(); return Math.max(0, Math.min(4, i)); }
+
+	private static void rebuildHostSet() {
+		customFlagAllowedHostSet.clear();
+		for(int i = 0; i < customFlagAllowedHosts.length; i++) {
+			String h = customFlagAllowedHosts[i];
+			if(h != null && h.trim().length() > 0)
+				customFlagAllowedHostSet.add(h.trim().toLowerCase());
+		}
+	}
+
+	private static boolean bool(Configuration c, String cat, String name, boolean def, String comment) { Property p = c.get(cat, name, def); p.comment = comment; return p.getBoolean(def); }
+	private static String string(Configuration c, String cat, String name, String def, String comment) { Property p = c.get(cat, name, def); p.comment = comment; String v = p.getString(); return v == null || v.trim().isEmpty() ? def : v.trim(); }
+	private static String[] stringList(Configuration c, String cat, String name, String[] def, String comment) { Property p = c.get(cat, name, def); p.comment = comment; return p.getStringList(); }
+	private static int integer(Configuration c, String cat, String name, int def, int min, int max, String comment) { Property p = c.get(cat, name, def); p.comment = comment; return clamp(name, p.getInt(def), min, max); }
+	private static float flt(Configuration c, String cat, String name, float def, float min, float max, String comment) { Property p = c.get(cat, name, (double)def); p.comment = comment; return (float)clamp(name, p.getDouble(def), min, max); }
+	private static double dbl(Configuration c, String cat, String name, double def, double min, double max, String comment) { Property p = c.get(cat, name, def); p.comment = comment; return clamp(name, p.getDouble(def), min, max); }
+	private static long hours(Configuration c, String cat, String name, double def, double min, double max, String comment) { return (long)(dbl(c, cat, name, def, min, max, comment) * 60D * 60D * 1000D); }
+	private static long minutes(Configuration c, String cat, String name, double def, double min, double max, String comment) { return (long)(dbl(c, cat, name, def, min, max, comment) * 60D * 1000D); }
+	private static long seconds(Configuration c, String cat, String name, double def, double min, double max, String comment) { return (long)(dbl(c, cat, name, def, min, max, comment) * 1000D); }
+	private static int[] intList(Configuration c, String cat, String name, int[] def, int min, int max, String comment) {
+		String[] defaults = new String[def.length]; for(int i = 0; i < def.length; i++) defaults[i] = Integer.toString(def[i]);
+		String[] raw = stringList(c, cat, name, defaults, comment); int[] out = new int[def.length];
+		for(int i = 0; i < out.length; i++) out[i] = clamp(name + "[" + i + "]", parseInt(raw, i, def[i]), min, max);
+		return out;
+	}
+	private static float[] floatList(Configuration c, String cat, String name, float[] def, float min, float max, String comment) {
+		String[] defaults = new String[def.length]; for(int i = 0; i < def.length; i++) defaults[i] = Float.toString(def[i]);
+		String[] raw = stringList(c, cat, name, defaults, comment); float[] out = new float[def.length];
+		for(int i = 0; i < out.length; i++) out[i] = (float)clamp(name + "[" + i + "]", parseFloat(raw, i, def[i]), min, max);
+		return out;
+	}
+	private static int parseInt(String[] raw, int i, int def) { try { return raw != null && i < raw.length ? Integer.parseInt(raw[i].trim()) : def; } catch(Exception e) { warn("Invalid integer for config list entry; using default " + def); return def; } }
+	private static float parseFloat(String[] raw, int i, float def) { try { return raw != null && i < raw.length ? Float.parseFloat(raw[i].trim()) : def; } catch(Exception e) { warn("Invalid decimal for config list entry; using default " + def); return def; } }
+	private static int clamp(String name, int value, int min, int max) { if(value < min) { warn(name + " was below " + min + "; corrected to " + min); return min; } if(value > max) { warn(name + " was above " + max + "; corrected to " + max); return max; } return value; }
+	private static double clamp(String name, double value, double min, double max) { if(value < min) { warn(name + " was below " + min + "; corrected to " + min); return min; } if(value > max) { warn(name + " was above " + max + "; corrected to " + max); return max; } return value; }
+	private static void warn(String message) { if(MainRegistry.logger != null) MainRegistry.logger.warn("Xenofactions config: " + message); }
+}

--- a/src/main/java/com/hfr/dynmap/XFDynmapIntegration.java
+++ b/src/main/java/com/hfr/dynmap/XFDynmapIntegration.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.hfr.clowder.Clowder;
+import com.hfr.config.XFConfig;
 import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.CoordPair;
 import com.hfr.clowder.ClowderTerritory.TerritoryMeta;
@@ -56,7 +57,7 @@ public class XFDynmapIntegration {
 			return;
 
 		tickCounter++;
-		if(tickCounter < UPDATE_INTERVAL_TICKS)
+		if(tickCounter < XFConfig.dynmapUpdateIntervalTicks)
 			return;
 
 		tickCounter = 0;
@@ -66,6 +67,8 @@ public class XFDynmapIntegration {
 
 	public static void updateMarkers() {
 		try {
+			if(!XFConfig.enableDynmapIntegration)
+				return;
 			Object markerApi = getMarkerApi();
 			if(markerApi == null)
 				return;
@@ -117,13 +120,13 @@ public class XFDynmapIntegration {
 
 	private static Object getOrCreateMarkerSet(Object markerApi) throws Exception {
 		Method getMarkerSet = markerApi.getClass().getMethod("getMarkerSet", String.class);
-		Object set = getMarkerSet.invoke(markerApi, MARKER_SET_ID);
+		Object set = getMarkerSet.invoke(markerApi, XFConfig.dynmapMarkerSetId);
 		if(set == null) {
 			Method createMarkerSet = markerApi.getClass().getMethod("createMarkerSet", String.class, String.class, Set.class, boolean.class);
-			set = createMarkerSet.invoke(markerApi, MARKER_SET_ID, MARKER_SET_LABEL, null, false);
+			set = createMarkerSet.invoke(markerApi, XFConfig.dynmapMarkerSetId, XFConfig.dynmapMarkerSetLabel, null, false);
 		}
 		if(set != null) {
-			callIfPresent(set, "setMarkerSetLabel", new Class[] { String.class }, new Object[] { MARKER_SET_LABEL });
+			callIfPresent(set, "setMarkerSetLabel", new Class[] { String.class }, new Object[] { XFConfig.dynmapMarkerSetLabel });
 			callIfPresent(set, "setLayerPriority", new Class[] { int.class }, new Object[] { Integer.valueOf(10) });
 			callIfPresent(set, "setHideByDefault", new Class[] { boolean.class }, new Object[] { Boolean.FALSE });
 		}
@@ -194,8 +197,8 @@ public class XFDynmapIntegration {
 					setRangeYMethod = area.getClass().getMethod("setRangeY", double.class, double.class);
 					setRangeYMethod.setAccessible(true);
 				}
-				setLineStyleMethod.invoke(area, Integer.valueOf(CLAIM_LINE_WEIGHT), Double.valueOf(CLAIM_LINE_OPACITY), Integer.valueOf(color));
-				setFillStyleMethod.invoke(area, Double.valueOf(CLAIM_FILL_OPACITY), Integer.valueOf(color));
+				setLineStyleMethod.invoke(area, Integer.valueOf(XFConfig.dynmapClaimLineWeight), Double.valueOf(XFConfig.dynmapClaimLineOpacity), Integer.valueOf(color));
+				setFillStyleMethod.invoke(area, Double.valueOf(XFConfig.dynmapClaimFillOpacity), Integer.valueOf(color));
 				setRangeYMethod.invoke(area, Double.valueOf(64.0D), Double.valueOf(64.0D));
 			}
 
@@ -210,7 +213,8 @@ public class XFDynmapIntegration {
 
 		for(CitySummary city : cities.values()) {
 			createCityBorders(worldName, city);
-			createCityCenterMarker(worldName, city);
+			if(XFConfig.dynmapShowCityCenterMarkers)
+				createCityCenterMarker(worldName, city);
 		}
 	}
 
@@ -240,7 +244,7 @@ public class XFDynmapIntegration {
 		if(line != null) {
 			Method setLineStyle = line.getClass().getMethod("setLineStyle", int.class, double.class, int.class);
 			setLineStyle.setAccessible(true);
-			setLineStyle.invoke(line, Integer.valueOf(3), Double.valueOf(0.9D), Integer.valueOf(city.owner.color & 0xFFFFFF));
+			setLineStyle.invoke(line, Integer.valueOf(XFConfig.dynmapBorderLineWeight), Double.valueOf(XFConfig.dynmapBorderLineOpacity), Integer.valueOf(city.owner.color & 0xFFFFFF));
 		}
 	}
 
@@ -268,18 +272,22 @@ public class XFDynmapIntegration {
 
 	private static String buildClaimLabel(TerritoryMeta meta, Clowder owner, CoordPair coords) {
 		String cityName = displayCityName(meta);
-		return "<b>" + escapeHtml(cityName) + "</b>"
-				+ "<br/><b>Faction:</b> " + escapeHtml(owner.name)
-				+ "<br/><b>Level:</b> " + escapeHtml(meta.getCityLevel().displayName)
-				+ "<br/><b>Chunk:</b> " + coords.x + ", " + coords.z;
+		String label = "<b>" + escapeHtml(cityName) + "</b>" + "<br/><b>Faction:</b> " + escapeHtml(owner.name);
+		if(XFConfig.dynmapShowClaimDetails)
+			label += "<br/><b>Level:</b> " + escapeHtml(meta.getCityLevel().displayName) + "<br/><b>Chunk:</b> " + coords.x + ", " + coords.z;
+		if(XFConfig.dynmapShowPrestigeDetails)
+			label += "<br/><b>Upkeep:</b> " + meta.getCityLevel().configuredUpkeep();
+		return label;
 	}
 
 	private static String buildCityLabel(TerritoryMeta meta, Clowder owner, int claimCount) {
-		return "<b>City Center: " + escapeHtml(displayCityName(meta)) + "</b>"
-				+ "<br/><b>Faction:</b> " + escapeHtml(owner.name)
-				+ "<br/><b>Level:</b> " + escapeHtml(meta.getCityLevel().displayName)
-				+ "<br/><b>Claims:</b> " + claimCount
-				+ "<br/><b>Faction Color:</b> #" + String.format("%06X", owner.color & 0xFFFFFF);
+		String label = "<b>City Center: " + escapeHtml(displayCityName(meta)) + "</b>" + "<br/><b>Faction:</b> " + escapeHtml(owner.name);
+		if(XFConfig.dynmapShowClaimDetails)
+			label += "<br/><b>Level:</b> " + escapeHtml(meta.getCityLevel().displayName) + "<br/><b>Claims:</b> " + claimCount;
+		if(XFConfig.dynmapShowPrestigeDetails)
+			label += "<br/><b>Upkeep:</b> " + meta.getCityLevel().configuredUpkeep();
+		label += "<br/><b>Faction Color:</b> #" + String.format("%06X", owner.color & 0xFFFFFF);
+		return label;
 	}
 
 	private static String displayCityName(TerritoryMeta meta) {

--- a/src/main/java/com/hfr/inventory/gui/GUIFlag.java
+++ b/src/main/java/com/hfr/inventory/gui/GUIFlag.java
@@ -49,7 +49,7 @@ public class GUIFlag extends GuiContainer {
 		drawTextBackground(45, 16, 132, 70);
 		this.fontRendererObj.drawString("City: " + this.fontRendererObj.trimStringToWidth(cityName, 92), 50, 20, 0xFFFFFF);
 		this.fontRendererObj.drawString("Level: " + diFurnace.cityLevel.displayName, 50, 31, 0xFFFFFF);
-		this.fontRendererObj.drawString("Radius: " + diFurnace.cityLevel.radius + " Upkeep: " + Clowder.round(diFurnace.cityLevel.upkeep), 50, 42, 0xFFFFFF);
+		this.fontRendererObj.drawString("Radius: " + diFurnace.cityLevel.configuredRadius() + " Upkeep: " + Clowder.round(diFurnace.cityLevel.configuredUpkeep()), 50, 42, 0xFFFFFF);
 		this.fontRendererObj.drawString("Owner: " + this.fontRendererObj.trimStringToWidth(ownerName, 82), 50, 53, 0xFFFFFF);
 		this.fontRendererObj.drawString("Prestige: " + Clowder.round(prestige), 50, 64, 0xFFFFFF);
 		this.fontRendererObj.drawString("Required: " + Clowder.round(prestigeReq), 50, 75, color);

--- a/src/main/java/com/hfr/items/ItemBlockLore.java
+++ b/src/main/java/com/hfr/items/ItemBlockLore.java
@@ -78,26 +78,26 @@ public class ItemBlockLore extends ItemBlock {
 		if(field_150939_a == ModBlocks.machine_uni) {
 			list.add("Requires sky access and foundation");
 			list.add("Generates research points over time");
-			list.add(Clowder.UniRate +" prestige gen / hour");
+			list.add(Clowder.UniRate() +" prestige gen / hour");
 		}
 		if(field_150939_a == ModBlocks.machine_reserve) {
 			list.add("Requires sky access and foundation");
 			list.add("Generates research points over time");
-			list.add(Clowder.FedRate +" prestige gen / hour");
+			list.add(Clowder.FedRate() +" prestige gen / hour");
 		}
 		if(field_150939_a == ModBlocks.machine_grainmill) {
 			list.add("Requires sky access and foundation");
 			list.add("Grinds wheat into flour");
-			list.add(Clowder.GrainRate + " prestige gen / hour");
+			list.add(Clowder.GrainRate() + " prestige gen / hour");
 		}
 		if(field_150939_a == ModBlocks.machine_blastfurnace) {
 			list.add("Requires foundation but no sky access");
 			list.add("Smelts iron ingots and ore into steel");
-			list.add(Clowder.BlastRate + " prestige gen / hour");
+			list.add(Clowder.BlastRate() + " prestige gen / hour");
 		}
 		if(field_150939_a == ModBlocks.machine_temple) {
 			list.add("Generates scrolls over time");
-			list.add(Clowder.TempleRate + " prestige gen / hour");
+			list.add(Clowder.TempleRate() + " prestige gen / hour");
 		}
 		if(field_150939_a == ModBlocks.machine_coalmine) {
 			list.add("Requires sky access and foundation");
@@ -130,18 +130,18 @@ public class ItemBlockLore extends ItemBlock {
 		if(field_150939_a == ModBlocks.med_tent) {
 			list.add("Requires sky access and foundation");
 			list.add("Generates healing aura");
-			list.add(Clowder.medTentRate + " prestige gen / hour");
+			list.add(Clowder.medTentRate() + " prestige gen / hour");
 		}
 		if(field_150939_a == ModBlocks.tp_tent) {
 			list.add("Requires sky access and foundation");
 			list.add("Allows to create faction teleport/TP/waypoints nearby");
-			list.add(Clowder.tentRate + " prestige gen / hour");
+			list.add(Clowder.tentRate() + " prestige gen / hour");
 			//retard alert!
 		}
 		if(field_150939_a == ModBlocks.statue) {
 			list.add("Requires sky access and foundation");
 			list.add("Low-level prestige generator");
-			list.add(Clowder.statueRate + " prestige gen / hour");
+			list.add(Clowder.statueRate() + " prestige gen / hour");
 		}
 
 		if(field_150939_a == ModBlocks.machine_coalgen) {

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -50,6 +50,7 @@ import com.hfr.blocks.*;
 import com.hfr.blocks.machine.MachineMarket.TileEntityMarket;
 import com.hfr.clowder.*;
 import com.hfr.command.*;
+import com.hfr.config.XFConfig;
 import com.hfr.data.*;
 import com.hfr.dynmap.XFDynmapIntegration;
 import com.hfr.data.StockData.Stock;
@@ -372,10 +373,12 @@ public class MainRegistry
 		FluidHandler.init();
 		HFRPotion.init();
 		MainRegistry.loadCustomDrops();
-		TDMManager.init();
-		TDMHandler tdmHandler = new TDMHandler();
-		MinecraftForge.EVENT_BUS.register(tdmHandler);
-		FMLCommonHandler.instance().bus().register(tdmHandler);
+		if(XFConfig.enableTDM) {
+			TDMManager.init();
+			TDMHandler tdmHandler = new TDMHandler();
+			MinecraftForge.EVENT_BUS.register(tdmHandler);
+			FMLCommonHandler.instance().bus().register(tdmHandler);
+		}
 
 
 		//todone: make chat filter apply to faction names so we don't have edgelords putting swastikas and shit in their fac names
@@ -673,7 +676,8 @@ public class MainRegistry
 		
 		FMLCommonHandler.instance().bus().register(handler);
 		FMLCommonHandler.instance().bus().register(clowder);
-		FMLCommonHandler.instance().bus().register(dynmap);
+		if(XFConfig.enableDynmapIntegration)
+			FMLCommonHandler.instance().bus().register(dynmap);
 		//FMLCommonHandler.instance().bus().register(pon4);
 		MinecraftForge.EVENT_BUS.register(handler);
 		MinecraftForge.EVENT_BUS.register(clowder);
@@ -783,7 +787,8 @@ public class MainRegistry
 		event.registerServerCommand(new CommandXMarket());
 		event.registerServerCommand(new CommandStoneDrop());
 		MuteManager.init();
-		TDMKitManager.init();
+		if(XFConfig.enableTDM)
+			TDMKitManager.init();
 		IgnoreManager.init();
 		event.registerServerCommand(new CommandMute());
 		event.registerServerCommand(new CommandUnmute());
@@ -792,7 +797,8 @@ public class MainRegistry
 		event.registerServerCommand(new CommandXFlags());
 		event.registerServerCommand(new CommandXMulti());
 		event.registerServerCommand(new CommandInvSee());
-		event.registerServerCommand(new CommandTDM());
+		if(XFConfig.enableTDM)
+			event.registerServerCommand(new CommandTDM());
 		MarketData.loadMarketData();
 		PlayerProtectionData.load();
 
@@ -875,6 +881,7 @@ public class MainRegistry
 		jsonDir = config.getConfigFile().getAbsolutePath().replace("cfg", "json");
 		
 		config.load();
+		XFConfig.load(config);
 		
 		Property propRadarRange = config.get("RADAR", "radarRange", 1000);
         propRadarRange.comment = "Range of the radar, 50 will result in 100x100 block area covered";

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -250,23 +250,23 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	}
 	
 	public float getGenRate() {
-		return owner == null ? 0 : Clowder.flagRate;
+		return owner == null ? 0 : Clowder.flagRate();
 	}
 	
 	public static float getGenRateFromMode(int mode) {
 		
 		if(mode != 0)
-			return Clowder.flagRate;
+			return Clowder.flagRate();
 		
 		return 0;
 	}
 	
 	public float getCost() {
-		return cityLevel.upkeep;
+		return cityLevel.configuredUpkeep();
 	}
 	
 	public static float getCostFromMode(int mode) {
-		return CityLevel.SETTLEMENT.upkeep;
+		return CityLevel.SETTLEMENT.configuredUpkeep();
 	}
 	
 	public void setOwner(Clowder c) {
@@ -308,9 +308,9 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 		if(next == null)
 			return false;
 		float beforeCost = getCost();
-		if(owner.getPrestige() < next.upgradeCost || owner.getPrestigeReq() - beforeCost + next.upkeep > owner.getPrestige() - next.upgradeCost)
+		if(owner.getPrestige() < next.configuredUpgradeCost() || owner.getPrestigeReq() - beforeCost + next.configuredUpkeep() > owner.getPrestige() - next.configuredUpgradeCost())
 			return false;
-		owner.addPrestige(-next.upgradeCost, worldObj);
+		owner.addPrestige(-next.configuredUpgradeCost(), worldObj);
 		owner.addPrestigeReq(-beforeCost, worldObj);
 		cityLevel = next;
 		owner.addPrestigeReq(getCost(), worldObj);
@@ -345,7 +345,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	@Override
 	public int getRadius() {
 		
-		return owner == null ? 0 : cityLevel.radius;
+		return owner == null ? 0 : cityLevel.configuredRadius();
 	}
 
 	@Override

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
@@ -13,6 +13,7 @@ import com.hfr.clowder.ClowderTerritory.CoordPair;
 import com.hfr.clowder.ClowderTerritory.TerritoryMeta;
 import com.hfr.clowder.ClowderTerritory.Zone;
 import com.hfr.clowder.events.RegionOwnershipChangedEvent;
+import com.hfr.config.XFConfig;
 import com.hfr.data.ClowderData;
 import com.hfr.items.ModItems;
 import com.hfr.tileentity.machine.TileEntityMachineBase;
@@ -53,7 +54,7 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 	}
 
 	public int getCost() {
-		return claim.size() / 150 + 1;
+		return Math.max(0, Math.round((claim.size() / 150 + 1) * XFConfig.claimFlagUpkeep));
 	}
 
 	@Override

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineBlastFurnace.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineBlastFurnace.java
@@ -67,14 +67,14 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase {
 					
 					if(o != null && o.zone == Zone.FACTION) {
 						if(owner != null)
-							owner.addPrestigeGen(-Clowder.BlastRate, worldObj);
+							owner.addPrestigeGen(-Clowder.BlastRate(), worldObj);
 						owner = o.owner;
-						owner.addPrestigeGen(Clowder.BlastRate, worldObj);
+						owner.addPrestigeGen(Clowder.BlastRate(), worldObj);
 						
 					} else {
 						
 						if(owner != null)
-							owner.addPrestigeGen(-Clowder.BlastRate, worldObj);
+							owner.addPrestigeGen(-Clowder.BlastRate(), worldObj);
 						
 						owner = null;
 					}

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineFederalReserve.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineFederalReserve.java
@@ -45,14 +45,14 @@ public class TileEntityMachineFederalReserve extends TileEntityMachineBase {
 
                     if(o != null && o.zone == Zone.FACTION) {
                         if(owner != null)
-                            owner.addPrestigeGen(-Clowder.FedRate, worldObj);
+                            owner.addPrestigeGen(-Clowder.FedRate(), worldObj);
                         owner = o.owner;
-                        owner.addPrestigeGen(Clowder.FedRate, worldObj);
+                        owner.addPrestigeGen(Clowder.FedRate(), worldObj);
 
                     } else {
 
                         if(owner != null)
-                            owner.addPrestigeGen(-Clowder.FedRate, worldObj);
+                            owner.addPrestigeGen(-Clowder.FedRate(), worldObj);
 
                         owner = null;
                     }
@@ -90,7 +90,7 @@ public class TileEntityMachineFederalReserve extends TileEntityMachineBase {
             } else {
 
                 if(owner != null) {
-                    owner.addPrestigeGen(-Clowder.FedRate, worldObj);
+                    owner.addPrestigeGen(-Clowder.FedRate(), worldObj);
                     owner = null;
                 }
             }

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineGrainmill.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineGrainmill.java
@@ -49,14 +49,14 @@ public class TileEntityMachineGrainmill extends TileEntityMachineBase {
 					
 					if(o != null && o.zone == Zone.FACTION) {
 						if(owner != null)
-							owner.addPrestigeGen(-Clowder.GrainRate, worldObj);
+							owner.addPrestigeGen(-Clowder.GrainRate(), worldObj);
 						owner = o.owner;
-						owner.addPrestigeGen(Clowder.GrainRate, worldObj);
+						owner.addPrestigeGen(Clowder.GrainRate(), worldObj);
 						
 					} else {
 						
 						if(owner != null)
-							owner.addPrestigeGen(-Clowder.GrainRate, worldObj);
+							owner.addPrestigeGen(-Clowder.GrainRate(), worldObj);
 						
 						owner = null;
 					}
@@ -83,7 +83,7 @@ public class TileEntityMachineGrainmill extends TileEntityMachineBase {
 				progress = 0;
 				
 				if(owner != null) {
-					owner.addPrestigeGen(-Clowder.GrainRate, worldObj);
+					owner.addPrestigeGen(-Clowder.GrainRate(), worldObj);
 					owner = null;
 				}
 			}

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineTemple.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineTemple.java
@@ -32,13 +32,13 @@ public class TileEntityMachineTemple extends TileEntityMachineBase {
 			if(o != null && o.zone == Zone.FACTION) {
 				if(owner != o.owner) {
 					if(owner != null)
-						owner.addPrestigeGen(-Clowder.TempleRate, worldObj);
+						owner.addPrestigeGen(-Clowder.TempleRate(), worldObj);
 					owner = o.owner;
-					owner.addPrestigeGen(Clowder.TempleRate, worldObj);
+					owner.addPrestigeGen(Clowder.TempleRate(), worldObj);
 					this.markDirty();
 				}
 			} else if(owner != null) {
-				owner.addPrestigeGen(-Clowder.TempleRate, worldObj);
+				owner.addPrestigeGen(-Clowder.TempleRate(), worldObj);
 				owner = null;
 				this.markDirty();
 			}

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineUni.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineUni.java
@@ -45,14 +45,14 @@ public class TileEntityMachineUni extends TileEntityMachineBase {
 					
 					if(o != null && o.zone == Zone.FACTION) {
 						if(owner != null)
-							owner.addPrestigeGen(-Clowder.UniRate, worldObj);
+							owner.addPrestigeGen(-Clowder.UniRate(), worldObj);
 						owner = o.owner;
-						owner.addPrestigeGen(Clowder.UniRate, worldObj);
+						owner.addPrestigeGen(Clowder.UniRate(), worldObj);
 						
 					} else {
 						
 						if(owner != null)
-							owner.addPrestigeGen(-Clowder.UniRate, worldObj);
+							owner.addPrestigeGen(-Clowder.UniRate(), worldObj);
 						
 						owner = null;
 					}
@@ -89,7 +89,7 @@ public class TileEntityMachineUni extends TileEntityMachineBase {
 			} else {
 				
 				if(owner != null) {
-					owner.addPrestigeGen(-Clowder.UniRate, worldObj);
+					owner.addPrestigeGen(-Clowder.UniRate(), worldObj);
 					owner = null;
 				}
 			}

--- a/src/main/java/com/hfr/tileentity/prop/TileEntityProp.java
+++ b/src/main/java/com/hfr/tileentity/prop/TileEntityProp.java
@@ -92,7 +92,7 @@ public class TileEntityProp extends TileEntity {
 			//FOR TENTS RETARD
 			if(this.getBlockType() == ModBlocks.tp_tent || this.getBlockType() == ModBlocks.med_tent) {
 				
-				float prestigeRate = this.getBlockType() == ModBlocks.med_tent ? Clowder.medTentRate : Clowder.tentRate;
+				float prestigeRate = this.getBlockType() == ModBlocks.med_tent ? Clowder.medTentRate() : Clowder.tentRate();
 
 				if(this.operational()) {
 

--- a/src/main/java/com/hfr/tileentity/prop/TileEntityStatue.java
+++ b/src/main/java/com/hfr/tileentity/prop/TileEntityStatue.java
@@ -44,14 +44,14 @@ public class TileEntityStatue extends TileEntityMachineBase {
 					
 					if(o != null && o.zone == Zone.FACTION) {
 						if(owner != null)
-							owner.addPrestigeGen(-Clowder.statueRate, worldObj);
+							owner.addPrestigeGen(-Clowder.statueRate(), worldObj);
 						owner = o.owner;
-						owner.addPrestigeGen(Clowder.statueRate, worldObj);
+						owner.addPrestigeGen(Clowder.statueRate(), worldObj);
 						
 					} else {
 						
 						if(owner != null)
-							owner.addPrestigeGen(-Clowder.statueRate, worldObj);
+							owner.addPrestigeGen(-Clowder.statueRate(), worldObj);
 						
 						owner = null;
 					}
@@ -61,7 +61,7 @@ public class TileEntityStatue extends TileEntityMachineBase {
 			} else {
 				
 				if(owner != null) {
-					owner.addPrestigeGen(-Clowder.statueRate, worldObj);
+					owner.addPrestigeGen(-Clowder.statueRate(), worldObj);
 					owner = null;
 					
 					this.markDirty();


### PR DESCRIPTION
### Motivation

- Provide a single, central configuration surface so server owners can safely tune gameplay (prestige/economy, claims/cities, war/diplomacy, new-player protection, custom flags, Dynmap and optional modules) without changing save formats or altering default behaviour.
- Make already-optional subsystems (Dynmap, TDM, custom flags, new-player protection, conquest-flag command) safe to enable/disable at runtime/load and avoid scattering raw config reads throughout the codebase.
- Expose the realistic, server-owner-facing knobs (costs, upkeep, thresholds, timeouts, limits, toggles) while keeping internal constants and logic stable.

### Description

- Added a new central config helper `com.hfr.config.XFConfig` that loads grouped, documented options from Forge `Configuration` and clamps/validates values with warnings when out-of-range.
- Wired module toggles and defaults: `enableDynmapIntegration`, `enableTDM`, `enableCustomFactionFlags`, `enableNewPlayerProtection`, and `enableConquestFlagsCommand`, and guarded registration/command/event hooks accordingly (e.g. Dynmap registration, TDM init/command, /xflags command, custom flag operations, new-player protection switches).
- Moved many gameplay values to config and updated usages to read `XFConfig.*` (preserving original defaults): prestige/econ values and caps, warp creation cost and warp upkeep, city radii/upgrade costs/upkeep, claim naming rules, war/diplomacy costs and cooldowns, surrender tribute percent/duration, bankruptcy thresholds and upkeep multipliers, raid/online thresholds and grace durations, new-player protection durations and gracebuild settings, custom flag host whitelist/size/timeout/rate limits, and Dynmap marker/display parameters.
- Introduced helper accessors so existing enums/logic use configured city radii/upkeep/upgradeCosts (`CityLevel.configured*()`), and adjusted prestige bookkeeping (Clowder) to use configured thresholds and multipliers without changing save data layout.
- Preserved previous behavior as defaults in `XFConfig` and added safe no-op behavior when optional modules are disabled or external dependencies (Dynmap) are absent; added config-driven safeguards in `CustomFlagService` and dynmap reflection code to avoid crashes when disabled or missing.
- Kept changes narrowly scoped: no persistent save-format changes, no large rewrites of faction/city/war data structures; most edits replace hardcoded literals with `XFConfig` lookups and add guard clauses around module registration.

### Testing

- Static code checks: used repository-wide searches to verify configuration sites were added and to confirm occurrences were updated; these checks completed successfully.
- Attempted automated build with `./gradlew compileJava`; the build failed in this environment due to external Gradle/Minecraft toolchain resolution issues (network/proxy and missing Minecraft version metadata), not because of the config changes themselves.
- Attempted a targeted `javac` invocation on modified files in the sandbox to validate Java syntax, but the environment/build output was truncated and inconclusive; no full successful artifact was produced inside this runner.

Notes: no runtime server start or integration tests were executed in this environment; the changes intentionally preserve defaults so existing servers should see no behavioural change until admins edit the generated config file. Recommended next steps are to run a normal local Gradle build (or inside the usual dev environment with Minecraft/Forge toolchain available) and then start a dedicated server to validate: server loads with no config, server loads with Dynmap absent/present, and toggling modules does not crash (functional smoke tests listed in the project checklist).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ea9d7a6ec8329bedc85c1e7a60800)