### PR TITLE
Add optional Y-range support to `/stonedrop`

### DIFF
--- a/src/main/java/com/hfr/command/CommandStoneDrop.java
+++ b/src/main/java/com/hfr/command/CommandStoneDrop.java
@@ -17,14 +17,14 @@ public class CommandStoneDrop extends CommandBase {
 
     @Override
     public String getCommandUsage(ICommandSender sender) {
-        return "/stonedrop <rarity> OR /stonedrop list OR /stonedrop remove [index]";
+        return "/stonedrop <rarity> [minY] [maxY] OR /stonedrop list OR /stonedrop remove [index]";
     }
 
     @Override
     public void processCommand(ICommandSender sender, String[] args) {
         // Check argument count.
         if (args.length < 1) {
-            sender.addChatMessage(new ChatComponentText("Usage: " + getCommandUsage(sender)));
+            sendUsage(sender);
             return;
         }
 
@@ -50,7 +50,11 @@ public class CommandStoneDrop extends CommandBase {
         sender.addChatMessage(new ChatComponentText("Custom Stone Drops:"));
         for (int i = 0; i < drops.size(); i++) {
             ItemStack stack = drops.get(i);
-            sender.addChatMessage(new ChatComponentText(i + 1 + ". " + stack.getDisplayName() + " (Chance: " + MainRegistry.customDropChances.get(i) + ")"));
+            Integer minY = MainRegistry.customDropMinYs.get(i);
+            Integer maxY = MainRegistry.customDropMaxYs.get(i);
+            sender.addChatMessage(new ChatComponentText(i + 1 + ". " + stack.getDisplayName()
+                    + " (Chance: " + MainRegistry.customDropChances.get(i)
+                    + ", Y: " + formatYRange(minY, maxY) + ")"));
         }
     }
 
@@ -75,19 +79,47 @@ public class CommandStoneDrop extends CommandBase {
 
         ItemStack removed = MainRegistry.customDrops.remove(index);
         double removedChance = MainRegistry.customDropChances.remove(index);
+        Integer removedMinY = MainRegistry.customDropMinYs.remove(index);
+        Integer removedMaxY = MainRegistry.customDropMaxYs.remove(index);
 
         MainRegistry.saveCustomDrops(); // Save after removing
 
-        sender.addChatMessage(new ChatComponentText("Removed custom drop: " + removed.getDisplayName() + " (Chance: " + removedChance + ")"));
+        sender.addChatMessage(new ChatComponentText("Removed custom drop: " + removed.getDisplayName()
+                + " (Chance: " + removedChance + ", Y: " + formatYRange(removedMinY, removedMaxY) + ")"));
     }
 
     private void handleAddCommand(ICommandSender sender, String[] args) {
+        if (args.length != 1 && args.length != 3) {
+            sendUsage(sender);
+            return;
+        }
+
         double rarity;
         try {
             rarity = Double.parseDouble(args[0]);
         } catch (NumberFormatException e) {
             sender.addChatMessage(new ChatComponentText("Invalid rarity. Must be a number, e.g. 0.25"));
+            sendUsage(sender);
             return;
+        }
+
+        Integer minY = null;
+        Integer maxY = null;
+
+        if (args.length == 3) {
+            try {
+                minY = Integer.valueOf(args[1]);
+                maxY = Integer.valueOf(args[2]);
+            } catch (NumberFormatException e) {
+                sender.addChatMessage(new ChatComponentText("Invalid Y levels. minY and maxY must be whole numbers, e.g. 5 30"));
+                sendUsage(sender);
+                return;
+            }
+
+            if (minY.intValue() > maxY.intValue()) {
+                sender.addChatMessage(new ChatComponentText("Invalid Y range. minY must be less than or equal to maxY."));
+                return;
+            }
         }
 
         if (!(sender instanceof EntityPlayerMP)) {
@@ -105,11 +137,28 @@ public class CommandStoneDrop extends CommandBase {
 
         MainRegistry.customDrops.add(heldItem.copy());
         MainRegistry.customDropChances.add(rarity);
+        MainRegistry.customDropMinYs.add(minY);
+        MainRegistry.customDropMaxYs.add(maxY);
 
         MainRegistry.saveCustomDrops(); // Save after adding
 
         sender.addChatMessage(new ChatComponentText("Stone drop added! "
                 + " Item: " + heldItem.getDisplayName()
-                + " | Rarity (chance): " + rarity));
+                + " | Rarity (chance): " + rarity
+                + " | Y levels: " + formatYRange(minY, maxY)));
+    }
+
+    private void sendUsage(ICommandSender sender) {
+        sender.addChatMessage(new ChatComponentText("Usage: " + getCommandUsage(sender)));
+        sender.addChatMessage(new ChatComponentText("Hold the item/block you want to drop, then run /stonedrop <rarity> to allow it at any Y level."));
+        sender.addChatMessage(new ChatComponentText("To limit it to a Y range, run /stonedrop <rarity> <minY> <maxY>, e.g. /stonedrop 0.02 5 30."));
+    }
+
+    private String formatYRange(Integer minY, Integer maxY) {
+        if (minY == null || maxY == null) {
+            return "any";
+        }
+
+        return minY + "-" + maxY;
     }
 }

--- a/src/main/java/com/hfr/main/CommonEventHandler.java
+++ b/src/main/java/com/hfr/main/CommonEventHandler.java
@@ -936,6 +936,10 @@ public class CommonEventHandler {
 		}
 	}
 	
