### PR TITLE
Add optional Guide-API Xenofactions Handbook

### DIFF
--- a/src/main/java/assets/hfr/lang/en_US.lang
+++ b/src/main/java/assets/hfr/lang/en_US.lang
@@ -358,3 +358,65 @@ item.canned_spam.name=Canned Coochie
 
 item.debug.name=Metal Junk of Debugging
 item.capsule.name=Explosive Capsule
+
+
+# Xenofactions Guide-API Handbook
+guide.xenofactions.book.title=Xenofactions Handbook
+guide.xenofactions.book.name=Xenofactions Handbook
+guide.xenofactions.book.welcome=Quick field notes for factions, claims, prestige, diplomacy, and war. Use /c help and /xc help for live command lists.
+
+guide.xenofactions.category.getting_started=Getting Started
+guide.xenofactions.category.factions_commands=Factions and Commands
+guide.xenofactions.category.city_claims=City Centers and Claims
+guide.xenofactions.category.prestige_upkeep=Prestige and Upkeep
+guide.xenofactions.category.grace=Grace Protection
+guide.xenofactions.category.diplomacy=Diplomacy and Allies
+guide.xenofactions.category.war=War, Raiding, Surrender, Peace
+guide.xenofactions.category.admin=Admin / Server Owner Notes
+guide.xenofactions.category.faq=FAQ / Troubleshooting
+
+guide.xenofactions.entry.getting_started=Your First Steps
+guide.xenofactions.entry.first_commands=First Commands
+guide.xenofactions.entry.faction_lifecycle=Create and Manage a Faction
+guide.xenofactions.entry.member_commands=Members and Ranks
+guide.xenofactions.entry.city_centers=City Centers
+guide.xenofactions.entry.claims=Claims and Radius
+guide.xenofactions.entry.prestige=Prestige Basics
+guide.xenofactions.entry.upkeep=Upkeep Checklist
+guide.xenofactions.entry.new_player_grace=New Player Grace
+guide.xenofactions.entry.build_grace=Build Grace
+guide.xenofactions.entry.allies=Allies
+guide.xenofactions.entry.diplomacy_commands=Diplomacy Commands
+guide.xenofactions.entry.war_raiding=War and Raiding
+guide.xenofactions.entry.peace=Surrender, Peace, Ceasefire
+guide.xenofactions.entry.admin_notes=Admin Commands
+guide.xenofactions.entry.server_owner=Server Owner Setup
+guide.xenofactions.entry.troubleshooting=Troubleshooting
+guide.xenofactions.entry.quick_reference=Quick Reference
+
+guide.xenofactions.page.getting_started=Start with /c help. If you are new, check whether starter grace is active before fighting. Create a faction with /c create <name>, then set a safe home with /c sethome.
+guide.xenofactions.page.first_commands=Useful first commands: /c help, /c create <name>, /c info, /c list, /c apply <faction>, /c sethome, /c home. Admins can use /xc help for server controls.
+guide.xenofactions.page.faction_lifecycle=Use /c create <name> to start. Recruit with applications, keep your MotD clear, and use /c leave only when you are ready to exit. Leaders can rename, set colors, flags, and transfer ownership.
+guide.xenofactions.page.member_commands=Members can use /c comrades and /c alliance. Officers handle applicants, kicks, warps, and many faction settings. Leaders control ownership, war decisions, and sensitive changes.
+guide.xenofactions.page.city_centers=Use /c claim <city name> where you want a City Center. Build and defend cities before expanding. Use /c city upgrade in the current claim when your faction can afford a larger city.
+guide.xenofactions.page.claims=Stand where you want territory and use /c claim <city name>. Use /xmap to inspect claims. Rename useful areas with /c nameclaim <name> so members understand what each claim is for.
+guide.xenofactions.page.claims_config=Server config: max city radius %s chunks; minimum city spacing %s chunks. City levels currently range from radius %s to %s chunks.
+guide.xenofactions.page.prestige=Prestige pays for growth and war. Check /c balance often. Generate prestige with faction infrastructure and deposit prestige items with /c deposit <amount> when needed.
+guide.xenofactions.page.prestige_config=Server config: factions start with %s prestige. Base hourly generation is %s and counted generation caps at %s.
+guide.xenofactions.page.upkeep=Keep upkeep lower than income. Remove unused warps, tents, and vulnerable claims before prestige goes negative. Negative prestige can disable important faction options.
+guide.xenofactions.page.upkeep_config=Server config: warp tent upkeep %s/h, medical tent upkeep %s/h, city claim upkeep %s/h, active war upkeep starts at %s/h.
+guide.xenofactions.page.new_player_grace=Starter grace protects brand-new players. Use that time to make tools, join or create a faction, and learn claims before picking fights.
+guide.xenofactions.page.new_player_grace_config=Server config: starter PvP grace lasts %s hours and keep-inventory grace lasts %s hours when enabled.
+guide.xenofactions.page.build_grace=Leaders can use /c gracebuild when allowed. Activate it before major construction, not during a war. Warn members when the timer is ending.
+guide.xenofactions.page.build_grace_config=Server config: build grace lasts %s hours and is %s.
+guide.xenofactions.page.allies=Allies are political commitments. Use alliances to coordinate defense, but confirm rules before joining fights. Check /c alliance before trusting another faction.
+guide.xenofactions.page.diplomacy_commands=Use diplomacy commands carefully: request alliances, break alliances, and respond to ally defense only when leadership agrees. Use /c help for exact syntax.
+guide.xenofactions.page.diplomacy_config=Server config: alliance break cooldown is %s hours. Allies %s join wars for allies.
+guide.xenofactions.page.war_raiding=Use /c war <faction> or /c declarewar <faction> only when ready. Stock supplies, confirm online requirements, and protect City Centers before raiding.
+guide.xenofactions.page.war_config=Server config: war target online threshold %s players; raid grace after online drop %s minutes. War cost starts at %s prestige plus %s percent of target prestige.
+guide.xenofactions.page.peace=End wars with /c surrender, /c peace, or /c ceasefire when fighting is no longer worth the upkeep. Read offers before accepting because cities or tribute may transfer.
+guide.xenofactions.page.peace_config=Server config: surrender cooldown %s hours, peace cooldown %s hours, ceasefire cooldown %s hours. Surrender tribute is %s percent for %s hours.
+guide.xenofactions.page.admin_notes=Admins: use /xc help for moderation and war controls. Useful examples: /xc setclaim, /xc addprestige, /xc warenable, /xc wardisable, /xc resetbuildgrace.
+guide.xenofactions.page.server_owner=Server owners: review the Xenofactions config categories before launch. Enable Guide-API and enableGuideBook for this handbook. Tune claims, grace, war, upkeep, and Dynmap for your server size.
+guide.xenofactions.page.troubleshooting=If a command fails, check your rank, faction membership, current dimension, active wars, cooldowns, and config toggles. Try /c help or ask staff to check /xc help.
+guide.xenofactions.page.quick_reference=Common examples: /c help, /c create New_Faction, /c claim Capital, /c sethome, /c balance, /c war Enemy_Faction, /c peace Enemy_Faction, /xc help.

