### PR TITLE
Add MCHeli compatibility and refactor explosion sound handling

### DIFF
--- a/src/main/java/com/hfr/handler/ExplosionSound.java
+++ b/src/main/java/com/hfr/handler/ExplosionSound.java
@@ -11,52 +11,108 @@ import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
 
 public class ExplosionSound {
-	
+
 	public static final double max = 8;
-	
+	private static final String MCHELI_EXPLOSION_CLASS = "mcheli.MCH_Explosion";
+
 	public static void handleExplosion(World world, Explosion explosion) {
-		
-		if(world.isRemote)
+
+		if(explosion == null)
 			return;
 
-		double x = explosion.explosionX;
-		double y = explosion.explosionY;
-		double z = explosion.explosionZ;
-		float pow = explosion.explosionSize;
-		
+		boolean isMCHeliExplosion = isMCHeliExplosion(explosion);
+
+		if(isMCHeliExplosion && !isMCHeliExplosionSoundEnabled(explosion))
+			return;
+
+		handleExplosion(world, explosion.explosionX, explosion.explosionY, explosion.explosionZ, explosion.explosionSize, !isMCHeliExplosion);
+	}
+
+	/**
+	 * Compatibility hook for MCHeli explosions. MCHeli creates its own
+	 * Explosion subclass directly instead of going through World#newExplosion,
+	 * so Forge's ExplosionEvent.Detonate is not always fired and the normal
+	 * Forge event listener never gets a chance to send the far explosion
+	 * sound packet.
+	 *
+	 * Add this call in MCH_Explosion after doExplosionB(true):
+	 * ExplosionSound.handleMCHeliExplosion(w, exp);
+	 *
+	 * This sends only the far explosion sound packet. It intentionally skips
+	 * Xenofactions' AuxParticlePacketNT because MCHeli already spawns its own
+	 * explosion particles.
+	 */
+	public static void handleMCHeliExplosion(World world, Explosion explosion) {
+		if(explosion == null)
+			return;
+
+		if(!isMCHeliExplosion(explosion))
+			return;
+
+		if(!isMCHeliExplosionSoundEnabled(explosion))
+			return;
+
+		handleExplosion(world, explosion.explosionX, explosion.explosionY, explosion.explosionZ, explosion.explosionSize, false);
+	}
+
+	/**
+	 * Coordinate-only MCHeli hook for patched MCH_Explosion sources that do not
+	 * want to expose the Explosion instance.
+	 */
+	public static void handleMCHeliExplosion(World world, double x, double y, double z, float pow) {
+		handleExplosion(world, x, y, z, pow, false);
+	}
+
+	private static void handleExplosion(World world, double x, double y, double z, float pow, boolean spawnParticles) {
+
+		if(world == null || world.isRemote)
+			return;
+
 		if(pow < 3)
 			return;
-		
+
 		if(pow > max)
 			pow = (float)max;
-		
+
 		double farRange = 1000D * pow / max;
 		PacketDispatcher.wrapper.sendToAllAround(new ExplosionSoundPacket((int)x, (int)y, (int)z, pow), new TargetPoint(world.provider.dimensionId, x, y, z, farRange));
 
-		NBTTagCompound data = new NBTTagCompound();
-		data.setString("type", "explosion");
-		data.setFloat("strength", pow);
-		PacketDispatcher.wrapper.sendToAllAround(new AuxParticlePacketNT(data, x, y, z), new TargetPoint(world.provider.dimensionId, x, y, z, 150));
+		if(spawnParticles) {
+			NBTTagCompound data = new NBTTagCompound();
+			data.setString("type", "explosion");
+			data.setFloat("strength", pow);
+			PacketDispatcher.wrapper.sendToAllAround(new AuxParticlePacketNT(data, x, y, z), new TargetPoint(world.provider.dimensionId, x, y, z, 150));
+		}
 	}
-	
+
+	private static boolean isMCHeliExplosion(Explosion explosion) {
+		return explosion != null && MCHELI_EXPLOSION_CLASS.equals(explosion.getClass().getName());
+	}
+
+	private static boolean isMCHeliExplosionSoundEnabled(Explosion explosion) {
+		try {
+			return explosion.getClass().getField("isPlaySound").getBoolean(explosion);
+		} catch(Exception ignored) {
+			return true;
+		}
+	}
+
 	public static void handleClient(EntityPlayer player, int x, int y, int z, float pow) {
 
 		World world = player.worldObj;
 		double closeRange = 50D * pow / max;
 		double mediumRange = 250D * pow / max;
 		double farRange = 1000D * pow / max;
-		
+
 		double distance = Math.sqrt(Math.pow(player.posX - x, 2) + Math.pow(player.posY - y, 2) + Math.pow(player.posZ - z, 2));
-		
+
 		if(distance <= closeRange) {
 			world.playSound(player.posX, player.posY, player.posZ, "hfr:explosion.close", 100, 0.8F + world.rand.nextFloat() * 0.4F, false);
 		} else if(distance <= mediumRange) {
 			world.playSound(player.posX, player.posY, player.posZ, "hfr:explosion.medium", 100, 0.8F + world.rand.nextFloat() * 0.4F, false);
 		} else if(distance <= farRange) {
 			world.playSound(player.posX, player.posY, player.posZ, "hfr:explosion.rumble", 100, 0.8F + world.rand.nextFloat() * 0.4F, false);
-		} 
+		}
 	}
 
 }
-
-//todo mcheli compat for ts but its infnite bullshit


### PR DESCRIPTION
### Motivation

- Ensure explosions created by the MCHeli mod still trigger the far explosion sound when MCHeli bypasses normal Forge explosion events.
- Respect MCHeli's per-explosion `isPlaySound` setting and avoid spawning duplicate particles for MCHeli explosions.
- Centralize explosion sound/particle logic so other callers can trigger the same behavior via coordinate-only hooks.

### Description

- Add `handleMCHeliExplosion(World, Explosion)` and `handleMCHeliExplosion(World, double, double, double, float)` as MCHeli compatibility hooks that call a unified handler with `spawnParticles=false`.
- Refactor explosion handling into a new `handleExplosion(World, double, double, double, float, boolean)` that early-returns on nulls/clients, clamps `pow` to `max`, and optionally sends the `AuxParticlePacketNT` only when `spawnParticles` is true.
- Add detection for MCHeli explosions via `MCHELI_EXPLOSION_CLASS` name and respect the `isPlaySound` reflection flag via `isMCHeliExplosionSoundEnabled`.
- Keep the client-side sound logic in `handleClient` unchanged except for formatting, and remove the previous inline Explosion-based handling.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a222f27ce308323bee555ffa3c87f02)