### PR TITLE
Add optional Guide-API Xenofactions handbook

### DIFF
--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -12,6 +12,7 @@ import com.hfr.clowder.Clowder.ScheduledTeleport;
 import com.hfr.clowder.ClowderFlag;
 import com.hfr.clowder.flag.CustomFlagService;
 import com.hfr.config.XFConfig;
+import com.hfr.guide.XFGuideIntegration;
 import com.hfr.clowder.CityLevel;
 import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.Ownership;
@@ -140,6 +141,11 @@ public class CommandClowder extends CommandBase {
 			return;
 		}
 
+		if(cmd.equals("guide") || cmd.equals("handbook") || cmd.equals("book")) {
+			cmdHandbook(sender);
+			return;
+		}
+
 		if(cmd.equals("create")) {
 			if(!requireArgs(sender, cmd, args, 2)) return;
 			String rawName = joinArgs(args, 1);
@@ -212,7 +218,7 @@ public class CommandClowder extends CommandBase {
 		if(cmd.equals("promote")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdPromote(sender, args[1]); return; }
 		if(cmd.equals("demote")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdDemote(sender, args[1]); return; }
 		if(cmd.equals("nameclaim")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdNameClaim(sender, joinArgs(args, 1)); return; }
-		if(cmd.equals("declarewar")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdDeclareWar(sender, joinArgs(args, 1)); return; }
+		if(cmd.equals("declarewar") || cmd.equals("war")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdDeclareWar(sender, joinArgs(args, 1)); return; }
 		if(cmd.equals("peace")) {
 			if(!requireArgs(sender, cmd, args, 2)) return;
 			// Faction names containing spaces should be written with underscores when a transfer city is supplied.
@@ -266,7 +272,7 @@ public class CommandClowder extends CommandBase {
 		if(cmd.equals("promote")) return "/c promote <player>";
 		if(cmd.equals("demote")) return "/c demote <player>";
 		if(cmd.equals("nameclaim")) return "/c nameclaim <name>";
-		if(cmd.equals("declarewar")) return "/c declarewar <faction>";
+		if(cmd.equals("declarewar") || cmd.equals("war")) return "/c war <faction>";
 		if(cmd.equals("peace")) return "/c peace <faction> {city}";
 		if(cmd.equals("acceptpeace")) return "/c acceptpeace <faction>";
 		if(cmd.equals("ceasefire")) return "/c ceasefire <faction>";
@@ -274,6 +280,7 @@ public class CommandClowder extends CommandBase {
 		if(cmd.equals("surrender")) return "/c surrender <faction>";
 		if(cmd.equals("acceptsurrender")) return "/c acceptsurrender <faction>";
 		if(cmd.equals("defendally")) return "/c defendally <ally>";
+		if(cmd.equals("guide") || cmd.equals("handbook") || cmd.equals("book")) return "/c guide";
 		return getCommandUsage(null);
 	}
 
@@ -291,6 +298,7 @@ public class CommandClowder extends CommandBase {
 		if(p == 1) {
 			sender.addChatMessage(new ChatComponentText(TITLE + "Basics & faction info"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-help {page}" + TITLE + " - Shows these help pages"));
+			sender.addChatMessage(new ChatComponentText(COMMAND + "-guide" + TITLE + " - Gets the handbook or explains how to enable it"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-create <name>" + TITLE + " - Creates a faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-info {faction}" + TITLE + " - Shows info on your faction or another faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-list" + TITLE + " - Lists all factions"));
@@ -357,7 +365,7 @@ public class CommandClowder extends CommandBase {
 
 		if(p == 6) {
 			sender.addChatMessage(new ChatComponentText(TITLE + "War & related utility commands"));
-			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-declarewar <faction>" + TITLE + " - Declares war on another faction"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-war <faction>" + TITLE + " - Declares war on another faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-peace <faction> {city}" + TITLE + " - Proposes peace, optionally transferring a city"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-acceptpeace <faction>" + TITLE + " - Accepts a peace proposal"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-ceasefire <faction>" + TITLE + " - Proposes a ceasefire"));
@@ -366,6 +374,23 @@ public class CommandClowder extends CommandBase {
 			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-acceptsurrender <faction>" + TITLE + " - Accepts enemy surrender"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_LEADER + "-defendally <ally>" + TITLE + " - Joins an ally's active wars"));
 			sender.addChatMessage(new ChatComponentText(INFO + "/xmap for a claim map, /xflags for conquest flags, /xmulti for a multitool."));
+		}
+	}
+
+
+	private void cmdHandbook(ICommandSender sender) {
+		if(XFGuideIntegration.isHandbookAvailable()) {
+			try {
+				EntityPlayer player = getCommandSenderAsPlayer(sender);
+				ItemStack handbook = XFGuideIntegration.getHandbookStack();
+				if(handbook != null && !player.inventory.addItemStackToInventory(handbook))
+					player.dropPlayerItemWithRandomChoice(handbook, false);
+				sender.addChatMessage(new ChatComponentText(INFO + XFGuideIntegration.translate("guide.xenofactions.command.added")));
+			} catch(Exception e) {
+				sender.addChatMessage(new ChatComponentText(INFO + XFGuideIntegration.getFallbackHelpMessage()));
+			}
+		} else {
+			sender.addChatMessage(new ChatComponentText(INFO + XFGuideIntegration.getFallbackHelpMessage()));
 		}
 	}
 
@@ -2078,11 +2103,11 @@ private void cmdCreate(ICommandSender sender, String name) {
 	}
 
 	private String[] getPlayerCommandNames() {
-		return new String[] { "help", "create", "info", "list", "comrades", "alliance", "leave", "apply",
+		return new String[] { "help", "guide", "handbook", "book", "create", "info", "list", "comrades", "alliance", "leave", "apply",
 				"applicants", "accept", "deny", "kick", "owner", "promote", "demote", "rename", "color", "motd",
 				"listflags", "flag", "gracebuild", "sethome", "home", "setwarp", "addwarp", "delwarp", "warp", "warps",
 				"claim", "city", "nameclaim", "balance", "deposit", "withdraw", "befriend", "ally", "acceptfriend",
-				"acceptally", "unfriend", "unally", "setallywarp", "allywarp", "merge", "acceptmerge", "declarewar",
+				"acceptally", "unfriend", "unally", "setallywarp", "allywarp", "merge", "acceptmerge", "declarewar", "war",
 				"peace", "acceptpeace", "ceasefire", "acceptceasefire", "surrender", "acceptsurrender", "defendally" };
 	}
 
@@ -2094,7 +2119,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 	private boolean isFactionCompletionCommand(String cmd) {
 		return cmd.equals("info") || cmd.equals("apply") || cmd.equals("befriend") || cmd.equals("ally")
 				|| cmd.equals("unfriend") || cmd.equals("unally") || cmd.equals("allywarp") || cmd.equals("merge")
-				|| cmd.equals("acceptmerge") || cmd.equals("declarewar") || cmd.equals("peace") || cmd.equals("acceptpeace")
+				|| cmd.equals("acceptmerge") || cmd.equals("declarewar") || cmd.equals("war") || cmd.equals("peace") || cmd.equals("acceptpeace")
 				|| cmd.equals("ceasefire") || cmd.equals("acceptceasefire") || cmd.equals("surrender")
 				|| cmd.equals("acceptsurrender") || cmd.equals("defendally");
 	}

--- a/src/main/java/com/hfr/config/XFConfig.java
+++ b/src/main/java/com/hfr/config/XFConfig.java
@@ -43,6 +43,7 @@ public final class XFConfig {
 	public static boolean enableTDM = true;
 	public static boolean enableCustomFactionFlags = true;
 	public static boolean enableNewPlayerProtection = false;
+	public static boolean enableGuideBook = true;
 	public static boolean enableConquestFlagsCommand = true;
 	public static boolean warEnabledDefault = false;
 
@@ -133,6 +134,7 @@ public final class XFConfig {
 		enableTDM = bool(config, CAT_MODULES, "enableTDM", enableTDM, "Enables Xenofactions TDM commands and event hooks.");
 		enableCustomFactionFlags = bool(config, CAT_MODULES, "enableCustomFactionFlags", enableCustomFactionFlags, "Enables imported custom faction flags via /c flag seturl.");
 		enableNewPlayerProtection = bool(config, CAT_MODULES, "enableNewPlayerProtection", enableNewPlayerProtection, "Enables starter PvP/keep-inventory protection for first-time players.");
+		enableGuideBook = bool(config, CAT_MODULES, "enableGuideBook", enableGuideBook, "Registers the optional Guide-API Xenofactions handbook when Guide-API is installed.");
 		enableConquestFlagsCommand = bool(config, CAT_MODULES, "enableConquestFlagsCommand", enableConquestFlagsCommand, "Enables the /xflags command that grants conquest flags while wars are enabled.");
 
 		startingPrestige = flt(config, CAT_PRESTIGE_GENERATION, "startingPrestige", startingPrestige, 0F, 1000000F, "Prestige granted to newly-created factions.");

--- a/src/main/java/com/hfr/guide/XFGuideIntegration.java
+++ b/src/main/java/com/hfr/guide/XFGuideIntegration.java
@@ -1,0 +1,195 @@
+package com.hfr.guide;
+
+import java.awt.Color;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.hfr.config.XFConfig;
+import com.hfr.items.ModItems;
+import com.hfr.lib.RefStrings;
+import com.hfr.main.MainRegistry;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.StatCollector;
+
+public final class XFGuideIntegration {
+
+	private static final String GUIDE_API_MODID = "guideapi";
+	private static final String BOOK_KEY_PREFIX = "guide.xenofactions.";
+	private static boolean registrationAttempted = false;
+	private static boolean registered = false;
+	private static ItemStack handbookStack;
+
+	private XFGuideIntegration() { }
+
+	public static void registerGuideBook() {
+		if(registrationAttempted)
+			return;
+
+		registrationAttempted = true;
+
+		if(!XFConfig.enableGuideBook) {
+			MainRegistry.logger.info("Xenofactions handbook registration disabled by config.");
+			return;
+		}
+
+		if(!Loader.isModLoaded(GUIDE_API_MODID)) {
+			MainRegistry.logger.info("Guide-API missing; Xenofactions handbook will not be registered. Install Guide-API for the in-game handbook.");
+			return;
+		}
+
+		try {
+			Reflection r = new Reflection();
+			Object book = r.newBook(buildCategories(r), key("title"), key("welcome"), key("item.name"), RefStrings.NAME, new Color(0x32, 0x6A, 0xA8));
+			r.registerBook(book);
+			handbookStack = r.getItemStackForBook(book);
+			if(handbookStack != null) {
+				GameRegistry.addShapelessRecipe(handbookStack.copy(), Items.book, Items.paper, ModItems.province_point);
+			}
+			registered = true;
+			MainRegistry.logger.info("Registered Xenofactions handbook with Guide-API.");
+		} catch(Throwable t) {
+			registered = false;
+			handbookStack = null;
+			MainRegistry.logger.error("Failed to register Xenofactions handbook with Guide-API.", t);
+		}
+	}
+
+	public static boolean isHandbookAvailable() {
+		return registered && handbookStack != null;
+	}
+
+	public static ItemStack getHandbookStack() {
+		return handbookStack == null ? null : handbookStack.copy();
+	}
+
+	public static String getFallbackHelpMessage() {
+		if(!XFConfig.enableGuideBook)
+			return tr("guide.xenofactions.fallback.disabled");
+		if(!Loader.isModLoaded(GUIDE_API_MODID))
+			return tr("guide.xenofactions.fallback.missing");
+		if(!isHandbookAvailable())
+			return tr("guide.xenofactions.fallback.failed");
+		return tr("guide.xenofactions.fallback.available");
+	}
+
+	private static List buildCategories(Reflection r) throws Exception {
+		List categories = new ArrayList();
+		categories.add(category(r, "getting_started", new ItemStack(Items.compass), entry(r, "first_steps", new ItemStack(Items.wooden_axe),
+				page(r, "getting_started.first_steps.1", fmt(XFConfig.startingPrestige), fmt(XFConfig.cityUpgradeCosts, 0)),
+				page(r, "getting_started.first_steps.2"))));
+		categories.add(category(r, "factions_commands", new ItemStack(Items.paper), entry(r, "daily_commands", new ItemStack(Items.paper),
+				page(r, "factions_commands.daily.1"),
+				page(r, "factions_commands.daily.2", fmt(MainRegistry.warpCost)))));
+		categories.add(category(r, "city_claims", new ItemStack(Blocks.beacon), entry(r, "claiming", new ItemStack(ModItems.province_point),
+				page(r, "city_claims.claiming.1", Integer.toString(XFConfig.cityRadii[0]), Integer.toString(XFConfig.maxCityRadius), Integer.toString(XFConfig.minCitySpacingChunks)),
+				page(r, "city_claims.claiming.2", fmt(XFConfig.cityUpkeep, 0)))));
+		categories.add(category(r, "prestige_upkeep", new ItemStack(ModItems.cog), entry(r, "prestige", new ItemStack(ModItems.coin),
+				page(r, "prestige_upkeep.prestige.1", fmt(XFConfig.basePrestigeGen), fmt(XFConfig.prestigeGenCap)),
+				page(r, "prestige_upkeep.prestige.2", fmt(XFConfig.financialCrisisThreshold), fmt(XFConfig.nationalCollapseThreshold), fmt(XFConfig.fallenNationThreshold)))));
+		categories.add(category(r, "grace", new ItemStack(Items.clock), entry(r, "protection", new ItemStack(Items.clock),
+				page(r, "grace.protection.1", hours(XFConfig.pvpGraceDurationMs), hours(XFConfig.keepInventoryDurationMs)),
+				page(r, "grace.protection.2", hours(XFConfig.graceBuildDurationMs)))));
+		categories.add(category(r, "diplomacy", new ItemStack(Items.name_tag), entry(r, "allies", new ItemStack(Items.name_tag),
+				page(r, "diplomacy.allies.1"),
+				page(r, "diplomacy.allies.2", hours(XFConfig.allianceBreakCooldownMs)))));
+		categories.add(category(r, "war", new ItemStack(Items.iron_sword), entry(r, "raiding", new ItemStack(Items.iron_sword),
+				page(r, "war.raiding.1", fmt(XFConfig.warDeclarationBaseCost), fmt(XFConfig.warDeclarationTargetPrestigeFactor * 100F), Integer.toString(XFConfig.warOnlinePlayerThreshold)),
+				page(r, "war.raiding.2", hours(XFConfig.surrenderCooldownMs), hours(XFConfig.peaceCooldownMs), fmt(XFConfig.surrenderPrestigeTransferPercent * 100F)))));
+		categories.add(category(r, "admin", new ItemStack(Blocks.command_block), entry(r, "server_owner", new ItemStack(Blocks.command_block),
+				page(r, "admin.server_owner.1"),
+				page(r, "admin.server_owner.2"))));
+		categories.add(category(r, "faq", new ItemStack(Items.book), entry(r, "troubleshooting", new ItemStack(Items.book),
+				page(r, "faq.troubleshooting.1"),
+				page(r, "faq.troubleshooting.2"))));
+		return categories;
+	}
+
+	private static Object category(Reflection r, String name, ItemStack icon, Object entry) throws Exception {
+		List entries = new ArrayList();
+		entries.add(entry);
+		return r.newCategory(entries, key("category." + name), icon);
+	}
+
+	private static Object entry(Reflection r, String name, ItemStack icon, Object page1, Object page2) throws Exception {
+		List pages = new ArrayList();
+		pages.add(page1);
+		pages.add(page2);
+		return r.newEntry(pages, key("entry." + name), icon);
+	}
+
+	private static Object page(Reflection r, String name, Object... args) throws Exception {
+		return r.newPageText(tr(key("page." + name), args));
+	}
+
+	private static String key(String suffix) {
+		return BOOK_KEY_PREFIX + suffix;
+	}
+
+	public static String translate(String key, Object... args) {
+		return tr(key, args);
+	}
+
+	private static String tr(String key, Object... args) {
+		return StatCollector.translateToLocalFormatted(key, args);
+	}
+
+	private static String fmt(float value) {
+		if(Math.abs(value - Math.round(value)) < 0.001F)
+			return Integer.toString(Math.round(value));
+		return String.format(java.util.Locale.US, "%.2f", value);
+	}
+
+	private static String fmt(float[] values, int index) {
+		if(values == null || values.length == 0)
+			return "0";
+		return fmt(values[Math.max(0, Math.min(values.length - 1, index))]);
+	}
+
+	private static String hours(long ms) {
+		return Long.toString(ms / (60L * 60L * 1000L));
+	}
+
+	private static final class Reflection {
+		private final Class bookClass = Class.forName("amerifrance.guideapi.api.base.Book");
+		private final Class registryClass = Class.forName("amerifrance.guideapi.api.GuideRegistry");
+		private final Constructor bookCtor = bookClass.getConstructor(List.class, String.class, String.class, String.class, Color.class, boolean.class);
+		private final Constructor categoryCtor = Class.forName("amerifrance.guideapi.categories.CategoryItemStack").getConstructor(List.class, String.class, ItemStack.class);
+		private final Constructor entryCtor = Class.forName("amerifrance.guideapi.entries.EntryItemStack").getConstructor(List.class, String.class, ItemStack.class);
+		private final Constructor pageTextCtor = Class.forName("amerifrance.guideapi.pages.PageText").getConstructor(String.class);
+		private final Method registerBook = registryClass.getMethod("registerBook", bookClass);
+		private final Method getItemStackForBook = registryClass.getMethod("getItemStackForBook", bookClass);
+
+		private Object newBook(List categories, String title, String welcome, String displayName, String author, Color color) throws Exception {
+			Object book = bookCtor.newInstance(categories, title, welcome, displayName, color, false);
+			bookClass.getField("author").set(book, author);
+			return book;
+		}
+
+		private Object newCategory(List entries, String title, ItemStack icon) throws Exception {
+			return categoryCtor.newInstance(entries, title, icon);
+		}
+
+		private Object newEntry(List pages, String title, ItemStack icon) throws Exception {
+			return entryCtor.newInstance(pages, title, icon);
+		}
+
+		private Object newPageText(String text) throws Exception {
+			return pageTextCtor.newInstance(text);
+		}
+
+		private void registerBook(Object book) throws Exception {
+			registerBook.invoke(null, book);
+		}
+
+		private ItemStack getItemStackForBook(Object book) throws Exception {
+			return (ItemStack)getItemStackForBook.invoke(null, book);
+		}
+	}
+}

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -62,6 +62,7 @@ import com.hfr.entity.logic.*;
 import com.hfr.entity.missile.*;
 import com.hfr.entity.projectile.*;
 import com.hfr.handler.*;
+import com.hfr.guide.XFGuideIntegration;
 import com.hfr.items.*;
 import com.hfr.lib.*;
 import com.hfr.packet.*;
@@ -87,7 +88,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import static com.hfr.clowder.Clowder.initializeDiplomacy;
 
 
-@Mod(modid = RefStrings.MODID, name = RefStrings.NAME, version = RefStrings.VERSION, guiFactory = RefStrings.GUI_FACTORY)
+@Mod(modid = RefStrings.MODID, name = RefStrings.NAME, version = RefStrings.VERSION, guiFactory = RefStrings.GUI_FACTORY, dependencies = "after:guideapi")
 public class MainRegistry
 {
 	@Instance(RefStrings.MODID)
@@ -743,7 +744,7 @@ public class MainRegistry
 	@EventHandler
 	public static void load(FMLInitializationEvent event)
 	{
-		
+		XFGuideIntegration.registerGuideBook();
 	}
 
 	@Mod.EventHandler

--- a/src/main/resources/assets/hfr/lang/en_US.lang
+++ b/src/main/resources/assets/hfr/lang/en_US.lang
@@ -358,3 +358,51 @@ item.canned_spam.name=Canned Coochie
 
 item.debug.name=Metal Junk of Debugging
 item.capsule.name=Explosive Capsule
+
+guide.xenofactions.title=Xenofactions Handbook
+guide.xenofactions.welcome=Quick field notes for building, claiming, defending, and administrating factions.
+guide.xenofactions.item.name=Xenofactions Handbook
+guide.xenofactions.fallback.missing=Install Guide-API to enable the in-game Xenofactions Handbook. For now, use /c help and /xc help.
+guide.xenofactions.fallback.disabled=The Xenofactions Handbook is disabled in the Xenofactions config. Use /c help and /xc help.
+guide.xenofactions.fallback.failed=Guide-API is installed, but handbook registration failed. Check the server log, then use /c help and /xc help.
+guide.xenofactions.fallback.available=Use /c guide to receive the Xenofactions Handbook.
+
+guide.xenofactions.category.getting_started=Getting Started
+guide.xenofactions.category.factions_commands=Factions and Commands
+guide.xenofactions.category.city_claims=City Centers and Claims
+guide.xenofactions.category.prestige_upkeep=Prestige and Upkeep
+guide.xenofactions.category.grace=Grace Protection
+guide.xenofactions.category.diplomacy=Diplomacy and Allies
+guide.xenofactions.category.war=War, Raiding, Surrender, Peace
+guide.xenofactions.category.admin=Admin / Server Owner Notes
+guide.xenofactions.category.faq=FAQ / Troubleshooting
+
+guide.xenofactions.entry.first_steps=First Steps
+guide.xenofactions.entry.daily_commands=Daily Commands
+guide.xenofactions.entry.claiming=Claiming Land
+guide.xenofactions.entry.prestige=Prestige Basics
+guide.xenofactions.entry.protection=Using Grace
+guide.xenofactions.entry.allies=Working With Allies
+guide.xenofactions.entry.raiding=War Checklist
+guide.xenofactions.entry.server_owner=Server Owner Notes
+guide.xenofactions.entry.troubleshooting=FAQ / Troubleshooting
+
+guide.xenofactions.page.getting_started.first_steps.1=Start with /c help, then create a faction with /c create <name>. New factions start with %s prestige. Place your first City Center with /c claim <city>; the first configured city cost is %s prestige.
+guide.xenofactions.page.getting_started.first_steps.2=Set a safe rally point with /c sethome after claiming. Use /c info, /c list, /c comrades, and /c alliance to check your status before inviting or fighting anyone.
+guide.xenofactions.page.factions_commands.daily.1=Most player commands use /c. Try /c help, /c create, /c claim, /c sethome, /c balance, /c deposit, and /c withdraw. Officers and leaders see extra commands in /c help.
+guide.xenofactions.page.factions_commands.daily.2=Use faction homes and warps to move your group. /c sethome sets the home; /c setwarp <name> costs about %s prestige; /c warp <name> uses it.
+guide.xenofactions.page.city_claims.claiming.1=Claims are centered on named cities. Use /c claim <city name>. The first city radius is %s chunks, max city radius is %s chunks, and city centers must be about %s chunks apart.
+guide.xenofactions.page.city_claims.claiming.2=Stand in your claim and use /c city upgrade to grow it. Watch upkeep: the first configured city upkeep is %s prestige per hour, and larger cities cost more.
+guide.xenofactions.page.prestige_upkeep.prestige.1=Prestige pays for claims, war, warps, and upkeep. The configured base generation is %s per hour and generation is capped at %s per hour.
+guide.xenofactions.page.prestige_upkeep.prestige.2=If prestige drops too low, penalties can start. Current thresholds are Financial Crisis %s, National Collapse %s, and Fallen Nation %s. Keep a reserve before declaring war.
+guide.xenofactions.page.grace.protection.1=If starter protection is enabled, new players get %s hours of PvP grace and %s hours of keep-inventory. Do not waste it picking fights.
+guide.xenofactions.page.grace.protection.2=Faction leaders can use /c gracebuild when available. It gives %s hours of build grace, but it is usually one-time and cannot be used during active war.
+guide.xenofactions.page.diplomacy.allies.1=Leaders can send alliances with /c befriend <faction>. Accept with /c acceptfriend <player>. Use /c setallywarp and /c allywarp <faction> for coordination.
+guide.xenofactions.page.diplomacy.allies.2=Breaking alliances may create a no-war cooldown; the configured break cooldown is %s hours. Talk before unfriend commands so allies do not mistake it for a hostile move.
+guide.xenofactions.page.war.raiding.1=Leaders declare war with /c war <faction>. Base war cost is %s prestige plus %s%% of target prestige. Target online requirement is %s players unless admins bypass it.
+guide.xenofactions.page.war.raiding.2=Use /c peace, /c ceasefire, or /c surrender to end wars. Surrender and peace cooldowns are %s and %s hours; surrender tribute is %s%% of generation.
+guide.xenofactions.page.admin.server_owner.1=Admins should review the Xenofactions config before launch: modules, claim radii, city costs, upkeep, protection, and war cooldowns all change handbook numbers.
+guide.xenofactions.page.admin.server_owner.2=Use /xc help for admin tools. Common examples: /xc setclaim, /xc addprestige, /xc warenable, /xc wardisable, and protection reset commands.
+guide.xenofactions.page.faq.troubleshooting.1=If a command says no faction, create or join one first. If spaces fail in names, try underscores. If a city cannot be claimed, move farther from another city center.
+guide.xenofactions.page.faq.troubleshooting.2=If this handbook is missing, install Guide-API and keep enableGuideBook=true. Without the book, /c help and /xc help are the safe fallback references.
+guide.xenofactions.command.added=Added the Xenofactions Handbook to your inventory.


### PR DESCRIPTION
### Motivation
- Provide an in-game, optional Xenofactions handbook using Guide-API so players can read short, practical usage notes without leaving Minecraft. 
- Keep Guide-API optional and the mod fully functional when Guide-API is absent by avoiding hard class references. 
- Organize core faction guidance into the requested categories and pull values from the Xenofactions config where reasonable. 
- Give server owners control to enable/disable handbook registration via config.

### Description
- Add a reflection-based integration class `com.hfr.guide.XFGuideIntegration` that builds and registers a Guide-API book via reflection only when `Loader.isModLoaded("guideapi")` and `XFConfig.enableGuideBook` are true. 
- Add a config toggle `enableGuideBook` in `XFConfig` and wire it into `XFConfig.load(...)` so server owners can opt out. 
- Register the handbook during initialization with a safe call from `MainRegistry.load(...)` and log clear outcomes for: registered, missing Guide-API, disabled by config, or registration failure. 
- Add localized strings in `assets/hfr/lang/en_US.lang` for handbook titles, categories, pages, fallback messages, and a small command success key; the handbook content uses values from `XFConfig` and `MainRegistry` (e.g. prestige/cost/upkeep/cooldowns). 
- Expose the handbook to players via a new command ` /c guide` (aliases: `handbook`, `book`), which gives the book when available or returns a safe fallback message explaining how to enable Guide-API; integrate the new command into existing help text and tab-completion lists. 
- Soft-declare the optional ordering by adding `dependencies = "after:guideapi"` to the `@Mod` annotation so Forge loads safely when Guide-API is present without hard compile-time coupling. 
- Create the in-game crafting fallback/recipe (shapeless) for the handbook using `province_point + book + paper` only after the book `ItemStack` is obtained from Guide-API. 
- Add a small UX change: player-facing alias ` /c war` added alongside the existing `/c declarewar` so handbook examples match actual commands.

### Testing
- Ran static validation with `git diff --check` to ensure no obvious whitespace or diff-check issues; this passed for the modified files. 
- Performed repository-wide searches (`rg`) to locate integration points for proxies, commands, config, and localization and updated the code to avoid hard Guide-API references; these inspections completed successfully. 
- Attempted to compile with the project Gradle tasks (`gradle compileJava` and `gradle --offline compileJava`) but the legacy ForgeGradle/Minecraft setup could not be configured in this environment (proxy/ForgeGradle + installed Gradle/JDK differences), causing project configuration failures rather than code errors; see the Gradle output for `JavaExec.setMain(...)` / "You must set the Minecraft Version!" messages. 
- No unit tests were added; behavior is guarded so the mod fully loads without Guide-API and produces clear log messages when handbook registration is skipped or fails.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2779851700832997a00818ef5120b5)