### PR TITLE
Add multi-dimension support for claims, teleports and Dynmap integration

### DIFF
--- a/src/main/java/com/hfr/blocks/clowder/Conquerer.java
+++ b/src/main/java/com/hfr/blocks/clowder/Conquerer.java
@@ -96,7 +96,7 @@ public class Conquerer extends BlockContainer {
 				flag.markDirty();
 				MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(
 						EnumChatFormatting.RED + "[WAR] " + EnumChatFormatting.GOLD + clowder.name +
-						EnumChatFormatting.YELLOW + " placed a claim flag for " + getTargetCityName(x, z) +
+						EnumChatFormatting.YELLOW + " placed a claim flag for " + getTargetCityName(world, x, z) +
 						EnumChatFormatting.YELLOW + " at " + EnumChatFormatting.AQUA + "(" + x + ", " + y + ", " + z + ")"
 				));
 			} else {
@@ -129,8 +129,8 @@ public class Conquerer extends BlockContainer {
 
 	}
 	
-	private String getTargetCityName(int x, int z) {
-		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords(x, z);
+	private String getTargetCityName(World world, int x, int z) {
+		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords(world, x, z);
 		if(meta != null) {
 			String cityName = meta.cityName != null && !meta.cityName.trim().isEmpty() ? meta.cityName : meta.name;
 			if(cityName != null && !cityName.trim().isEmpty()) {

--- a/src/main/java/com/hfr/blocks/clowder/Flag.java
+++ b/src/main/java/com/hfr/blocks/clowder/Flag.java
@@ -111,7 +111,7 @@ public class Flag extends BlockContainer {
 
 			String cityName = itemStack.hasTagCompound() ? itemStack.stackTagCompound.getString("cityName") : "";
 			CoordPair cityChunk = ClowderTerritory.getCoordPair(x, z);
-			String cityError = ClowderTerritory.getCityPlacementError(cityChunk.x, cityChunk.z);
+			String cityError = ClowderTerritory.getCityPlacementError(world, cityChunk.x, cityChunk.z);
 
 			if(cityName == null || cityName.trim().isEmpty()) {
 				world.setBlockToAir(x, y, z);

--- a/src/main/java/com/hfr/clowder/Clowder.java
+++ b/src/main/java/com/hfr/clowder/Clowder.java
@@ -51,6 +51,7 @@ public class Clowder {
 	public int homeX;
 	public int homeY;
 	public int homeZ;
+	public int homeDim;
 	public HashMap<String, int[]> warps = new HashMap();
 
 	//tracks how many times the clowder has bought from this market option
@@ -150,6 +151,7 @@ public class Clowder {
 	public int allyWarpX;
 	public int allyWarpY;
 	public int allyWarpZ;
+	public int allyWarpDim;
 	public long buildGraceUntil = 0L;
 	public boolean buildGraceUsed = false;
 	public String surrenderTributeTo = "";
@@ -1053,8 +1055,10 @@ public class Clowder {
 		this.homeX = (int) x;
 		this.homeY = (int) y;
 		this.homeZ = (int) z;
+		this.homeDim = player != null ? ClowderTerritory.getDimensionId(player.worldObj) : 0;
 
-		ClowderData.getData(player.worldObj).markDirty();
+		if(player != null && player.worldObj != null)
+			ClowderData.getData(player.worldObj).markDirty();
 	}
 
 	public void setAllyWarp(double x, double y, double z, EntityPlayer player) {
@@ -1062,8 +1066,10 @@ public class Clowder {
 		this.allyWarpX = (int) x;
 		this.allyWarpY = (int) y;
 		this.allyWarpZ = (int) z;
+		this.allyWarpDim = player != null ? ClowderTerritory.getDimensionId(player.worldObj) : 0;
 
-		ClowderData.getData(player.worldObj).markDirty();
+		if(player != null && player.worldObj != null)
+			ClowderData.getData(player.worldObj).markDirty();
 	}
 
 	public void rename(String name, EntityPlayer player) {
@@ -1128,7 +1134,7 @@ public class Clowder {
 						tent.warp = name;
 						tent.markDirty();
 
-						clowder.warps.put(name, new int[] { x, y + 1, z });
+						clowder.warps.put(name, new int[] { x, y + 1, z, world.provider.dimensionId });
 
 						ClowderData.getData(world).markDirty();
 						return 0;
@@ -1534,9 +1540,11 @@ public class Clowder {
 		nbt.setInteger(i + "_homeX", this.homeX);
 		nbt.setInteger(i + "_homeY", this.homeY);
 		nbt.setInteger(i + "_homeZ", this.homeZ);
+		nbt.setInteger(i + "_homeDim", this.homeDim);
 		nbt.setInteger(i + "_allyWarpX", this.allyWarpX);
 		nbt.setInteger(i + "_allyWarpY", this.allyWarpY);
 		nbt.setInteger(i + "_allyWarpZ", this.allyWarpZ);
+		nbt.setInteger(i + "_allyWarpDim", this.allyWarpDim);
 		nbt.setFloat(i + "_prestige", this.prestige);
 		nbt.setFloat(i + "_prestigeGen", this.prestigeGen);
 		nbt.setFloat(i + "_prestigeReq", this.prestigeReq);
@@ -1632,6 +1640,7 @@ public class Clowder {
 			nbt.setInteger(i + "_" + j + "_x", coords[0]);
 			nbt.setInteger(i + "_" + j + "_y", coords[1]);
 			nbt.setInteger(i + "_" + j + "_z", coords[2]);
+			nbt.setInteger(i + "_" + j + "_dim", coords.length > 3 ? coords[3] : 0);
 		}
 
 		for (int j = 0; j < this.activeWars.size(); j++)
@@ -1681,9 +1690,11 @@ public class Clowder {
 		c.homeX = nbt.getInteger(i + "_homeX");
 		c.homeY = nbt.getInteger(i + "_homeY");
 		c.homeZ = nbt.getInteger(i + "_homeZ");
+		c.homeDim = nbt.hasKey(i + "_homeDim") ? nbt.getInteger(i + "_homeDim") : 0;
 		c.allyWarpX = nbt.getInteger(i + "_allyWarpX");
 		c.allyWarpY = nbt.getInteger(i + "_allyWarpY");
 		c.allyWarpZ = nbt.getInteger(i + "_allyWarpZ");
+		c.allyWarpDim = nbt.hasKey(i + "_allyWarpDim") ? nbt.getInteger(i + "_allyWarpDim") : 0;
 		c.prestige = nbt.getFloat(i + "_prestige");
 		c.canDeclareTime = Math.max(nbt.getFloat(i + "_canDeclareTime"), 0F);
 		c.fabricateTime = Math.max(nbt.getFloat(i + "_fabricateTime"), 0F);
@@ -1771,7 +1782,7 @@ public class Clowder {
 
 			String name = nbt.getString(i + "_" + j + "_name");
 			int[] coord = new int[] { nbt.getInteger(i + "_" + j + "_x"), nbt.getInteger(i + "_" + j + "_y"),
-					nbt.getInteger(i + "_" + j + "_z") };
+					nbt.getInteger(i + "_" + j + "_z"), nbt.hasKey(i + "_" + j + "_dim") ? nbt.getInteger(i + "_" + j + "_dim") : 0 };
 
 			c.warps.put(name, coord);
 		}
@@ -2003,33 +2014,52 @@ public class Clowder {
 		int posX;
 		int posY;
 		int posZ;
+		int dimensionId;
 		String player;
 		String warp;
 		boolean home;
 		boolean rendezvous = false;
 		String allyName;
 
+		public ScheduledTeleport(int dimensionId, int posX, int posY, int posZ, String player, String warp) {
+			this(posX, posY, posZ, player, warp);
+			this.dimensionId = dimensionId;
+		}
+
 		public ScheduledTeleport(int posX, int posY, int posZ, String player, String warp) {
 			this.posX = posX;
 			this.posY = posY;
 			this.posZ = posZ;
+			this.dimensionId = 0;
 			this.player = player;
 			this.warp = warp;
+		}
+
+		public ScheduledTeleport(int dimensionId, int posX, int posY, int posZ, String player, boolean home) {
+			this(posX, posY, posZ, player, home);
+			this.dimensionId = dimensionId;
 		}
 
 		public ScheduledTeleport(int posX, int posY, int posZ, String player, boolean home) {
 			this.posX = posX;
 			this.posY = posY;
 			this.posZ = posZ;
+			this.dimensionId = 0;
 			this.player = player;
 			this.home = home;
 		}
 
 		//for ally warp
+		public ScheduledTeleport(int dimensionId, int posX, int posY, int posZ, String player, boolean home, boolean rendezvous, String allyName) {
+			this(posX, posY, posZ, player, home, rendezvous, allyName);
+			this.dimensionId = dimensionId;
+		}
+
 		public ScheduledTeleport(int posX, int posY, int posZ, String player, boolean home, boolean rendezvous, String allyName) {
 			this.posX = posX;
 			this.posY = posY;
 			this.posZ = posZ;
+			this.dimensionId = 0;
 			this.player = player;
 			this.home = home;
 			this.rendezvous = rendezvous;

--- a/src/main/java/com/hfr/clowder/ClowderEvents.java
+++ b/src/main/java/com/hfr/clowder/ClowderEvents.java
@@ -58,6 +58,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.*;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.World;
+import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.ServerChatEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
@@ -297,7 +298,7 @@ public void handleChatServer(ServerChatEvent event) {
 			
 			Block b = event.world.getBlock(x, y, z);
 			
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(event.world, x, z);
 			//handleCollisionInZone(owner);
 			
 			if(event instanceof BreakEvent) {
@@ -515,7 +516,7 @@ public void handleChatServer(ServerChatEvent event) {
 			int y = pos.chunkPosY;
 			int z = pos.chunkPosZ;
 			
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(event.world, x, z);
 			
 			if(!canExplode(owner, event.world, x, y, z)) {
 				event.getAffectedBlocks().remove(i);
@@ -527,7 +528,7 @@ public void handleChatServer(ServerChatEvent event) {
 		int x = (int)event.explosion.explosionX;
 		int y = (int)event.explosion.explosionY;
 		int z = (int)event.explosion.explosionZ;
-		Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+		Ownership owner = ClowderTerritory.getOwnerFromInts(event.world, x, z);
 		
 		if(!canExplode(owner, event.world, x, y, z)) {
 			event.getAffectedBlocks().clear();
@@ -581,7 +582,7 @@ public void handleChatServer(ServerChatEvent event) {
 			if(player.getHeldItem() != null && player.getHeldItem().getItem() == ModItems.debug)
 				return;
 			
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(event.world, x, z);
 			
 			if(owner != null) {
 				Clowder clowder = Clowder.getClowderFromPlayer(event.entityPlayer);
@@ -661,7 +662,7 @@ public void handleChatServer(ServerChatEvent event) {
 	// so to fix this, track back this annoying shithole logic and fix that how god intended instead
 	private void flagPopup(World world, EntityPlayer player) {
 
-		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords((int)player.posX, (int)player.posZ - 1);
+		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords(player.worldObj, (int)player.posX, (int)player.posZ - 1);
 		
 		Ownership owner;
 		
@@ -711,7 +712,7 @@ public void handleChatServer(ServerChatEvent event) {
 
 	private void handleBuildGraceMovement(EntityPlayer player) {
 
-		Ownership owner = ClowderTerritory.getOwnerFromInts((int) player.posX, (int) player.posZ);
+		Ownership owner = ClowderTerritory.getOwnerFromInts(player.worldObj, (int) player.posX, (int) player.posZ);
 
 		if (owner == null)
 			return;
@@ -850,9 +851,9 @@ public void handleChatServer(ServerChatEvent event) {
 		for(int x = -range; x < range; x++) {
 			for(int z = -range; z < range; z++) {
 
-				Ownership center = ClowderTerritory.getOwnerFromInts(ox + x * 16 + 1, oz + z * 16);
-				Ownership north = ClowderTerritory.getOwnerFromInts(ox + (x + ForgeDirection.NORTH.offsetX) * 16 + 1, oz + (z + ForgeDirection.NORTH.offsetZ) * 16);
-				Ownership west = ClowderTerritory.getOwnerFromInts(ox + (x + ForgeDirection.WEST.offsetX) * 16 + 1, oz + (z + ForgeDirection.WEST.offsetZ) * 16);
+				Ownership center = ClowderTerritory.getOwnerFromInts(world, ox + x * 16 + 1, oz + z * 16);
+				Ownership north = ClowderTerritory.getOwnerFromInts(world, ox + (x + ForgeDirection.NORTH.offsetX) * 16 + 1, oz + (z + ForgeDirection.NORTH.offsetZ) * 16);
+				Ownership west = ClowderTerritory.getOwnerFromInts(world, ox + (x + ForgeDirection.WEST.offsetX) * 16 + 1, oz + (z + ForgeDirection.WEST.offsetZ) * 16);
 
 				Ownership none = ClowderTerritory.WILDERNESS;
 				boolean n = isTerritoryDifferent(north, center);
@@ -885,7 +886,7 @@ public void handleChatServer(ServerChatEvent event) {
 			return;
 		}
 
-		Ownership owner = ClowderTerritory.getOwner((int) entity.posX, (int) entity.posZ);
+		Ownership owner = ClowderTerritory.getOwner(entity.worldObj, (int) entity.posX, (int) entity.posZ);
 		if (owner != null && owner.zone == Zone.SAFEZONE) {
 			entity.setDead();
 			event.setCanceled(true);
@@ -927,7 +928,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 	// Check if the entity is any of the relevant types (Minecraft base entities)
 	if (entity instanceof EntityArrow || entity instanceof EntityThrowable || entity instanceof EntityFireball) {
 		// Check if the entity is in a safezone
-		Ownership owner = ClowderTerritory.getOwnerFromInts((int) entity.posX, (int) entity.posZ);
+		Ownership owner = ClowderTerritory.getOwnerFromInts(entity.worldObj, (int) entity.posX, (int) entity.posZ);
 		if (owner != null && owner.zone == Zone.SAFEZONE) {
 			event.setCanceled(true);  // Cancel the event
 			entity.setDead(); // Kill the entity
@@ -947,7 +948,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 				(MCH_EntityRocket != null && MCH_EntityRocket.isInstance(entity))) {
 
 			// Check if the entity is in a safezone
-			Ownership owner = ClowderTerritory.getOwnerFromInts((int) entity.posX, (int) entity.posZ);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(entity.worldObj, (int) entity.posX, (int) entity.posZ);
 			if (owner != null && owner.zone == Zone.SAFEZONE) {
 				event.setCanceled(true);  // Cancel the event
 				entity.setDead(); // Kill the entity
@@ -993,7 +994,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 		EntityLivingBase e = event.entityLiving;
 		DamageSource dmg = event.source;
 
-		Ownership owner = ClowderTerritory.getOwner((int)e.posX, (int)e.posZ);
+		Ownership owner = ClowderTerritory.getOwner(e.worldObj, (int)e.posX, (int)e.posZ);
 
 		if(e instanceof EntityPlayer && owner != null && owner.zone == Zone.SAFEZONE)
 			event.setCanceled(true);
@@ -1075,7 +1076,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 		// Check if the entity is one of the projectiles we care about (Minecraft base or MCHeli)
 		if (entity instanceof EntityArrow || entity instanceof EntityThrowable || entity instanceof EntityFireball) {
 			// Get the owner based on the entity's position
-			Ownership owner = ClowderTerritory.getOwnerFromInts((int) entity.posX, (int) entity.posZ);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(entity.worldObj, (int) entity.posX, (int) entity.posZ);
 
 			// If the owner exists and it's a safezone, proceed to delete the projectile
 			if (owner != null && owner.zone == Zone.SAFEZONE) {
@@ -1095,7 +1096,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 					(MCH_EntityRocket != null && MCH_EntityRocket.isInstance(entity))) {
 
 				// Get the owner based on the entity's position
-				Ownership owner = ClowderTerritory.getOwnerFromInts((int) entity.posX, (int) entity.posZ);
+				Ownership owner = ClowderTerritory.getOwnerFromInts(entity.worldObj, (int) entity.posX, (int) entity.posZ);
 
 				// If the owner exists and it's a safezone, proceed to disable the projectile
 				if (owner != null && owner.zone == Zone.SAFEZONE) {
@@ -1137,7 +1138,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 			int x = (int) e.posX;
 			int y = (int) e.posY;
 			int z = (int) e.posZ;
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(e.worldObj, x, z);
 			if (owner != null && owner.zone == Zone.SAFEZONE) {
 				// Cancel the event to prevent any damage
 				event.setCanceled(true);
@@ -1154,7 +1155,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 			int x = (int) e.posX;
 			int y = (int) e.posY;
 			int z = (int) e.posZ;
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(e.worldObj, x, z);
 			if (owner != null && owner.zone == Zone.SAFEZONE) {
 				// Apply a regeneration effect
 				e.addPotionEffect(new PotionEffect(Potion.regeneration.id, 40));
@@ -1196,7 +1197,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 		int z = MathHelper.floor_double(explosionPos.zCoord);
 
 		// Check if the explosion is within a safezone
-		Ownership owner = ClowderTerritory.getOwner(x, z);
+		Ownership owner = ClowderTerritory.getOwner(world, x, z);
 		if (owner != null && owner.zone == Zone.SAFEZONE) {
 			// Clear the affected block list to prevent block damage
 			event.getAffectedBlocks().clear();
@@ -1215,7 +1216,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 		int z = event.z;
 
 		// Check if the block is in a safezone
-		Ownership owner = ClowderTerritory.getOwner(x, z);
+		Ownership owner = ClowderTerritory.getOwner(world, x, z);
 		if (owner != null && owner.zone == Zone.SAFEZONE) {
 			Entity entity = event.getPlayer();
 
@@ -1252,7 +1253,7 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 		
 		if(!player.worldObj.isRemote) {
 
-			Ownership owner = ClowderTerritory.getOwnerFromInts((int)player.posX, (int)player.posZ - 1);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(player.worldObj, (int)player.posX, (int)player.posZ - 1);
 			flagPopup(player.worldObj, player);
 			handleBuildGraceMovement(player);
 			
@@ -1357,15 +1358,17 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 		
 		World world = event.world;
 		
-		if(world.isRemote || world.provider.dimensionId != 0 || event.phase == Phase.END)
+		if(world.isRemote || event.phase == Phase.END)
 			return;
 
-		if (hour > 0) {
-			hour--;
-		} else {
-			hour = MainRegistry.prestigeDelay;
-			Clowder.updatePrestige(world);
-			System.out.println("[Clowder] Prestige update complete.");
+		if(world.provider.dimensionId == 0) {
+			if (hour > 0) {
+				hour--;
+			} else {
+				hour = MainRegistry.prestigeDelay;
+				Clowder.updatePrestige(world);
+				System.out.println("[Clowder] Prestige update complete.");
+			}
 		}
 		
 		if(delay > 0) {
@@ -1379,14 +1382,17 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 		for(Long time : Clowder.teleports.keySet()) {
 
 			ScheduledTeleport tp = Clowder.teleports.get(time);
-			EntityPlayer player = world.getPlayerEntityByName(tp.player);
+			World tpWorld = DimensionManager.getWorld(tp.dimensionId);
+			if(tpWorld == null)
+				continue;
+			EntityPlayer player = MinecraftServer.getServer().getConfigurationManager().func_152612_a(tp.player);
 
 			if(player == null)
 				continue;
 
 			if(time < System.currentTimeMillis()) {
 
-				Ownership owner = ClowderTerritory.getOwnerFromInts(tp.posX, tp.posZ);
+				Ownership owner = ClowderTerritory.getOwnerFromInts(tp.dimensionId, tp.posX, tp.posZ);
 				Clowder me = Clowder.getClowderFromPlayer(player);
 
 				if(!tp.rendezvous && (owner == null || owner.zone != Zone.FACTION || owner.owner != me)) {
@@ -1398,6 +1404,8 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 
 					EntityPlayerMP playermp = (EntityPlayerMP)player;
 					playermp.mountEntity(null);
+					if(playermp.dimension != tp.dimensionId)
+						playermp.travelToDimension(tp.dimensionId);
 					playermp.playerNetServerHandler.setPlayerLocation(tp.posX + 0.5D, tp.posY, tp.posZ + 0.5D, player.rotationYaw, player.rotationPitch);
 
 					if(tp.rendezvous)

--- a/src/main/java/com/hfr/clowder/ClowderTerritory.java
+++ b/src/main/java/com/hfr/clowder/ClowderTerritory.java
@@ -30,27 +30,45 @@ public class ClowderTerritory {
 	public static final int WARZONE_COLOR = 0xFF0000;
 	public static final int WILDERNESS_COLOR = 0xFFFFFF;
 	
-	public static HashMap<Long, TerritoryMeta> territories = new HashMap();
+	public static HashMap<CoordPair, TerritoryMeta> territories = new HashMap();
 	
 	//the chunk coords in the CodePair wrapper class
-	public static CoordPair getCoordPair(int x, int z) {
+	public static CoordPair getCoordPair(int x, int z) { return getCoordPair(0, x, z); }
+
+	public static CoordPair getCoordPair(World world, int x, int z) { return getCoordPair(getDimensionId(world), x, z); }
+
+	public static CoordPair getCoordPair(int dimensionId, int x, int z) {
 		
 		//why is this necessary? idk but it is
 		x += 1;
 		z += 1;
 		
-		return new CoordPair(x / 16, z / 16);
+		return new CoordPair(dimensionId, x / 16, z / 16);
 	}
 	
 
 	public static boolean canPlaceCityCenter(int chunkX, int chunkZ) {
-		return getCityPlacementError(chunkX, chunkZ) == null;
+		return getCityPlacementError(0, chunkX, chunkZ) == null;
+	}
+
+	public static boolean canPlaceCityCenter(World world, int chunkX, int chunkZ) {
+		return getCityPlacementError(world, chunkX, chunkZ) == null;
+	}
+
+	public static String getCityPlacementError(World world, int chunkX, int chunkZ) {
+		return getCityPlacementError(getDimensionId(world), chunkX, chunkZ);
 	}
 
 	public static String getCityPlacementError(int chunkX, int chunkZ) {
+		return getCityPlacementError(0, chunkX, chunkZ);
+	}
+
+	public static String getCityPlacementError(int dimensionId, int chunkX, int chunkZ) {
 		for(TerritoryMeta meta : territories.values()) {
 			if(meta != null && meta.owner != null && meta.owner.zone == Zone.FACTION && meta.isCityClaim()) {
-				CoordPair other = getCoordPair(meta.flagX, meta.flagZ);
+				if(meta.dimensionId != dimensionId)
+					continue;
+				CoordPair other = getCoordPair(meta.dimensionId, meta.flagX, meta.flagZ);
 				double dist = Math.sqrt(Math.pow(chunkX - other.x, 2) + Math.pow(chunkZ - other.z, 2));
 				int required = XFConfig.minCitySpacingChunks;
 				if(dist < required)
@@ -105,7 +123,7 @@ public class ClowderTerritory {
 	}
 
 	public static int renameClaimsForCity(World world, int fX, int fY, int fZ, String name) {
-		String id = fX + "," + fY + "," + fZ;
+		String id = cityId(getDimensionId(world), fX, fY, fZ);
 		int renamed = 0;
 		for(TerritoryMeta meta : territories.values()) {
 			if(meta != null && id.equals(meta.cityId)) {
@@ -124,15 +142,15 @@ public class ClowderTerritory {
 				ClowderData.getData(world).markDirty();
 		}
 		if(renamed > 0)
-			com.hfr.dynmap.XFDynmapIntegration.markDirty();
+		com.hfr.dynmap.XFDynmapIntegration.markDirty();
 		return renamed;
 	}
 
 	public static int removeClaimsForCity(World world, int fX, int fY, int fZ) {
-		String id = fX + "," + fY + "," + fZ;
+		String id = cityId(getDimensionId(world), fX, fY, fZ);
 		int removed = 0;
-		List<Long> claims = new ArrayList(territories.keySet());
-		for(Long code : claims) {
+		List<CoordPair> claims = new ArrayList(territories.keySet());
+		for(CoordPair code : claims) {
 			TerritoryMeta meta = territories.get(code);
 			if(meta != null && id.equals(meta.cityId)) {
 				territories.remove(code);
@@ -142,7 +160,7 @@ public class ClowderTerritory {
 		if(removed > 0 && world != null)
 			ClowderData.getData(world).markDirty();
 		if(removed > 0)
-			com.hfr.dynmap.XFDynmapIntegration.markDirty();
+		com.hfr.dynmap.XFDynmapIntegration.markDirty();
 		return removed;
 	}
 
@@ -174,7 +192,7 @@ public class ClowderTerritory {
 		}
 		ClowderData.getData(world).markDirty();
 		if(moved > 0)
-			com.hfr.dynmap.XFDynmapIntegration.markDirty();
+		com.hfr.dynmap.XFDynmapIntegration.markDirty();
 		return moved;
 	}
 
@@ -187,7 +205,9 @@ public class ClowderTerritory {
 	//sets the owner of a chunk to a clowder
 	public static void setOwnerForInts(World world, int x, int z, Clowder owner, int fX, int fY, int fZ, String name) {
 		
-		long code = intsToCode(x, z);
+		if(!XFConfig.canClaimInDimension(getDimensionId(world)))
+			return;
+		CoordPair code = new CoordPair(getDimensionId(world), x, z);
 		//TerritoryMeta old = territories.get(code);
 		
 		territories.remove(code);
@@ -197,7 +217,8 @@ public class ClowderTerritory {
 		TerritoryMeta metadata = new TerritoryMeta(o, fX, fY, fZ);
 		metadata.name = name;
 		metadata.cityName = name;
-		metadata.cityId = fX + "," + fY + "," + fZ;
+		metadata.dimensionId = getDimensionId(world);
+		metadata.cityId = cityId(metadata.dimensionId, fX, fY, fZ);
 		//fuck this goddamn shithole of a mod
 		TileEntity flag = world.getTileEntity(fX, fY, fZ);
 		if(flag != null) {
@@ -221,7 +242,9 @@ public class ClowderTerritory {
 	//sets the owner of a chunk to a special zone
 	public static void setZoneForInts(World world, int x, int z, Zone zone) {
 		
-		long code = intsToCode(x, z);
+		if(!XFConfig.canClaimInDimension(getDimensionId(world)))
+			return;
+		CoordPair code = new CoordPair(getDimensionId(world), x, z);
 		
 		territories.remove(code);
 		
@@ -245,7 +268,7 @@ public class ClowderTerritory {
 	//removes territory metadata
 	public static void removeZoneForInts(World world, int x, int z) {
 
-		long code = intsToCode(x, z);
+		CoordPair code = new CoordPair(getDimensionId(world), x, z);
 		territories.remove(code);
 		
 		ClowderData.getData(world).markDirty();
@@ -255,21 +278,29 @@ public class ClowderTerritory {
 	//returns the ownership information of the chunk
 	public static Ownership getOwnerFromCoords(CoordPair coords) {
 		
-		return getOwner(coords.x, coords.z);
+		return getOwner(coords.dimensionId, coords.x, coords.z);
 	}
 	
 	//returns the ownership information of the chunk
-	public static Ownership getOwnerFromInts(int x, int z) {
+	public static Ownership getOwnerFromInts(int x, int z) { return getOwnerFromInts(0, x, z); }
+
+	public static Ownership getOwnerFromInts(World world, int x, int z) { return getOwnerFromInts(getDimensionId(world), x, z); }
+
+	public static Ownership getOwnerFromInts(int dimensionId, int x, int z) {
 
 		z += 1;
 		
-		return getOwner(x / 16, z / 16);
+		return getOwner(dimensionId, x / 16, z / 16);
 	}
 	
 	//returns the ownership information of the chunk
-	public static Ownership getOwner(int x, int z) {
+	public static Ownership getOwner(World world, int x, int z) { return getOwner(getDimensionId(world), x, z); }
+
+	public static Ownership getOwner(int x, int z) { return getOwner(0, x, z); }
+
+	public static Ownership getOwner(int dimensionId, int x, int z) {
 		
-		long code = intsToCode(x, z);
+		CoordPair code = new CoordPair(dimensionId, x, z);
 		
 		TerritoryMeta meta = territories.get(code);
 		
@@ -292,7 +323,7 @@ public class ClowderTerritory {
 		if(clowder == null)
 			return false;
 		
-		Ownership owner = getOwnerFromInts((int)player.posX, (int)player.posZ);
+		Ownership owner = getOwnerFromInts(player.worldObj, (int)player.posX, (int)player.posZ);
 		
 		if(owner != null && owner.zone == Zone.FACTION && owner.owner == clowder)
 			return true;
@@ -302,23 +333,31 @@ public class ClowderTerritory {
 	}
 	
 	//returns the ownership information of the chunk
-	public static TerritoryMeta getMetaFromIntCoords(int x, int z) {
+	public static TerritoryMeta getMetaFromIntCoords(int x, int z) { return getMetaFromIntCoords(0, x, z); }
+
+	public static TerritoryMeta getMetaFromIntCoords(World world, int x, int z) { return getMetaFromIntCoords(getDimensionId(world), x, z); }
+
+	public static TerritoryMeta getMetaFromIntCoords(int dimensionId, int x, int z) {
 
 		z += 1;
 		
-		return getMetaFromInts(x / 16, z / 16);
+		return getMetaFromInts(dimensionId, x / 16, z / 16);
 	}
 	
 	//returns the ownership information of the chunk
 	public static TerritoryMeta getMetaFromCoords(CoordPair coords) {
 		
-		return getMetaFromInts(coords.x, coords.z);
+		return getMetaFromInts(coords.dimensionId, coords.x, coords.z);
 	}
 	
 	//returns the ownership information of the chunk
-	public static TerritoryMeta getMetaFromInts(int x, int z) {
+	public static TerritoryMeta getMetaFromInts(int x, int z) { return getMetaFromInts(0, x, z); }
+
+	public static TerritoryMeta getMetaFromInts(World world, int x, int z) { return getMetaFromInts(getDimensionId(world), x, z); }
+
+	public static TerritoryMeta getMetaFromInts(int dimensionId, int x, int z) {
 		
-		long code = intsToCode(x, z);
+		CoordPair code = new CoordPair(dimensionId, x, z);
 		
 		TerritoryMeta meta = territories.get(code);
 		
@@ -332,18 +371,22 @@ public class ClowderTerritory {
 	}
 
 	//converts the UUID long code into a CoordPair instance
+	public static CoordPair codeToCoords(CoordPair code) { return code; }
+
+	public static CoordPair codeToCoords(String code) { return CoordPair.parse(code); }
+
 	public static CoordPair codeToCoords(long code) {
 
-		return new CoordPair((int)(code >> 32), (int)code);
+		return new CoordPair(0, (int)(code >> 32), (int)code);
 	}
 
 	//converts a CoordPair instance into the UUID long code
-	public static long coordsToCode(CoordPair coord) {
+	public static String coordsToCode(CoordPair coord) {
 		try {
-			return intsToCode(coord.x, coord.z);
+			return coord.toString();
 		} catch (Exception e) {
 			e.printStackTrace();
-			return 0L;
+			return "0:0,0";
 		}
 	}
 
@@ -351,6 +394,10 @@ public class ClowderTerritory {
 		
         return ((long)x & 0xFFFFFFFFL) << 32 | ((long)z & 0xFFFFFFFFL);
 	}
+
+	public static int getDimensionId(World world) { return world == null || world.provider == null ? 0 : world.provider.dimensionId; }
+
+	public static String cityId(int dimensionId, int x, int y, int z) { return dimensionId + ":" + x + "," + y + "," + z; }
 	
 	public static class Ownership {
 		
@@ -439,6 +486,7 @@ public class ClowderTerritory {
 		public int hashCode() {
 			final int prime = 31;
 			int result = 1;
+			result = prime * result + dimensionId;
 			result = prime * result + x;
 			result = prime * result + z;
 			return result;
@@ -453,6 +501,8 @@ public class ClowderTerritory {
 			if (getClass() != obj.getClass())
 				return false;
 			CoordPair other = (CoordPair) obj;
+			if (dimensionId != other.dimensionId)
+				return false;
 			if (x != other.x)
 				return false;
 			if (z != other.z)
@@ -460,18 +510,33 @@ public class ClowderTerritory {
 			return true;
 		}
 
+		public int dimensionId;
 		public int x;
 		public int z;
 		
-		public CoordPair(int x, int z) {
+		public CoordPair(int x, int z) { this(0, x, z); }
+		public CoordPair(World world, int x, int z) { this(getDimensionId(world), x, z); }
+		public CoordPair(int dimensionId, int x, int z) {
+			this.dimensionId = dimensionId;
 			this.x = x;
 			this.z = z;
+		}
+		public String toString() { return dimensionId + ":" + x + "," + z; }
+		public static CoordPair parse(String s) {
+			try {
+				String[] dimSplit = s.split(":", 2);
+				int dim = dimSplit.length == 2 ? Integer.parseInt(dimSplit[0]) : 0;
+				String coords = dimSplit.length == 2 ? dimSplit[1] : dimSplit[0];
+				String[] parts = coords.split(",", 2);
+				return new CoordPair(dim, Integer.parseInt(parts[0]), Integer.parseInt(parts[1]));
+			} catch(Exception e) { return new CoordPair(0, 0, 0); }
 		}
 	}
 	
 	public static class TerritoryMeta {
 		
 		public Ownership owner;
+		public int dimensionId;
 		public int flagX;
 		public int flagY;
 		public int flagZ;
@@ -482,17 +547,19 @@ public class ClowderTerritory {
 		
 		public TerritoryMeta(Ownership owner, int flagX, int flagY, int flagZ) {
 			this.owner = owner;
+			this.dimensionId = 0;
 			this.flagX = flagX;
 			this.flagY = flagY;
 			this.flagZ = flagZ;
 			this.name = "";
-			this.cityId = flagX + "," + flagY + "," + flagZ;
+			this.cityId = cityId(dimensionId, flagX, flagY, flagZ);
 			this.cityName = "";
 			this.cityLevel = 0;
 		}
 
 		public TerritoryMeta(Ownership owner, int flagX, int flagY, int flagZ, World world, String name) {
 			this.owner = owner;
+			this.dimensionId = getDimensionId(world);
 			this.flagX = flagX;
 			this.flagY = flagY;
 			this.flagZ = flagZ;
@@ -512,6 +579,7 @@ public class ClowderTerritory {
 			//nbt.setInteger("terr_" + code + "_flagZ", flagZ);
 
 			owner.writeToNBT(nbt, code);
+			nbt.setInteger("dim_" + code, dimensionId);
 			nbt.setInteger(code + "X",flagX);
 			nbt.setInteger(code + "Y",flagY);
 			nbt.setInteger(code + "Z",flagZ);
@@ -529,10 +597,11 @@ public class ClowderTerritory {
 					nbt.getInteger(code + "Y"),
 					nbt.getInteger(code + "Z")
 			);
+			meta.dimensionId = nbt.hasKey("dim_" + code) ? nbt.getInteger("dim_" + code) : 0;
 			meta.name = nbt.getString("name_" + code);
 			meta.cityId = nbt.getString("cityId_" + code);
 			if(meta.cityId == null || meta.cityId.isEmpty())
-				meta.cityId = meta.flagX + "," + meta.flagY + "," + meta.flagZ;
+				meta.cityId = cityId(meta.dimensionId, meta.flagX, meta.flagY, meta.flagZ);
 			meta.cityName = nbt.getString("cityName_" + code);
 			if(meta.cityName == null || meta.cityName.isEmpty())
 				meta.cityName = meta.name;
@@ -567,7 +636,7 @@ public class ClowderTerritory {
 				return false;
 			
 			Clowder own = owner.owner;
-			CoordPair origin = getCoordPair(flagX, flagZ);
+			CoordPair origin = getCoordPair(dimensionId, flagX, flagZ);
 			
 			if(world == null || world.getChunkProvider() == null)
 				return true;
@@ -617,11 +686,11 @@ public class ClowderTerritory {
 	//checks a part of the clowder claim data for persistence, will delete non-persistent ones
 	public static void checkPersistence(World world, int cycle, int index) {
 		
-		List<Long> BOW = new ArrayList(territories.keySet());
+		List<CoordPair> BOW = new ArrayList(territories.keySet());
 		
 		for(int i = index; i < BOW.size(); i += cycle) {
 			
-			long code = BOW.get(i);
+			CoordPair code = BOW.get(i);
 			TerritoryMeta meta = territories.get(code);
 			
 			//code will be deleted IF
@@ -629,6 +698,8 @@ public class ClowderTerritory {
 			// -the code refers to a claim that is deemed non-persistent
 			if(meta != null) {
 				
+				if(code.dimensionId != getDimensionId(world))
+					continue;
 				if(!meta.checkPersistence(world, codeToCoords(code))) {
 					territories.remove(code);
 					i--;
@@ -657,15 +728,29 @@ public class ClowderTerritory {
 		
 		territories.clear();
 		int count = nbt.getInteger("territory_count");
+		int migrated = 0;
 		
 		for(int i = 0; i < count; i++) {
 			
-			long code = nbt.getLong("code_" + i);
+			CoordPair code;
+			String rawCode = nbt.getString("code_" + i);
+			if(rawCode != null && rawCode.indexOf(":") >= 0)
+				code = CoordPair.parse(rawCode);
+			else {
+				code = codeToCoords(nbt.getLong("code_" + i));
+				migrated++;
+			}
 			TerritoryMeta meta = TerritoryMeta.readFromNBT(nbt, "meta_" + i);
 			
-			if(meta != null && meta.owner.zone != Zone.WILDERNESS) //todo here
+			if(meta != null && meta.owner.zone != Zone.WILDERNESS) { //todo here
+				meta.dimensionId = code.dimensionId;
+				if(meta.cityId == null || meta.cityId.indexOf(":") < 0)
+					meta.cityId = cityId(meta.dimensionId, meta.flagX, meta.flagY, meta.flagZ);
 				territories.put(code, meta);
+			}
 		}
+		if(migrated > 0 && MainRegistry.logger != null)
+			MainRegistry.logger.info("Migrated " + migrated + " legacy faction territory entries to dimension 0 claim keys.");
 		com.hfr.dynmap.XFDynmapIntegration.markDirty();
 	}
 	
@@ -674,14 +759,14 @@ public class ClowderTerritory {
 		nbt.setInteger("territory_count", territories.size());
 		int index = 0;
 		
-		for(long code : territories.keySet()) {
+		for(CoordPair code : territories.keySet()) {
 			
 			TerritoryMeta meta = territories.get(code);
 			
 			//do not save wilderness
 			//todo check that this isnt some bs
 			if(meta.owner.zone != Zone.WILDERNESS) {
-				nbt.setLong("code_" + index, code);
+				nbt.setString("code_" + index, code.toString());
 				meta.writeToNBT(nbt, "meta_" + index);
 			}
 			

--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -46,6 +46,7 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -120,11 +121,6 @@ public class CommandClowder extends CommandBase {
 	public void processCommand(ICommandSender sender, String[] args) {
 
 		//todo add a /c merge command to merge into other factions (with consent ofc)
-
-		if(sender.getEntityWorld().provider.dimensionId != 0) {
-			sender.addChatMessage(new ChatComponentText(CRITICAL + "Critical error: XenoFac only works in overworld!!"));
-			//todo... remove??? why is this the case? does it work outside overworld?
-		}
 
 		if(Clowder.clowders.size() == 0)
 			ClowderData.getData(sender.getEntityWorld());
@@ -1167,7 +1163,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 			// level 1 member level 2 officer level 3 leader
 			if (clowder.getPermLevel(player.getDisplayName()) > 1) {
 
-				Ownership owner = ClowderTerritory.getOwnerFromInts((int) player.posX, (int) player.posZ);
+				Ownership owner = ClowderTerritory.getOwnerFromInts(player.worldObj, (int) player.posX, (int) player.posZ);
 
 				if (owner != null && owner.zone == Zone.FACTION && owner.owner == clowder) {
 
@@ -1207,7 +1203,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 			// level 1 member level 2 officer level 3 leader
 			if (clowder.getPermLevel(player.getDisplayName()) > 1) {
 
-				Ownership owner = ClowderTerritory.getOwnerFromInts((int) player.posX, (int) player.posZ);
+				Ownership owner = ClowderTerritory.getOwnerFromInts(player.worldObj, (int) player.posX, (int) player.posZ);
 
 				if (owner != null && owner.zone == Zone.FACTION && owner.owner == clowder) {
 
@@ -1253,7 +1249,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 				return;
 			}
 
-			Ownership owner = ClowderTerritory.getOwnerFromInts((int)player.posX, (int)player.posZ);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(player.worldObj, (int)player.posX, (int)player.posZ);
 
 			if(owner != null && (owner.zone == Zone.WARZONE || (owner.zone == Zone.FACTION && (owner.owner != clowder && clowder.allies.get(owner.owner) == null) ) ) ) { //allow warp from allied territory
 
@@ -1262,7 +1258,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 			} else {
 
 				sender.addChatMessage(new ChatComponentText(INFO + "Please stand still for 10 seconds!"));
-				clowder.teleports.put(System.currentTimeMillis() + 10000L, new ScheduledTeleport(clowder.homeX, clowder.homeY, clowder.homeZ, player.getDisplayName(), true));
+				clowder.teleports.put(System.currentTimeMillis() + 10000L, new ScheduledTeleport(clowder.homeDim, clowder.homeX, clowder.homeY, clowder.homeZ, player.getDisplayName(), true));
 			}
 
 		} else {
@@ -1287,7 +1283,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 					return;
 				}
 
-				Ownership owner = ClowderTerritory.getOwnerFromInts((int) player.posX, (int) player.posZ);
+				Ownership owner = ClowderTerritory.getOwnerFromInts(player.worldObj, (int) player.posX, (int) player.posZ);
 
 				if (owner != null
 						&& (owner.zone == Zone.WARZONE || (owner.zone == Zone.FACTION && (owner.owner != clowder && clowder.allies.get(owner.owner) == null) ) ) ) {
@@ -1305,7 +1301,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 						if(ally.allyWarpX != 0 && ally.allyWarpY != 0 && ally.allyWarpZ != 0)
 						{
 							sender.addChatMessage(new ChatComponentText(INFO + "Please stand still for 10 seconds!"));
-							clowder.teleports.put(System.currentTimeMillis() + 10000L, new ScheduledTeleport(ally.allyWarpX,
+							clowder.teleports.put(System.currentTimeMillis() + 10000L, new ScheduledTeleport(ally.allyWarpDim, ally.allyWarpX,
 									ally.allyWarpY, ally.allyWarpZ, player.getDisplayName(), true, true, ally.name));
 						}
 						else
@@ -1400,7 +1396,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 
 			if (clowder.warps.containsKey(name)) {
 
-				Ownership owner = ClowderTerritory.getOwnerFromInts((int) player.posX, (int) player.posZ);
+				Ownership owner = ClowderTerritory.getOwnerFromInts(player.worldObj, (int) player.posX, (int) player.posZ);
 
 				if (owner != null
 						//&& (owner.zone == Zone.WARZONE || (owner.zone == Zone.FACTION && owner.owner != clowder))) {
@@ -1416,7 +1412,9 @@ private void cmdCreate(ICommandSender sender, String name) {
 					return;
 				}
 
-				IChunkProvider provider = player.worldObj.getChunkProvider();
+				World warpWorld = net.minecraftforge.common.DimensionManager.getWorld(warp.length > 3 ? warp[3] : 0);
+				if(warpWorld == null) { sender.addChatMessage(new ChatComponentText(ERROR + "Warp dimension is not loaded.")); return; }
+				IChunkProvider provider = warpWorld.getChunkProvider();
 
 				for (int i = 2; i <= 5; i++) {
 
@@ -1427,17 +1425,17 @@ private void cmdCreate(ICommandSender sender, String name) {
 					int tentX = warp[0] + dir.offsetX * 2;
 					int tentZ = warp[2] + dir.offsetZ * 2;
 
-					Block block = player.worldObj.getBlock(tentX, warp[1], tentZ);
+					Block block = warpWorld.getBlock(tentX, warp[1], tentZ);
 
 					if (block == ModBlocks.tp_tent) {
 
-						int[] pos = ((BlockDummyable) ModBlocks.tp_tent).findCore(player.worldObj, tentX, warp[1],
+						int[] pos = ((BlockDummyable) ModBlocks.tp_tent).findCore(warpWorld, tentX, warp[1],
 								tentZ);
 
 						if (pos != null) {
 
 							provider.loadChunk(pos[0] >> 4, pos[2] >> 4);
-							TileEntityProp tent = (TileEntityProp) player.worldObj.getTileEntity(pos[0], pos[1],
+							TileEntityProp tent = (TileEntityProp) warpWorld.getTileEntity(pos[0], pos[1],
 									pos[2]);
 
 							if (tent.warp.equals(name) && tent.operational()) {
@@ -1445,7 +1443,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 								sender.addChatMessage(
 										new ChatComponentText(INFO + "Please stand still for 10 seconds!"));
 								clowder.teleports.put(System.currentTimeMillis() + 10000L, new ScheduledTeleport(
-										warp[0], warp[1], warp[2], player.getDisplayName(), name));
+										warp.length > 3 ? warp[3] : 0, warp[0], warp[1], warp[2], player.getDisplayName(), name));
 
 								return;
 							}
@@ -1701,7 +1699,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "You lack the permissions to upgrade cities!"));
 			return;
 		}
-		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords((int)player.posX, (int)player.posZ);
+		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords(player.worldObj, (int)player.posX, (int)player.posZ);
 		if(meta == null || meta.owner == null || meta.owner.owner != clowder) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "Stand inside one of your city claims to upgrade it."));
 			return;
@@ -1825,7 +1823,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 			return;
 		}
 
-		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords((int)player.posX, (int)player.posZ);
+		TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords(player.worldObj, (int)player.posX, (int)player.posZ);
 
 		if(meta == null || meta.owner == null || !meta.isCityClaim()) {
 			sender.addChatMessage(new ChatComponentText(ERROR + "You are not in a city claim!"));

--- a/src/main/java/com/hfr/command/CommandClowderAdmin.java
+++ b/src/main/java/com/hfr/command/CommandClowderAdmin.java
@@ -59,10 +59,6 @@ public class CommandClowderAdmin extends CommandBase {
 	@Override
 	public void processCommand(ICommandSender sender, String[] args) {
 
-		//but like i want to colonize mars or something... but that might break or something hmm...
-		if(sender.getEntityWorld().provider.dimensionId != 0) {
-			sender.addChatMessage(new ChatComponentText(CRITICAL + "Critical error: CatFac only works in overworld!!"));
-		}
 
 		if(Clowder.clowders.size() == 0)
 			ClowderData.getData(sender.getEntityWorld());

--- a/src/main/java/com/hfr/config/XFConfig.java
+++ b/src/main/java/com/hfr/config/XFConfig.java
@@ -84,6 +84,9 @@ public final class XFConfig {
 	public static boolean claimNameRequireUnique = true;
 	public static boolean claimRenameOfficersAllowed = true;
 	public static boolean peaceCityTransfersEnabled = true;
+	public static boolean enableClaimsInAllDimensions = true;
+	public static int[] allowedClaimDimensions = new int[0];
+	public static int[] blockedClaimDimensions = new int[0];
 	public static boolean surrenderTransfersCities = true;
 	public static int[] cityRadii = new int[] { 2, 3, 4, 5, 6 };
 	public static float[] cityUpgradeCosts = new float[] { 75F, 150F, 300F, 600F, 1000F };
@@ -126,6 +129,7 @@ public final class XFConfig {
 	public static boolean dynmapShowCityCenterMarkers = true;
 	public static boolean dynmapShowClaimDetails = true;
 	public static boolean dynmapShowPrestigeDetails = true;
+	public static String[] dynmapDimensionWorldMap = new String[] { "0=world", "-1=world_nether", "1=world_the_end" };
 
 	public static void load(Configuration config) {
 		commentCategories(config);
@@ -169,6 +173,9 @@ public final class XFConfig {
 		nationalCollapseUpkeepMult = flt(config, CAT_BANKRUPTCY, "nationalCollapseUpkeepMultiplier", nationalCollapseUpkeepMult, 0F, 100F, "Upkeep multiplier during National Collapse.");
 		fallenNationUpkeepMult = flt(config, CAT_BANKRUPTCY, "fallenNationUpkeepMultiplier", fallenNationUpkeepMult, 0F, 100F, "Upkeep multiplier during Fallen Nation.");
 
+		enableClaimsInAllDimensions = bool(config, CAT_CLAIMS, "enableClaimsInAllDimensions", enableClaimsInAllDimensions, "Allows faction claims outside dimension 0.");
+		allowedClaimDimensions = intList(config, CAT_CLAIMS, "allowedClaimDimensions", allowedClaimDimensions, -100000, 100000, "Dimension whitelist for claims; empty means all dimensions.");
+		blockedClaimDimensions = intList(config, CAT_CLAIMS, "blockedClaimDimensions", blockedClaimDimensions, -100000, 100000, "Dimension blacklist for claims; empty means none.");
 		maxCityRadius = integer(config, CAT_CLAIMS, "maxCityRadius", maxCityRadius, 1, 32, "Maximum city radius in chunks. Existing claims are not deleted when lowered.");
 		minCitySpacingChunks = integer(config, CAT_CLAIMS, "minimumCitySpacingChunks", minCitySpacingChunks, 0, 128, "Minimum chunk distance between city centers to prevent overlap.");
 		claimNameMinLength = integer(config, CAT_CLAIMS, "claimNameMinLength", claimNameMinLength, 1, 64, "Minimum city/claim name length.");
@@ -219,6 +226,7 @@ public final class XFConfig {
 		dynmapShowCityCenterMarkers = bool(config, CAT_DYNMAP, "showCityCenterMarkers", dynmapShowCityCenterMarkers, "Shows a marker at each City Center.");
 		dynmapShowClaimDetails = bool(config, CAT_DYNMAP, "showClaimDetailsInLabels", dynmapShowClaimDetails, "Includes city/claim chunk details in Dynmap labels.");
 		dynmapShowPrestigeDetails = bool(config, CAT_DYNMAP, "showPrestigeDetailsInLabels", dynmapShowPrestigeDetails, "Includes prestige/upkeep details in Dynmap labels.");
+		dynmapDimensionWorldMap = stringList(config, CAT_DYNMAP, "dynmapDimensionWorldMap", dynmapDimensionWorldMap, "Minecraft dimension to Dynmap world map, entries like 0=world.");
 
 		MainRegistry.warpCost = Math.round(warpCost);
 		CommandClowderAdmin.WARENABLED = warEnabledDefault;
@@ -249,6 +257,23 @@ public final class XFConfig {
 	public static float cityUpgradeCost(CityLevel level) { return cityUpgradeCosts[index(level)]; }
 	public static float cityUpkeep(CityLevel level) { return cityUpkeep[index(level)]; }
 	private static int index(CityLevel level) { int i = level == null ? 0 : level.ordinal(); return Math.max(0, Math.min(4, i)); }
+
+	public static boolean canClaimInDimension(int dim) {
+		if(!enableClaimsInAllDimensions && dim != 0) return false;
+		for(int blocked : blockedClaimDimensions) if(blocked == dim) return false;
+		if(allowedClaimDimensions.length == 0) return true;
+		for(int allowed : allowedClaimDimensions) if(allowed == dim) return true;
+		return false;
+	}
+
+	public static String dynmapWorldNameForDimension(int dim) {
+		for(String entry : dynmapDimensionWorldMap) {
+			if(entry == null) continue;
+			String[] parts = entry.split("=", 2);
+			try { if(parts.length == 2 && Integer.parseInt(parts[0].trim()) == dim) return parts[1].trim(); } catch(Exception ignored) { }
+		}
+		return null;
+	}
 
 	private static void rebuildHostSet() {
 		customFlagAllowedHostSet.clear();

--- a/src/main/java/com/hfr/data/ClowderData.java
+++ b/src/main/java/com/hfr/data/ClowderData.java
@@ -8,6 +8,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagString;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSavedData;
+import net.minecraftforge.common.DimensionManager;
 
 import java.util.ArrayList;
 
@@ -71,20 +72,23 @@ public class ClowderData extends WorldSavedData {
 
 		//initializeDiplomacy(worldObj);
 		//there's no way this works but let's try it
-		
-		if(worldObj.provider.dimensionId == 0) {
-	
-			data = (ClowderData)worldObj.perWorldStorage.loadData(ClowderData.class, "hfr_clowder");
-		    if(data == null) {
-		        worldObj.perWorldStorage.setData("hfr_clowder", new ClowderData("hfr_clowder"));
-		        
-		        data = (ClowderData)worldObj.perWorldStorage.loadData(ClowderData.class, "hfr_clowder");
-		    }
-		    
-		    return data;
+		if(worldObj == null)
+			return data;
+
+		World storageWorld = worldObj;
+		if(worldObj.provider != null && worldObj.provider.dimensionId != 0) {
+			World overworld = DimensionManager.getWorld(0);
+			if(overworld != null)
+				storageWorld = overworld;
 		}
-		
-	    return null;
+
+		data = (ClowderData)storageWorld.perWorldStorage.loadData(ClowderData.class, "hfr_clowder");
+		if(data == null) {
+			storageWorld.perWorldStorage.setData("hfr_clowder", new ClowderData("hfr_clowder"));
+			data = (ClowderData)storageWorld.perWorldStorage.loadData(ClowderData.class, "hfr_clowder");
+		}
+
+		return data;
 	}
 
 }

--- a/src/main/java/com/hfr/dynmap/XFDynmapIntegration.java
+++ b/src/main/java/com/hfr/dynmap/XFDynmapIntegration.java
@@ -73,9 +73,7 @@ public class XFDynmapIntegration {
 			if(markerApi == null)
 				return;
 
-			World world = DimensionManager.getWorld(0);
-			if(world == null)
-				return;
+			World world = null;
 
 			markerSet = getOrCreateMarkerSet(markerApi);
 			if(markerSet == null)
@@ -89,7 +87,15 @@ public class XFDynmapIntegration {
 
 			cacheMarkerMethods();
 			clearMarkerSet(markerSet);
-			createCityMarkers(world, getWorldName(world));
+			HashSet<Integer> renderedDims = new HashSet();
+			for(CoordPair coord : ClowderTerritory.territories.keySet()) {
+				if(!renderedDims.add(Integer.valueOf(coord.dimensionId)))
+					continue;
+				World dimWorld = DimensionManager.getWorld(coord.dimensionId);
+				String worldName = XFConfig.dynmapWorldNameForDimension(coord.dimensionId);
+				if(dimWorld != null && worldName != null && !worldName.isEmpty())
+					createCityMarkers(dimWorld, worldName);
+			}
 			dirty = false;
 		} catch(Throwable t) {
 			markerSet = null;
@@ -169,16 +175,18 @@ public class XFDynmapIntegration {
 
 	private static void createCityMarkers(World world, String worldName) throws Exception {
 		HashMap<String, CitySummary> cities = new HashMap();
-		for(Map.Entry<Long, TerritoryMeta> entry : ClowderTerritory.territories.entrySet()) {
+		for(Map.Entry<CoordPair, TerritoryMeta> entry : ClowderTerritory.territories.entrySet()) {
 			TerritoryMeta meta = entry.getValue();
 			if(meta == null || meta.owner == null || meta.owner.zone != Zone.FACTION || meta.owner.owner == null || !meta.isCityClaim())
 				continue;
 
-			CoordPair coords = ClowderTerritory.codeToCoords(entry.getKey().longValue());
+			CoordPair coords = entry.getKey();
+			if(coords.dimensionId != ClowderTerritory.getDimensionId(world))
+				continue;
 			Clowder owner = meta.owner.owner;
 			int color = owner.color & 0xFFFFFF;
 			String cityId = safeCityId(meta);
-			String markerId = "xf_claim_" + Long.toUnsignedString(entry.getKey().longValue(), 16);
+			String markerId = "xf_claim_" + coords.dimensionId + "_" + coords.x + "_" + coords.z;
 			String label = buildClaimLabel(meta, owner, coords);
 			double[] x = new double[] { coords.x * 16.0D, coords.x * 16.0D + 16.0D };
 			double[] z = new double[] { coords.z * 16.0D, coords.z * 16.0D + 16.0D };

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -356,8 +356,8 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	public void generateClaim() {
 		
 		int rad = Math.min(getRadius(), CityLevel.maxRadius());
-		String placementError = ClowderTerritory.getCityPlacementError(xCoord >> 4, zCoord >> 4);
-		if(placementError != null && ClowderTerritory.getMetaFromIntCoords(xCoord, zCoord) == null)
+		String placementError = ClowderTerritory.getCityPlacementError(worldObj, xCoord >> 4, zCoord >> 4);
+		if(placementError != null && ClowderTerritory.getMetaFromIntCoords(worldObj, xCoord, zCoord) == null)
 			return;
 		
 		for(int x = -CityLevel.maxRadius(); x <= CityLevel.maxRadius(); x++) {

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
@@ -81,7 +81,7 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 			//CoordPair[] coords = new CoordPair[0]);
 			//Random rng = new Random();
 
-			long sampleCode = ClowderTerritory.coordsToCode(coords[rng.nextInt(coords.length)]);
+			CoordPair sampleCode = coords[rng.nextInt(coords.length)];
 			TerritoryMeta sampleMeta = ClowderTerritory.territories.get(sampleCode);
 
 			if (sampleMeta == null) return; // Prevent crash if territory is missing
@@ -94,7 +94,7 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 				owner = null;
 				isCappable = false;
 				for(CoordPair a : claim) {
-					long code = ClowderTerritory.coordsToCode(a);
+					CoordPair code = a;
 					if(ClowderTerritory.territories.get(code) != null && ClowderTerritory.territories.get(code).owner.zone == Zone.FACTION)
 						ClowderTerritory.territories.get(code).owner = new Ownership(Zone.WILDERNESS);
 
@@ -201,10 +201,10 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 		int maxX = Math.max(x1, x2);
 		int maxZ = Math.max(z1, z2);
 		
-		CoordPair origin = ClowderTerritory.getCoordPair(xCoord, zCoord);
+		CoordPair origin = ClowderTerritory.getCoordPair(worldObj, xCoord, zCoord);
 		for(int x = minX; x <= maxX; x += 16) {
 			for(int z = minZ; z <= maxZ; z += 16) {
-				CoordPair coord = ClowderTerritory.getCoordPair(x, z);
+				CoordPair coord = ClowderTerritory.getCoordPair(worldObj, x, z);
 				double dist = Math.sqrt(Math.pow(origin.x - coord.x, 2) + Math.pow(origin.z - coord.z, 2));
 				if(dist < getRadius())
 					this.claim.add(coord);
@@ -265,6 +265,7 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 		
 		for(int i = 0; i < length; i++) {
 			this.claim.add(new CoordPair(
+					nbt.hasKey("dim" + i) ? nbt.getInteger("dim" + i) : 0,
 					nbt.getInteger("x" + i),
 					nbt.getInteger("z" + i)
 					));
@@ -289,6 +290,7 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 		
 		for(CoordPair coords : this.claim) {
 
+			nbt.setInteger("dim" + i, coords.dimensionId);
 			nbt.setInteger("x" + i, coords.x);
 			nbt.setInteger("z" + i, coords.z);
 			


### PR DESCRIPTION
### Motivation

- Extend territory/claim logic to support multiple Minecraft dimensions so claims, city centers and war mechanics work outside dimension 0.
- Persist and migrate legacy single-dimension territory keys to a dimension-aware format and allow teleports/home/ally-warps to target other dimensions.  

### Description

- Converted territory keying to a dimension-aware `CoordPair` (added `dimensionId`) and switched from long codes to string keys (`dim:x,z`) with parsing and graceful migration for legacy data.  
- Added `dimensionId` to `TerritoryMeta`, included dimension in `cityId` generation, and updated all `ClowderTerritory` lookup/set APIs to accept `World` or explicit `dimensionId`; added helper `getDimensionId`.  
- Added dimension fields and handling for warps/home (`Clowder.homeDim`, `Clowder.allyWarpDim`), scheduled teleports (`ScheduledTeleport.dimensionId`), and updated teleport scheduling/execution to load the target world and change player dimension when teleporting.  
- Updated `ClowderData` to store territory/faction data in the overworld save and migrated accessors to use the overworld `WorldSavedData` when called from other dimensions.  
- Dynmap integration updated to render markers per-dimension using configurable `XFConfig.dynmapDimensionWorldMap` and iterate dimension sets when creating markers.  
- Added configuration options in `XFConfig` to control multi-dimension claims: `enableClaimsInAllDimensions`, `allowedClaimDimensions`, `blockedClaimDimensions`, and helper `canClaimInDimension`.  
- Propagated API changes across codebase: updated many event handlers, commands and tile-entities (`Flag`, `Conquerer`, `TileEntityFlag`, `TileEntityFlagBig`, `ClowderEvents`, `CommandClowder`, etc.) to pass `World` or dimension-aware calls for territory checks, city placement validation, warp handling, and persistence.  

### Testing

- Performed a project build to validate compilation after refactor (`gradle build`/Java compile); the build completed successfully.  
- Exercised server data load/save path to validate territory NBT read/write and legacy key migration handling (overworld `WorldSavedData` retrieval); migration logging is emitted for legacy entries.  
- No new automated unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f3b7a4e688329ae108b0706de334a)