### PR TITLE
Add MCHeli explosion sound compatibility

### DIFF
--- a/src/main/java/com/hfr/handler/ExplosionSound.java
+++ b/src/main/java/com/hfr/handler/ExplosionSound.java
@@ -11,25 +11,60 @@ import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 
 public class ExplosionSound {
-	
+
 	public static final double max = 8;
-	
+	private static final String MCHELI_EXPLOSION_CLASS = "mcheli.MCH_Explosion";
+
 	public static void handleExplosion(World world, Explosion explosion) {
-		
-		if(world.isRemote)
+
+		if(explosion == null)
 			return;
 
-		double x = explosion.explosionX;
-		double y = explosion.explosionY;
-		double z = explosion.explosionZ;
-		float pow = explosion.explosionSize;
-		
+		handleExplosion(world, explosion.explosionX, explosion.explosionY, explosion.explosionZ, explosion.explosionSize);
+	}
+
+	/**
+	 * Compatibility hook for MCHeli explosions. MCHeli creates its own
+	 * Explosion subclass directly instead of going through World#newExplosion,
+	 * so Forge's ExplosionEvent.Detonate is not always fired and the normal
+	 * Forge event listener never gets a chance to send the far explosion
+	 * sound packet.
+	 *
+	 * Add this call in MCH_Explosion after doExplosionB(true):
+	 * ExplosionSound.handleMCHeliExplosion(w, exp);
+	 */
+	public static void handleMCHeliExplosion(World world, Explosion explosion) {
+		if(explosion == null)
+			return;
+
+		if(!MCHELI_EXPLOSION_CLASS.equals(explosion.getClass().getName()))
+			return;
+
+		if(!isMCHeliExplosionSoundEnabled(explosion))
+			return;
+
+		handleExplosion(world, explosion);
+	}
+
+	/**
+	 * Coordinate-only MCHeli hook for patched MCH_Explosion sources that do not
+	 * want to expose the Explosion instance.
+	 */
+	public static void handleMCHeliExplosion(World world, double x, double y, double z, float pow) {
+		handleExplosion(world, x, y, z, pow);
+	}
+
+	private static void handleExplosion(World world, double x, double y, double z, float pow) {
+
+		if(world == null || world.isRemote)
+			return;
+
 		if(pow < 3)
 			return;
-		
+
 		if(pow > max)
 			pow = (float)max;
-		
+
 		double farRange = 1000D * pow / max;
 		PacketDispatcher.wrapper.sendToAllAround(new ExplosionSoundPacket((int)x, (int)y, (int)z, pow), new TargetPoint(world.provider.dimensionId, x, y, z, farRange));
 
@@ -38,25 +73,31 @@ public class ExplosionSound {
 		data.setFloat("strength", pow);
 		PacketDispatcher.wrapper.sendToAllAround(new AuxParticlePacketNT(data, x, y, z), new TargetPoint(world.provider.dimensionId, x, y, z, 150));
 	}
-	
+
+	private static boolean isMCHeliExplosionSoundEnabled(Explosion explosion) {
+		try {
+			return explosion.getClass().getField("isPlaySound").getBoolean(explosion);
+		} catch(Exception ignored) {
+			return true;
+		}
+	}
+
 	public static void handleClient(EntityPlayer player, int x, int y, int z, float pow) {
 
 		World world = player.worldObj;
 		double closeRange = 50D * pow / max;
 		double mediumRange = 250D * pow / max;
 		double farRange = 1000D * pow / max;
-		
+
 		double distance = Math.sqrt(Math.pow(player.posX - x, 2) + Math.pow(player.posY - y, 2) + Math.pow(player.posZ - z, 2));
-		
+
 		if(distance <= closeRange) {
 			world.playSound(player.posX, player.posY, player.posZ, "hfr:explosion.close", 100, 0.8F + world.rand.nextFloat() * 0.4F, false);
 		} else if(distance <= mediumRange) {
 			world.playSound(player.posX, player.posY, player.posZ, "hfr:explosion.medium", 100, 0.8F + world.rand.nextFloat() * 0.4F, false);
 		} else if(distance <= farRange) {
 			world.playSound(player.posX, player.posY, player.posZ, "hfr:explosion.rumble", 100, 0.8F + world.rand.nextFloat() * 0.4F, false);
-		} 
+		}
 	}
 
 }
-
-//todo mcheli compat for ts but its infnite bullshit


### PR DESCRIPTION
### Motivation
- MCHeli creates its own `Explosion` subclass and sometimes bypasses Forge's normal explosion event flow, so the far-range explosion sound/particle packets were not always sent for MCHeli explosions.\n
### Description
- Add MCHeli compatibility hooks in `com.hfr.handler.ExplosionSound`: `handleMCHeliExplosion(World, Explosion)` and `handleMCHeliExplosion(World, double x, double y, double z, float pow)`.\n- Refactor the sound/particle packet dispatch into a shared coordinate helper `handleExplosion(World,double,double,double,float)` so Forge and MCHeli callers share the same clamping, range calculation and packet behaviour.\n- Add reflection-based check `isMCHeliExplosionSoundEnabled(Explosion)` that reads the `isPlaySound` field on `mcheli.MCH_Explosion` so MCHeli explosions that intentionally disable sound are respected, and include inline docs instructing where to call the compatibility hook from `MCH_Explosion`.\n
### Testing
- Ran `git diff --check` to validate there are no trailing-whitespace/style issues and it passed.\n- Attempted `gradle compileJava` to validate the project build but it could not complete in this environment because the local Gradle (8.x) is incompatible with the legacy ForgeGradle 1.2 build script and project evaluation failed with `You must set the Minecraft Version!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a222f27ce308323bee555ffa3c87f02)