+	private boolean isWithinCustomDropYRange(int y, Integer minY, Integer maxY) {
+		return minY == null || maxY == null || (y >= minY.intValue() && y <= maxY.intValue());
+	}
+
 	@SubscribeEvent
 	public void onEntityDropEvent(LivingDropsEvent event) {
 		
@@ -982,8 +986,10 @@ public class CommonEventHandler {
 			for (int i = 0; i < MainRegistry.customDrops.size(); i++) {
 				ItemStack drop = MainRegistry.customDrops.get(i);
 				double chance = MainRegistry.customDropChances.get(i);
+				Integer minY = MainRegistry.customDropMinYs.get(i);
+				Integer maxY = MainRegistry.customDropMaxYs.get(i);
 
-				if (world.rand.nextDouble() < chance) {
+				if (isWithinCustomDropYRange(event.y, minY, maxY) && world.rand.nextDouble() < chance) {
 					// Spawn the item from the list
 					ItemStack toDrop = drop.copy();
 					EntityItem entityItem = new EntityItem(world,

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -104,6 +104,8 @@ public class MainRegistry
 	public static ItemStack customDropStack = null;
 	public static final List<ItemStack> customDrops = new ArrayList<ItemStack>();
 	public static final List<Double> customDropChances = new ArrayList<Double>();
+	public static final List<Integer> customDropMinYs = new ArrayList<Integer>();
+	public static final List<Integer> customDropMaxYs = new ArrayList<Integer>();
 	
 	//public static WorldGeneratorMoon worldGenMoon = new WorldGeneratorMoon();
 	
@@ -271,11 +273,13 @@ public class MainRegistry
 				int metadata = stack.getItemDamage(); // Store metadata (subtype)
 				int count = stack.stackSize; // Store count
 				double chance = MainRegistry.customDropChances.get(i);
+				Integer minY = MainRegistry.customDropMinYs.get(i);
+				Integer maxY = MainRegistry.customDropMaxYs.get(i);
 
 				// Convert NBT to a string format for saving
 				String nbtData = stack.hasTagCompound() ? stack.getTagCompound().toString() : null;
 
-				entries.add(new DropEntry(itemName, metadata, count, chance, nbtData));
+				entries.add(new DropEntry(itemName, metadata, count, chance, nbtData, minY, maxY));
 			}
 
 			GSON.toJson(entries, writer);
@@ -306,6 +310,8 @@ public class MainRegistry
 
 			MainRegistry.customDrops.clear();
 			MainRegistry.customDropChances.clear();
+			MainRegistry.customDropMinYs.clear();
+			MainRegistry.customDropMaxYs.clear();
 
 			for (DropEntry entry : entries) {
 				Item item = (Item) Item.itemRegistry.getObject(entry.itemName);
@@ -324,6 +330,8 @@ public class MainRegistry
 
 					MainRegistry.customDrops.add(stack);
 					MainRegistry.customDropChances.add(entry.chance);
+					MainRegistry.customDropMinYs.add(entry.minY);
+					MainRegistry.customDropMaxYs.add(entry.maxY);
 				} else {
 					System.err.println("Item not found: " + entry.itemName);
 				}
@@ -348,13 +356,17 @@ public class MainRegistry
 		int count;
 		double chance;
 		String nbtData; // Store NBT as a string
+		Integer minY;
+		Integer maxY;
 
-		DropEntry(String itemName, int metadata, int count, double chance, String nbtData) {
+		DropEntry(String itemName, int metadata, int count, double chance, String nbtData, Integer minY, Integer maxY) {
 			this.itemName = itemName;
 			this.metadata = metadata;
 			this.count = count;
 			this.chance = chance;
 			this.nbtData = nbtData;
+			this.minY = minY;
+			this.maxY = maxY;
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Allow server operators to restrict custom stone drops to a vertical range so modded/custom drops can be limited by Y-level rather than always spawning everywhere.
- Make the `/stonedrop` command self-documenting so players know how to add ranged drops from in-game.

### Description
- Extended the `/stonedrop` command to accept optional `minY` and `maxY` arguments: usage is now `"/stonedrop <rarity> [minY] [maxY]"` and guidance is shown via a new `sendUsage` message when needed. (`CommandStoneDrop`) 
- Validates numeric `minY`/`maxY` and ensures `minY <= maxY`, and shows the configured Y range or `any` in list/remove/add feedback; added helper `formatYRange`. (`CommandStoneDrop`) 
- Persisted per-drop Y bounds by adding `customDropMinYs` and `customDropMaxYs` lists and extending `DropEntry` to include `minY`/`maxY` so `stonedrops.json` now stores the range alongside item, metadata, count, chance and NBT. (`MainRegistry`) 
- Applied the Y-range filter when rolling custom drops during stone breaking by adding `isWithinCustomDropYRange(y,minY,maxY)` so drops only roll when the broken block Y is inside the configured range (null range means unrestricted). (`CommonEventHandler`) 
- Maintains backward compatibility by treating `null` min/max as "any" when loading older JSON entries.

### Testing
- Ran `git diff --check` to verify whitespace/format issues and fix them, which succeeded.
- Attempted build with `gradle build` and `gradle build --offline`, both failed due to the local environment/ForgeGradle configuration (proxy/missing Minecraft version) rather than the changes; failures are external to the code edits. 
- No unit tests were present for this feature; manual command validation and JSON read/write logic were exercised locally via code inspection and `loadCustomDrops`/`saveCustomDrops` updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f96d471688329b4d74fc7a6cd7345)