### PR TITLE
Fix custom flag image memory leak

### DIFF
--- a/src/main/java/com/hfr/client/flag/FactionFlagTextureManager.java
+++ b/src/main/java/com/hfr/client/flag/FactionFlagTextureManager.java
@@ -72,7 +72,10 @@ public class FactionFlagTextureManager {
 			return;
 		}
 		String old = HASHES.get(factionName);
+		ResourceLocation existing = TEXTURES.get(factionName);
 		HASHES.put(factionName, hash);
+		if(old != null && old.equals(hash) && existing != null)
+			return;
 		if(old == null || !old.equals(hash))
 			TEXTURES.remove(factionName);
 		if(!loadCached(factionName, hash))

--- a/src/main/java/com/hfr/clowder/flag/CustomFlagService.java
+++ b/src/main/java/com/hfr/clowder/flag/CustomFlagService.java
@@ -20,10 +20,13 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Iterator;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
 import javax.net.ssl.HttpsURLConnection;
 
 import com.hfr.clowder.Clowder;
@@ -188,11 +191,7 @@ public class CustomFlagService {
 	private static ImportResult importAndSave(Clowder clowder, String urlText) throws Exception {
 		URL url = validateUrl(urlText);
 		byte[] downloaded = download(url, 0);
-		BufferedImage input = ImageIO.read(new ByteArrayInputStream(downloaded));
-		if(input == null)
-			return new ImportResult("failed to decode image", null, null);
-		if(input.getWidth() > XFConfig.customFlagMaxWidth || input.getHeight() > XFConfig.customFlagMaxHeight)
-			return new ImportResult("image too large", null, null);
+		BufferedImage input = decodeValidatedImage(downloaded);
 		BufferedImage output = resizeToFlag(input);
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		ImageIO.write(output, "png", out);
@@ -272,6 +271,38 @@ public class CustomFlagService {
 			throw new FlagImportException("failed to decode image");
 		} finally {
 			conn.disconnect();
+		}
+	}
+
+	private static BufferedImage decodeValidatedImage(byte[] downloaded) throws IOException {
+		ImageInputStream stream = ImageIO.createImageInputStream(new ByteArrayInputStream(downloaded));
+		if(stream == null)
+			throw new FlagImportException("failed to decode image");
+		ImageReader reader = null;
+		try {
+			Iterator<ImageReader> readers = ImageIO.getImageReaders(stream);
+			if(!readers.hasNext())
+				throw new FlagImportException("failed to decode image");
+			reader = readers.next();
+			reader.setInput(stream, true, true);
+			int width = reader.getWidth(0);
+			int height = reader.getHeight(0);
+			if(width <= 0 || height <= 0)
+				throw new FlagImportException("failed to decode image");
+			if(width > XFConfig.customFlagMaxWidth || height > XFConfig.customFlagMaxHeight)
+				throw new FlagImportException("image too large");
+			long pixels = (long)width * (long)height;
+			long maxPixels = (long)XFConfig.customFlagMaxWidth * (long)XFConfig.customFlagMaxHeight;
+			if(pixels > maxPixels)
+				throw new FlagImportException("image too large");
+			BufferedImage image = reader.read(0);
+			if(image == null)
+				throw new FlagImportException("failed to decode image");
+			return image;
+		} finally {
+			if(reader != null)
+				reader.dispose();
+			stream.close();
 		}
 	}
 


### PR DESCRIPTION
### Motivation

- Repeated handling of custom-flag metadata caused cached custom flag textures to be reloaded and re-registered on every render/packet, producing extreme memory usage when using /c flag seturl with postimages-hosted images. 
- Image decoding could allocate very large pixel buffers before verifying dimensions, making the server vulnerable to high-memory image payloads during import.

### Description

- In `FactionFlagTextureManager.handleMetadata` return early when the incoming hash equals the stored hash and a texture is already registered, avoiding redundant texture re-registration and reloads. 
- In `CustomFlagService` replace the single `ImageIO.read` call with `decodeValidatedImage` that uses `ImageInputStream` and `ImageReader` to inspect `width`/`height` and total `pixels` before fully decoding, rejecting oversized or invalid images to avoid large allocations. 
- Add required imports for `ImageReader`, `ImageInputStream`, and `Iterator`, and ensure the `ImageReader` and stream are disposed/closed in a `finally` block. 

### Testing

- Ran `git diff --check` to validate there are no whitespace/git-diff issues and it succeeded. 
- Attempted `gradle test` in this environment, but the build fails during root project evaluation due to the local Gradle/Minecraft configuration (the build reports a `JavaExec.setMain(...)` incompatibility and `You must set the Minecraft Version`), so full automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a372a946d448323ad843c96228a30da)