### PR TITLE
Fix crash when placing City Center from creative without a faction

### DIFF
--- a/src/main/java/com/hfr/blocks/clowder/Flag.java
+++ b/src/main/java/com/hfr/blocks/clowder/Flag.java
@@ -93,10 +93,22 @@ public class Flag extends BlockContainer {
 		}
 
 		if(player instanceof EntityPlayer && !world.isRemote) {
-			TileEntityFlag flag = (TileEntityFlag)world.getTileEntity(x, y, z);
+			TileEntity tile = world.getTileEntity(x, y, z);
+			if(!(tile instanceof TileEntityFlag)) {
+				world.setBlockToAir(x, y, z);
+				return;
+			}
+
+			TileEntityFlag flag = (TileEntityFlag)tile;
 			EntityPlayer entityPlayer = (EntityPlayer)player;
 
 			Clowder clowder = Clowder.getClowderFromPlayer(entityPlayer);
+			if(clowder == null) {
+				world.setBlockToAir(x, y, z);
+				entityPlayer.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "City Centers require a faction. Use /c create first, then /c claim <city name>."));
+				return;
+			}
+
 			String cityName = itemStack.hasTagCompound() ? itemStack.stackTagCompound.getString("cityName") : "";
 			CoordPair cityChunk = ClowderTerritory.getCoordPair(x, z);
 			String cityError = ClowderTerritory.getCityPlacementError(cityChunk.x, cityChunk.z);
@@ -118,7 +130,7 @@ public class Flag extends BlockContainer {
 				return;
 			}
 
-			if(clowder != null && flag.canSeeSky()) {
+			if(flag.canSeeSky()) {
 				float foundingCost = clowder.getCityFoundingCost();
 				float foundingUpkeep = XFConfig.cityUpkeep(CityLevel.SETTLEMENT);
 				if(clowder.getPrestige() < foundingCost || clowder.getPrestigeReq() + foundingUpkeep > clowder.getPrestige() - foundingCost) {

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityConquerer.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityConquerer.java
@@ -35,9 +35,7 @@ public class TileEntityConquerer extends TileEntityMachineBase implements ITerri
 	public ClowderFlag flag;
 	@SideOnly(Side.CLIENT)
 	public int color;
-	@SideOnly(Side.CLIENT)
 	public String ownerName = "";
-	@SideOnly(Side.CLIENT)
 	public String customFlagHash = "";
 
 	public TileEntityConquerer() {

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -50,7 +50,6 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	public float prestige;
 	@SideOnly(Side.CLIENT)
 	public float prestigeReq;
-	@SideOnly(Side.CLIENT)
 	public String customFlagHash = "";
 
 	public TileEntityFlag() {

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
@@ -42,9 +42,7 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 	public ClowderFlag flag;
 	@SideOnly(Side.CLIENT)
 	public int color;
-	@SideOnly(Side.CLIENT)
 	public String ownerName = "";
-	@SideOnly(Side.CLIENT)
 	public String customFlagHash = "";
 	public String provinceName = "";
 


### PR DESCRIPTION
### Motivation
- Prevent a dedicated-server crash caused by `NoSuchFieldError: customFlagHash` when a City Center (flag) is placed from the creative menu with no faction present, and reject invalid creative placements that cause the server-side tile construction to fail.
- Ensure flag metadata fields used on both client and server are present server-side so tile entities built on the server do not depend on client-only fields.

### Description
- Remove the `@SideOnly(Side.CLIENT)` annotation from server-used metadata fields so `customFlagHash` and `ownerName` remain available in `TileEntityFlag`, `TileEntityFlagBig`, and `TileEntityConquerer` on the server.
- Harden `Flag.onBlockPlacedBy` by validating the tile entity before casting, removing the block if the tile is missing or unexpected, and returning early to avoid unsafe casts.
- Reject City Center placements when the placing player is not in a faction by removing the block and sending a clear chat message to the player.
- Preserve all existing validations for city name, duplicate city names, placement constraints, prestige and upkeep checks, and claim generation logic when a valid faction is present.

### Testing
- Ran `git diff --check` to verify no whitespace or trivial diffs were introduced and it passed.
- Ran `rg -n -U "@SideOnly\(Side\.CLIENT\)\n\s*public String (ownerName|customFlagHash) = \"\""` to confirm those initialized metadata fields are no longer client-only and the search returned no matches.
- Attempted `gradle compileJava` to perform a full compile, but the build was blocked by the environment: ForgeGradle attempted remote access through a proxy and returned HTTP 403, and the legacy ForgeGradle plugin surfaced Gradle 8 API incompatibility, so compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f9e03cb4c832986efb49682103327)