--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -12,6 +12,7 @@ import com.hfr.clowder.Clowder.ScheduledTeleport;
 import com.hfr.clowder.ClowderFlag;
 import com.hfr.clowder.flag.CustomFlagService;
 import com.hfr.config.XFConfig;
+import com.hfr.guide.XFGuideBook;
 import com.hfr.clowder.CityLevel;
 import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.Ownership;
@@ -291,6 +292,7 @@ public class CommandClowder extends CommandBase {
 		if(p == 1) {
 			sender.addChatMessage(new ChatComponentText(TITLE + "Basics & faction info"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-help {page}" + TITLE + " - Shows these help pages"));
+			sender.addChatMessage(new ChatComponentText(INFO + "Handbook: " + XFGuideBook.getFallbackHelp()));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-create <name>" + TITLE + " - Creates a faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-info {faction}" + TITLE + " - Shows info on your faction or another faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND + "-list" + TITLE + " - Lists all factions"));

--- a/src/main/java/com/hfr/command/CommandClowderAdmin.java
+++ b/src/main/java/com/hfr/command/CommandClowderAdmin.java
@@ -11,6 +11,7 @@ import com.hfr.clowder.ClowderTerritory.Zone;
 import com.hfr.clowder.ClowderEvents;
 import com.hfr.clowder.PlayerProtectionData;
 import com.hfr.config.XFConfig;
+import com.hfr.guide.XFGuideBook;
 import com.hfr.data.ClowderData;
 import com.hfr.packet.PacketDispatcher;
 import com.hfr.packet.effect.ClowderFlagPacket;
@@ -204,6 +205,7 @@ public class CommandClowderAdmin extends CommandBase {
 		if(p == 1) {
 			sender.addChatMessage(new ChatComponentText(TITLE + "Faction administration"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-forcejoin <faction>" + TITLE + " - Forcefully joins a faction"));
+			sender.addChatMessage(new ChatComponentText(INFO + "Handbook: " + XFGuideBook.getFallbackHelp()));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-forcekick <player>" + TITLE + " - Forcefully kicks a player from their faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-forcedisband <faction>" + TITLE + " - Forcefully disbands a faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-forcerename <name>" + TITLE + " - Forcefully renames your faction"));

--- a/src/main/java/com/hfr/config/XFConfig.java
+++ b/src/main/java/com/hfr/config/XFConfig.java
@@ -44,6 +44,7 @@ public final class XFConfig {
 	public static boolean enableCustomFactionFlags = true;
 	public static boolean enableNewPlayerProtection = false;
 	public static boolean enableConquestFlagsCommand = true;
+	public static boolean enableGuideBook = true;
 	public static boolean warEnabledDefault = false;
 
 	public static float startingPrestige = 250F;
@@ -134,6 +135,7 @@ public final class XFConfig {
 		enableCustomFactionFlags = bool(config, CAT_MODULES, "enableCustomFactionFlags", enableCustomFactionFlags, "Enables imported custom faction flags via /c flag seturl.");
 		enableNewPlayerProtection = bool(config, CAT_MODULES, "enableNewPlayerProtection", enableNewPlayerProtection, "Enables starter PvP/keep-inventory protection for first-time players.");
 		enableConquestFlagsCommand = bool(config, CAT_MODULES, "enableConquestFlagsCommand", enableConquestFlagsCommand, "Enables the /xflags command that grants conquest flags while wars are enabled.");
+		enableGuideBook = bool(config, CAT_MODULES, "enableGuideBook", enableGuideBook, "Registers the optional Guide-API Xenofactions Handbook when Guide-API is installed.");
 
 		startingPrestige = flt(config, CAT_PRESTIGE_GENERATION, "startingPrestige", startingPrestige, 0F, 1000000F, "Prestige granted to newly-created factions.");
 		basePrestigeGen = flt(config, CAT_PRESTIGE_GENERATION, "basePrestigeGeneration", basePrestigeGen, 0F, 100000F, "Base hourly prestige generation for factions.");

--- a/src/main/java/com/hfr/guide/XFGuideBook.java
+++ b/src/main/java/com/hfr/guide/XFGuideBook.java
@@ -1,0 +1,223 @@
+package com.hfr.guide;
+
+import java.awt.Color;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.hfr.config.XFConfig;
+import com.hfr.lib.RefStrings;
+import com.hfr.main.MainRegistry;
+
+import cpw.mods.fml.common.Loader;
+import net.minecraft.util.StatCollector;
+
+/**
+ * Optional Guide-API integration for the Xenofactions Handbook.
+ *
+ * This class intentionally references Guide-API classes by name only so the base mod can load
+ * when Guide-API is not installed.
+ */
+public final class XFGuideBook {
+
+	private static final String GUIDE_API_MODID = "guideapi";
+	private static final String BOOK_KEY = "guide.xenofactions.book";
+	private static final String CATEGORY_KEY = "guide.xenofactions.category.";
+	private static final String ENTRY_KEY = "guide.xenofactions.entry.";
+	private static final String PAGE_KEY = "guide.xenofactions.page.";
+
+	private static boolean registered = false;
+	private static boolean attempted = false;
+
+	private XFGuideBook() { }
+
+	public static void register() {
+		attempted = true;
+
+		if(!XFConfig.enableGuideBook) {
+			logInfo("Xenofactions Handbook registration disabled in config.");
+			return;
+		}
+
+		if(!Loader.isModLoaded(GUIDE_API_MODID)) {
+			logInfo("Guide-API missing; Xenofactions Handbook will not be registered. Install Guide-API for the in-game handbook.");
+			return;
+		}
+
+		try {
+			Object book = createBook();
+			Class guideRegistry = Class.forName("amerifrance.guideapi.api.GuideRegistry");
+			Class bookClass = Class.forName("amerifrance.guideapi.api.base.Book");
+			Method registerBook = guideRegistry.getMethod("registerBook", bookClass);
+			registerBook.invoke(null, book);
+			registered = true;
+			logInfo("Xenofactions Handbook registered with Guide-API.");
+		} catch(Throwable t) {
+			registered = false;
+			logWarn("Xenofactions Handbook registration failed. Guide-API is installed, but the book could not be created.", t);
+		}
+	}
+
+	public static boolean isAvailable() {
+		return XFConfig.enableGuideBook && registered;
+	}
+
+	public static String getFallbackHelp() {
+		if(registered)
+			return "Open the Xenofactions Handbook for quick faction help.";
+		if(!XFConfig.enableGuideBook)
+			return "In-game handbook is disabled in the config.";
+		if(!Loader.isModLoaded(GUIDE_API_MODID))
+			return "Install Guide-API to enable the Xenofactions Handbook item.";
+		if(attempted)
+			return "Xenofactions Handbook registration failed; check the server log.";
+		return "Xenofactions Handbook will load if Guide-API is installed.";
+	}
+
+	private static Object createBook() throws Exception {
+		Class bookBuilderClass = Class.forName("amerifrance.guideapi.api.util.BookBuilder");
+		Object builder = bookBuilderClass.newInstance();
+
+		invokeBuilder(builder, bookBuilderClass, "setCategories", List.class, createCategories());
+		invokeBuilder(builder, bookBuilderClass, "setUnlocBookTitle", String.class, BOOK_KEY + ".title");
+		invokeBuilder(builder, bookBuilderClass, "setUnlocDisplayName", String.class, BOOK_KEY + ".name");
+		invokeBuilder(builder, bookBuilderClass, "setUnlocWelcomeMessage", String.class, BOOK_KEY + ".welcome");
+		invokeBuilder(builder, bookBuilderClass, "setAuthor", String.class, "Xenofactions");
+		invokeBuilder(builder, bookBuilderClass, "setBookColor", Color.class, new Color(80, 35, 135));
+		invokeBuilder(builder, bookBuilderClass, "setSpawnWithBook", Boolean.TYPE, false);
+		invokeBuilder(builder, bookBuilderClass, "setIsLostBook", Boolean.TYPE, false);
+		invokeBuilder(builder, bookBuilderClass, "setItemTexture", String.class, RefStrings.MODID + ":designator_manual");
+
+		return bookBuilderClass.getMethod("build").invoke(builder);
+	}
+
+	private static void invokeBuilder(Object builder, Class builderClass, String methodName, Class argType, Object arg) throws Exception {
+		builderClass.getMethod(methodName, argType).invoke(builder, arg);
+	}
+
+	private static List createCategories() throws Exception {
+		List categories = new ArrayList();
+		categories.add(category("getting_started", entry("getting_started", "getting_started"), entry("first_commands", "first_commands")));
+		categories.add(category("factions_commands", entry("faction_lifecycle", "faction_lifecycle"), entry("member_commands", "member_commands")));
+		categories.add(category("city_claims", entry("city_centers", "city_centers"), entry("claims", "claims", configText("claims_config"))));
+		categories.add(category("prestige_upkeep", entry("prestige", "prestige", configText("prestige_config")), entry("upkeep", "upkeep", configText("upkeep_config"))));
+		categories.add(category("grace", entry("new_player_grace", "new_player_grace", configText("new_player_grace_config")), entry("build_grace", "build_grace", configText("build_grace_config"))));
+		categories.add(category("diplomacy", entry("allies", "allies"), entry("diplomacy_commands", "diplomacy_commands", configText("diplomacy_config"))));
+		categories.add(category("war", entry("war_raiding", "war_raiding", configText("war_config")), entry("peace", "peace", configText("peace_config"))));
+		categories.add(category("admin", entry("admin_notes", "admin_notes"), entry("server_owner", "server_owner")));
+		categories.add(category("faq", entry("troubleshooting", "troubleshooting"), entry("quick_reference", "quick_reference")));
+		return categories;
+	}
+
+	private static Object category(String key, Object... entries) throws Exception {
+		List entryList = new ArrayList();
+		for(int i = 0; i < entries.length; i++)
+			entryList.add(entries[i]);
+
+		Class categoryClass = Class.forName("amerifrance.guideapi.api.base.CategoryBase");
+		Constructor constructor = categoryClass.getConstructor(List.class, String.class);
+		return constructor.newInstance(entryList, CATEGORY_KEY + key);
+	}
+
+	private static Object entry(String entryKey, String pageKey) throws Exception {
+		return entry(entryKey, pageKey, null);
+	}
+
+	private static Object entry(String entryKey, String pageKey, String extraPageText) throws Exception {
+		List pages = new ArrayList();
+		pages.add(pageUnloc(pageKey));
+		if(extraPageText != null && extraPageText.length() > 0)
+			pages.add(pageLoc(extraPageText));
+
+		Class entryClass = Class.forName("amerifrance.guideapi.api.base.EntryBase");
+		Constructor constructor = entryClass.getConstructor(List.class, String.class);
+		return constructor.newInstance(pages, ENTRY_KEY + entryKey);
+	}
+
+	private static Object pageUnloc(String key) throws Exception {
+		Class pageClass = Class.forName("amerifrance.guideapi.pages.PageUnlocText");
+		Constructor constructor = pageClass.getConstructor(String.class, Integer.TYPE);
+		return constructor.newInstance(PAGE_KEY + key, 10);
+	}
+
+	private static Object pageLoc(String text) throws Exception {
+		Class pageClass = Class.forName("amerifrance.guideapi.pages.PageLocText");
+		Constructor constructor = pageClass.getConstructor(String.class, Integer.TYPE);
+		return constructor.newInstance(text, 10);
+	}
+
+	private static String configText(String key) {
+		String template = StatCollector.translateToLocal(PAGE_KEY + key);
+		if((PAGE_KEY + key).equals(template))
+			return fallbackConfigText(key);
+
+		if("claims_config".equals(key))
+			return String.format(template, XFConfig.maxCityRadius, XFConfig.minCitySpacingChunks, XFConfig.cityRadii[0], XFConfig.cityRadii[XFConfig.cityRadii.length - 1]);
+		if("prestige_config".equals(key))
+			return String.format(template, format(XFConfig.startingPrestige), format(XFConfig.basePrestigeGen), format(XFConfig.prestigeGenCap));
+		if("upkeep_config".equals(key))
+			return String.format(template, format(XFConfig.warpTentUpkeep), format(XFConfig.medTentUpkeep), format(XFConfig.cityClaimUpkeep), format(XFConfig.activeWarUpkeep));
+		if("new_player_grace_config".equals(key))
+			return String.format(template, hours(XFConfig.pvpGraceDurationMs), hours(XFConfig.keepInventoryDurationMs));
+		if("build_grace_config".equals(key))
+			return String.format(template, hours(XFConfig.graceBuildDurationMs), XFConfig.graceBuildOneTimeUse ? "one use per faction" : "repeatable");
+		if("diplomacy_config".equals(key))
+			return String.format(template, hours(XFConfig.allianceBreakCooldownMs), XFConfig.alliesCanJoinWars ? "can" : "cannot");
+		if("war_config".equals(key))
+			return String.format(template, XFConfig.warOnlinePlayerThreshold, minutes(XFConfig.raidGraceAfterOnlineDropMs), format(XFConfig.warDeclarationBaseCost), format(XFConfig.warDeclarationTargetPrestigeFactor * 100F));
+		if("peace_config".equals(key))
+			return String.format(template, hours(XFConfig.surrenderCooldownMs), hours(XFConfig.peaceCooldownMs), hours(XFConfig.ceasefireCooldownMs), format(XFConfig.surrenderPrestigeTransferPercent * 100F), hours(XFConfig.surrenderTributeDurationMs));
+		return template;
+	}
+
+	private static String fallbackConfigText(String key) {
+		if("claims_config".equals(key))
+			return "Configured city claim radius cap: " + XFConfig.maxCityRadius + " chunks. Minimum spacing: " + XFConfig.minCitySpacingChunks + " chunks.";
+		if("prestige_config".equals(key))
+			return "Configured starting prestige: " + format(XFConfig.startingPrestige) + ". Base hourly generation: " + format(XFConfig.basePrestigeGen) + ".";
+		if("upkeep_config".equals(key))
+			return "Configured upkeep includes warp tents at " + format(XFConfig.warpTentUpkeep) + " and active wars at " + format(XFConfig.activeWarUpkeep) + " prestige per hour.";
+		if("new_player_grace_config".equals(key))
+			return "Configured starter grace: " + hours(XFConfig.pvpGraceDurationMs) + "h PvP and " + hours(XFConfig.keepInventoryDurationMs) + "h keep-inventory.";
+		if("build_grace_config".equals(key))
+			return "Configured build grace lasts " + hours(XFConfig.graceBuildDurationMs) + "h.";
+		if("diplomacy_config".equals(key))
+			return "Configured alliance break cooldown: " + hours(XFConfig.allianceBreakCooldownMs) + "h.";
+		if("war_config".equals(key))
+			return "Configured war online threshold: " + XFConfig.warOnlinePlayerThreshold + " players. Raid grace after online drop: " + minutes(XFConfig.raidGraceAfterOnlineDropMs) + " minutes.";
+		if("peace_config".equals(key))
+			return "Configured surrender/peace cooldowns: " + hours(XFConfig.surrenderCooldownMs) + "h / " + hours(XFConfig.peaceCooldownMs) + "h.";
+		return "See the Xenofactions config for current server values.";
+	}
+
+	private static String format(float value) {
+		if(value == (long)value)
+			return Long.toString((long)value);
+		return Float.toString(value);
+	}
+
+	private static long hours(long ms) {
+		return ms / (60L * 60L * 1000L);
+	}
+
+	private static long minutes(long ms) {
+		return ms / (60L * 1000L);
+	}
+
+	private static void logInfo(String message) {
+		if(MainRegistry.logger != null)
+			MainRegistry.logger.info(message);
+		else
+			System.out.println("[XF] " + message);
+	}
+
+	private static void logWarn(String message, Throwable t) {
+		if(MainRegistry.logger != null)
+			MainRegistry.logger.warn(message, t);
+		else {
+			System.out.println("[XF] " + message);
+			t.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -61,6 +61,7 @@ import com.hfr.entity.grenade.*;
 import com.hfr.entity.logic.*;
 import com.hfr.entity.missile.*;
 import com.hfr.entity.projectile.*;
+import com.hfr.guide.XFGuideBook;
 import com.hfr.handler.*;
 import com.hfr.items.*;
 import com.hfr.lib.*;
@@ -87,7 +88,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import static com.hfr.clowder.Clowder.initializeDiplomacy;
 
 
-@Mod(modid = RefStrings.MODID, name = RefStrings.NAME, version = RefStrings.VERSION, guiFactory = RefStrings.GUI_FACTORY)
+@Mod(modid = RefStrings.MODID, name = RefStrings.NAME, version = RefStrings.VERSION, guiFactory = RefStrings.GUI_FACTORY, dependencies = "after:guideapi")
 public class MainRegistry
 {
 	@Instance(RefStrings.MODID)
@@ -763,6 +764,7 @@ public class MainRegistry
 	{
 		//in postload, long after all blocks have been registered, the buffered config is being evaluated and processed.
 		processBuffer();
+		XFGuideBook.register();
 		
 		try {
 			BobbyBreaker.loadConfiguration(jsonDir);


### PR DESCRIPTION
### Motivation
- Provide an in-game handbook for Xenofactions using Guide-API while keeping Guide-API optional so the mod can run without it. 
- Surface concise, practical guide content (commands, workflows, and config-derived values) so players and admins can discover usage without reading external docs.

### Description
- Add a reflection-based registration class `com.hfr.guide.XFGuideBook` that builds and registers a Guide-API `Book` only when `Guide-API` is present, using `Loader.isModLoaded(...)`, `Class.forName(...)`, and reflective invocations to avoid hard references. The class logs: handbook disabled, Guide-API missing, registered, or registration failed. (`src/main/java/com/hfr/guide/XFGuideBook.java`).
- Add a config toggle `enableGuideBook` and load it from the existing Xenofactions config flow so server owners can enable/disable handbook registration via `XFConfig` (`src/main/java/com/hfr/config/XFConfig.java`).
- Trigger handbook registration in `PostLoad` via `XFGuideBook.register()` (safe/no hard references) and add optional mod ordering `dependencies = "after:guideapi"` to prefer Guide-API being initialized first without making it required (`src/main/java/com/hfr/main/MainRegistry.java`).
- Provide safe fallback help: `XFGuideBook.getFallbackHelp()` is displayed in `/c help` and `/xc help` when the book is unavailable, and commands were updated to call this method so players see a helpful hint (`src/main/java/com/hfr/command/CommandClowder.java`, `src/main/java/com/hfr/command/CommandClowderAdmin.java`).
- Add localization keys for book title, categories, entries, and short practical pages (including command examples and config-derived text placeholders) in `en_US.lang` to avoid hardcoded English strings and to allow translation (`src/main/java/assets/hfr/lang/en_US.lang`).

### Testing
- Ran a static check that ensures no hard Guide-API imports exist in project code by scanning for `amerifrance` imports; the check passed (no hard references found). (used an inline Python check). 
- Attempted project compilation with `gradle compileJava` and `gradle compileJava --offline`, but the environment blocked external Forge metadata requests (`HTTP/1.1 403 Forbidden`) and the legacy ForgeGradle 1.2 tooling is incompatible with the available Gradle/Java in this environment, so a full build could not be completed here. 
- Verified by inspection that handbook registration is reflection-only and guarded by `Loader.isModLoaded` and the `enableGuideBook` config, and that helpful log messages and fallback text are present for the three main states (disabled/missing/failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27804016e083298c0ddf13c1357a4a)