### PR TITLE
Make claim/ally/war persistence and prestige generation dimension-aware and sync City Center UI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,22 @@
+# Persist war state and make faction claims dimension-aware
+
+- Fixed warp tents and medical tents in non-overworld dimensions by resolving their owning claim with the tile entity's actual world dimension instead of the implicit overworld.
+- Fixed statue and other prestige-building owner detection in non-overworld dimensions so prestige generation is credited to the faction that owns that dimension's claim.
+- Fixed prestige-building break cleanup to use the block's world dimension when subtracting generation, preventing non-overworld buildings from looking up overworld claims.
+- Added immediate City Center prestige UI refresh when a faction's prestige generation changes, without changing the prestige tick/earning interval.
+- Added a City Center GUI `Gain: <amount>/h` line so players can see whether statues and other prestige buildings changed generation.
+- Restored ally object references from saved ally names during Clowder NBT load and synchronized ally names before saving, fixing alliances disappearing from runtime commands after server restart.
+- Kept the prior dimension-aware city/admin-claim and war-runtime persistence work from this PR.
+
+## Manual verification notes
+
+- In a Nether/End/LOTR/Middle-earth claim, place a warp tent on valid foundation blocks with sky access, run `/c setwarp <name>`, restart, and verify `/c warp <name>` still targets that dimension.
+- In a non-overworld city claim, place a statue and each enabled prestige building, then open the City Center GUI and verify the `Gain` line updates within a tick or two without waiting for the hourly prestige interval.
+- Break those prestige buildings in the same non-overworld claim and verify the City Center GUI generation drops immediately.
+- Create and accept an alliance, restart the server, and verify `/c alliance`, `/c allywarp`, and ally war defense checks still recognize the ally.
+- Load a legacy world missing dimension fields and verify legacy homes/warps still migrate to dimension `0` with clear server log messages.
+
+## Remaining risky assumptions
+
+- Some legacy helper overloads still intentionally default to dimension `0`; new gameplay code should prefer `World`/dimension-aware overloads.
+- The City Center GUI now displays prestige generation (`/h`) immediately, but actual prestige balance accrual still follows the configured prestige update interval by design.

--- a/docs/server-administration.md
+++ b/docs/server-administration.md
@@ -46,3 +46,11 @@ Back up the world and config directory before:
 - Compare your old config against the new generated `XENOFACTIONS_*` categories.
 - Re-check feature toggles because new systems may default to enabled for compatibility with the maintained fork.
 - Test faction commands, prestige ticks, claims, and war declarations on a staging copy before updating a live server.
+
+## Multi-dimension persistence checks
+
+When validating an update, test faction claims, City Centers, homes, faction warps, and ally warps in every enabled dimension. Legacy saves that predate dimension-aware faction locations are migrated to dimension `0`, and the server log should include a migration message for each legacy location type that is encountered.
+
+Runtime admin war toggles such as `/xc warenable`, `/xc wardisable`, and war-check bypass toggles are saved with faction data and restored on restart. The `warEnabledDefault` config value only applies before a runtime value has been saved for the world.
+
+For non-overworld claims, specifically verify warp tents, medical tents, statues, and other prestige buildings. These structures should resolve the claim in their own dimension, and City Center GUIs should show prestige generation changes immediately while the actual prestige accrual interval remains unchanged.

--- a/src/main/java/com/hfr/blocks/machine/MachineBlastFurnace.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineBlastFurnace.java
@@ -139,7 +139,7 @@ public class MachineBlastFurnace extends BlockDummyable {
         }
         
 		if(i >= ForgeDirection.UNKNOWN.ordinal()) {
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(world, x, z);
 			
 			if(owner != null && owner.zone == Zone.FACTION) {
 

--- a/src/main/java/com/hfr/blocks/machine/MachineCoalMine.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineCoalMine.java
@@ -132,7 +132,7 @@ public class MachineCoalMine extends BlockDummyable {
         }
         
 		/*if(i >= ForgeDirection.UNKNOWN.ordinal()) {
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(world, x, z);
 			
 			if(owner != null && owner.zone == Zone.FACTION) {
 

--- a/src/main/java/com/hfr/blocks/machine/MachineFed.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineFed.java
@@ -145,7 +145,7 @@ public class MachineFed extends BlockDummyable {
         }
 
         if(i >= ForgeDirection.UNKNOWN.ordinal()) {
-            Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+            Ownership owner = ClowderTerritory.getOwnerFromInts(world, x, z);
 
             if(owner != null && owner.zone == Zone.FACTION) {
 

--- a/src/main/java/com/hfr/blocks/machine/MachineGrainmill.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineGrainmill.java
@@ -136,7 +136,7 @@ public class MachineGrainmill extends BlockDummyable {
         }
         
 		if(i >= ForgeDirection.UNKNOWN.ordinal()) {
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(world, x, z);
 			
 			if(owner != null && owner.zone == Zone.FACTION) {
 

--- a/src/main/java/com/hfr/blocks/machine/MachineTemple.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineTemple.java
@@ -46,7 +46,7 @@ public class MachineTemple extends BlockDummyable {
 	@Override
 	public void breakBlock(World world, int x, int y, int z, Block block, int meta) {
 		if(meta >= 12) {
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(world, x, z);
 			TileEntity entity = world.getTileEntity(x, y, z);
 			if(owner != null && owner.zone == Zone.FACTION && entity instanceof TileEntityMachineTemple) {
 				TileEntityMachineTemple temple = (TileEntityMachineTemple)entity;

--- a/src/main/java/com/hfr/blocks/machine/MachineUni.java
+++ b/src/main/java/com/hfr/blocks/machine/MachineUni.java
@@ -145,7 +145,7 @@ public class MachineUni extends BlockDummyable {
         }
         
 		if(i >= ForgeDirection.UNKNOWN.ordinal()) {
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(world, x, z);
 			
 			if(owner != null && owner.zone == Zone.FACTION) {
 

--- a/src/main/java/com/hfr/blocks/props/PropStatue.java
+++ b/src/main/java/com/hfr/blocks/props/PropStatue.java
@@ -43,7 +43,7 @@ public class PropStatue extends BlockDummyable {
 	public void breakBlock(World world, int x, int y, int z, Block b, int i)
     {
 		if(i >= ForgeDirection.UNKNOWN.ordinal()) {
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(world, x, z);
 			
 			if(owner != null && owner.zone == Zone.FACTION) {
 

--- a/src/main/java/com/hfr/blocks/props/PropTent.java
+++ b/src/main/java/com/hfr/blocks/props/PropTent.java
@@ -44,7 +44,7 @@ public class PropTent extends BlockDummyable {
 	public void breakBlock(World world, int x, int y, int z, Block b, int i)
     {
 		if(i >= ForgeDirection.UNKNOWN.ordinal()) {
-			Ownership owner = ClowderTerritory.getOwnerFromInts(x, z);
+			Ownership owner = ClowderTerritory.getOwnerFromInts(world, x, z);
 			
 			if(owner != null && owner.zone == Zone.FACTION) {
 

--- a/src/main/java/com/hfr/clowder/Clowder.java
+++ b/src/main/java/com/hfr/clowder/Clowder.java
@@ -10,10 +10,12 @@ import java.util.UUID;
 import com.hfr.blocks.BlockDummyable;
 import com.hfr.blocks.ModBlocks;
 import com.hfr.command.CommandClowder;
+import com.hfr.command.CommandClowderAdmin;
 import com.hfr.config.XFConfig;
 import com.hfr.data.ClowderData;
 //import com.hfr.data.MarketData.Offer;
 import com.hfr.main.MainRegistry;
+import com.hfr.tileentity.clowder.TileEntityFlag;
 import com.hfr.tileentity.prop.TileEntityProp;
 
 import cpw.mods.fml.common.Loader;
@@ -22,10 +24,12 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 import net.minecraft.world.World;
+import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.util.ForgeDirection;
 
 //it's like a faction
@@ -1337,7 +1341,21 @@ public class Clowder {
 			prestigeGen = 0F;
 
 		prestigeGen = Math.min(prestigeGen, XFConfig.prestigeGenCap);
+		refreshPrestigeDisplays();
 		this.save(world);
+	}
+
+	private void refreshPrestigeDisplays() {
+		for(TerritoryMeta meta : ClowderTerritory.getCityClaims(this)) {
+			if(meta == null)
+				continue;
+			World world = DimensionManager.getWorld(meta.dimensionId);
+			if(world == null)
+				continue;
+			TileEntity te = world.getTileEntity(meta.flagX, meta.flagY, meta.flagZ);
+			if(te instanceof TileEntityFlag)
+				((TileEntityFlag)te).syncPrestigeGauges();
+		}
 	}
 
 	public void addPrestigeReq(float f, World world) {
@@ -1529,6 +1547,7 @@ public class Clowder {
 	}
 
 	public void saveClowder(int i, NBTTagCompound nbt) {
+		syncAllyNames();
 		nbt.setString(i + "_uuid", this.uuid);
 		nbt.setString(i + "_name", this.name);
 		nbt.setString(i + "_motd", this.motd);
@@ -1578,6 +1597,8 @@ public class Clowder {
 		nbt.setString(i + "_leader", this.leader);
 		nbt.setInteger(i + "_members", this.members.size());
 		nbt.setInteger(i + "_officers", this.officers.size());
+		nbt.setInteger(i + "_potentialFriends", this.potentialFriends.size());
+		nbt.setInteger(i + "_allies", this.alliesS.size());
 		nbt.setInteger(i + "_warps", this.warps.size());
 		nbt.setInteger(i + "_activeWars", this.activeWars.size());
 		nbt.setInteger(i + "_defendingAllies", this.defendingAllies.size());
@@ -1622,7 +1643,10 @@ public class Clowder {
 		for (int j = 0; j < this.members.keySet().size(); j++)
 			nbt.setString(i + "_" + j, (String) this.members.keySet().toArray()[j]);
 
-		// try to save allies
+		// save pending and active allies
+		for (int j = 0; j < this.potentialFriends.size(); j++)
+			nbt.setString(i + "_" + j + "_pfriend", (String) this.potentialFriends.toArray()[j]);
+
 		for (int j = 0; j < this.alliesS.keySet().size(); j++)
 			nbt.setString(i + "_" + j + "_ally", (String) this.alliesS.keySet().toArray()[j]);
 
@@ -1690,10 +1714,12 @@ public class Clowder {
 		c.homeX = nbt.getInteger(i + "_homeX");
 		c.homeY = nbt.getInteger(i + "_homeY");
 		c.homeZ = nbt.getInteger(i + "_homeZ");
+		if(!nbt.hasKey(i + "_homeDim") && MainRegistry.logger != null) MainRegistry.logger.info("Migrating legacy faction home for " + c.name + " to dimension 0.");
 		c.homeDim = nbt.hasKey(i + "_homeDim") ? nbt.getInteger(i + "_homeDim") : 0;
 		c.allyWarpX = nbt.getInteger(i + "_allyWarpX");
 		c.allyWarpY = nbt.getInteger(i + "_allyWarpY");
 		c.allyWarpZ = nbt.getInteger(i + "_allyWarpZ");
+		if(!nbt.hasKey(i + "_allyWarpDim") && MainRegistry.logger != null) MainRegistry.logger.info("Migrating legacy ally warp for " + c.name + " to dimension 0.");
 		c.allyWarpDim = nbt.hasKey(i + "_allyWarpDim") ? nbt.getInteger(i + "_allyWarpDim") : 0;
 		c.prestige = nbt.getFloat(i + "_prestige");
 		c.canDeclareTime = Math.max(nbt.getFloat(i + "_canDeclareTime"), 0F);
@@ -1752,6 +1778,13 @@ public class Clowder {
 		c.leader = nbt.getString(i + "_leader");
 		int count = nbt.getInteger(i + "_members");
 		int co = nbt.getInteger(i + "_officers");
+		int cpf = nbt.getInteger(i + "_potentialFriends");
+		int ca = nbt.getInteger(i + "_allies");
+		if(ca == 0 && nbt.getInteger(i + "_members") > 0 && nbt.hasKey(i + "_0_ally")) {
+			ca = nbt.getInteger(i + "_members");
+			if(MainRegistry.logger != null)
+				MainRegistry.logger.info("Migrating legacy ally list for faction " + c.name + "; using member-count bounded ally entries from old saves.");
+		}
 		int cwarp = nbt.getInteger(i + "_warps");
 		int cwar = nbt.getInteger(i + "_activeWars");
 		int cdef = nbt.getInteger(i + "_defendingAllies");
@@ -1772,8 +1805,14 @@ public class Clowder {
 		for (int j = 0; j < count; j++)
 			c.members.put(nbt.getString(i + "_" + j), time());
 
-		for (int j = 0; j < count; j++)
-			c.alliesS.put(nbt.getString(i + "_" + j + "_ally"), time());
+		for (int j = 0; j < cpf; j++)
+			c.potentialFriends.add(nbt.getString(i + "_" + j + "_pfriend"));
+
+		for (int j = 0; j < ca; j++) {
+			String allyName = nbt.getString(i + "_" + j + "_ally");
+			if(allyName != null && !allyName.isEmpty())
+				c.alliesS.put(allyName, time());
+		}
 
 		for (int j = 0; j < co; j++)
 			c.officers.add(nbt.getString(i + "_" + j + "_off"));
@@ -1781,6 +1820,7 @@ public class Clowder {
 		for (int j = 0; j < cwarp; j++) {
 
 			String name = nbt.getString(i + "_" + j + "_name");
+			if(!nbt.hasKey(i + "_" + j + "_dim") && MainRegistry.logger != null) MainRegistry.logger.info("Migrating legacy faction warp " + name + " for " + c.name + " to dimension 0.");
 			int[] coord = new int[] { nbt.getInteger(i + "_" + j + "_x"), nbt.getInteger(i + "_" + j + "_y"),
 					nbt.getInteger(i + "_" + j + "_z"), nbt.hasKey(i + "_" + j + "_dim") ? nbt.getInteger(i + "_" + j + "_dim") : 0 };
 
@@ -1859,6 +1899,24 @@ public class Clowder {
 		}
 	}
 
+	private void syncAllyNames() {
+		for(Clowder ally : new ArrayList<Clowder>(allies.keySet())) {
+			if(ally != null && ally.valid())
+				alliesS.put(ally.name, allies.get(ally));
+		}
+	}
+
+	private static void restoreAllyReferences() {
+		for(Clowder clowder : clowders) {
+			clowder.allies.clear();
+			for(String allyName : new HashSet<String>(clowder.alliesS.keySet())) {
+				Clowder ally = getClowderFromName(allyName);
+				if(ally != null && ally != clowder)
+					clowder.allies.put(ally, clowder.alliesS.get(allyName));
+			}
+		}
+	}
+
 	public static void readFromNBT(NBTTagCompound nbt) {
 
 		colours.add(ClowderTerritory.SAFEZONE_COLOR);
@@ -1867,17 +1925,29 @@ public class Clowder {
 
 		clowders.clear();
 
+		CommandClowderAdmin.WARENABLED = nbt.hasKey("warEnabledRuntime") ? nbt.getBoolean("warEnabledRuntime") : XFConfig.warEnabledDefault;
+		CommandClowderAdmin.WAR_COOLDOWNS_DISABLED = nbt.getBoolean("warCooldownsDisabled");
+		CommandClowderAdmin.WAR_ONLINE_CHECK_DISABLED = nbt.getBoolean("warOnlineCheckDisabled");
+		CommandClowderAdmin.WAR_STATE_CHECK_DISABLED = nbt.getBoolean("warStateCheckDisabled");
+		CommandClowderAdmin.LEGACY_WAR_ENABLED = nbt.getBoolean("legacyWarEnabled");
+
 		int count = nbt.getInteger("clowderCount");
 
 		for (int i = 0; i < count; i++)
 			clowders.add(loadClowder(i, nbt));
 
+		restoreAllyReferences();
 		recalculateIMap();
 	}
 
 	public static void writeToNBT(NBTTagCompound nbt) {
 
 		nbt.setInteger("clowderCount", clowders.size());
+		nbt.setBoolean("warEnabledRuntime", CommandClowderAdmin.WARENABLED);
+		nbt.setBoolean("warCooldownsDisabled", CommandClowderAdmin.WAR_COOLDOWNS_DISABLED);
+		nbt.setBoolean("warOnlineCheckDisabled", CommandClowderAdmin.WAR_ONLINE_CHECK_DISABLED);
+		nbt.setBoolean("warStateCheckDisabled", CommandClowderAdmin.WAR_STATE_CHECK_DISABLED);
+		nbt.setBoolean("legacyWarEnabled", CommandClowderAdmin.LEGACY_WAR_ENABLED);
 
 		for (int i = 0; i < clowders.size(); i++)
 			clowders.get(i).saveClowder(i, nbt);

--- a/src/main/java/com/hfr/command/CommandClowderAdmin.java
+++ b/src/main/java/com/hfr/command/CommandClowderAdmin.java
@@ -84,6 +84,7 @@ public class CommandClowderAdmin extends CommandBase {
 
 		if (cmd.equals("warenable")) {
 			WARENABLED = true;
+			ClowderData.getData(sender.getEntityWorld()).markDirty();
 			sender.addChatMessage(new ChatComponentText(INFO + "War declarations enabled!"));
 
 			// Notify and play sound for all players
@@ -111,6 +112,7 @@ public class CommandClowderAdmin extends CommandBase {
 
 		if(cmd.equals("wardisable")) {
 			WARENABLED = false;
+			ClowderData.getData(sender.getEntityWorld()).markDirty();
 			for (Object obj : MinecraftServer.getServer().getConfigurationManager().playerEntityList) {
 				if (obj instanceof EntityPlayerMP) {
 					EntityPlayerMP player = (EntityPlayerMP) obj;
@@ -128,6 +130,7 @@ public class CommandClowderAdmin extends CommandBase {
 			for (Clowder c : Clowder.clowders) {
 				c.activeWars.clear();
 				c.defendingAllies.clear();
+				c.warDeclaredAt.clear();
 			}
 			sender.addChatMessage(new ChatComponentText(INFO + "War declarations disabled; active wars cleared."));
 			return;
@@ -136,10 +139,10 @@ public class CommandClowderAdmin extends CommandBase {
 		if(cmd.equals("newplayerprotection")) { if(!XFConfig.enableNewPlayerProtection) { sender.addChatMessage(new ChatComponentText(ERROR + "New-player protection module is disabled in the config.")); return; } ClowderEvents.newPlayerProtectionEnabled = !ClowderEvents.newPlayerProtectionEnabled; sender.addChatMessage(new ChatComponentText(INFO + "New player protection is now " + (ClowderEvents.newPlayerProtectionEnabled ? "enabled" : "disabled") + ".")); return; }
 		if(cmd.equals("resetnewplayerprotection")) { cmdResetNewPlayerProtection(sender); return; }
 		if(cmd.equals("endnewplayerprotection")) { cmdEndNewPlayerProtection(sender); return; }
-		if(cmd.equals("skipwarcooldowns")) { WAR_COOLDOWNS_DISABLED = !WAR_COOLDOWNS_DISABLED; sender.addChatMessage(new ChatComponentText(INFO + "War cooldown skipping is now " + (WAR_COOLDOWNS_DISABLED ? "ENABLED" : "DISABLED") + ".")); return; }
-		if(cmd.equals("ignorewarcooldowncheck")) { WAR_COOLDOWNS_DISABLED = !WAR_COOLDOWNS_DISABLED; sender.addChatMessage(new ChatComponentText(INFO + "War cooldown checks are now " + (WAR_COOLDOWNS_DISABLED ? "IGNORED" : "ENFORCED") + ".")); return; }
-		if(cmd.equals("ignorewaronlinecheck")) { WAR_ONLINE_CHECK_DISABLED = !WAR_ONLINE_CHECK_DISABLED; sender.addChatMessage(new ChatComponentText(INFO + "War online checks are now " + (WAR_ONLINE_CHECK_DISABLED ? "IGNORED" : "ENFORCED") + ".")); return; }
-		if(cmd.equals("ignorewarstatecheck")) { WAR_STATE_CHECK_DISABLED = !WAR_STATE_CHECK_DISABLED; sender.addChatMessage(new ChatComponentText(INFO + "War state checks are now " + (WAR_STATE_CHECK_DISABLED ? "IGNORED" : "ENFORCED") + ".")); return; }
+		if(cmd.equals("skipwarcooldowns")) { WAR_COOLDOWNS_DISABLED = !WAR_COOLDOWNS_DISABLED; ClowderData.getData(sender.getEntityWorld()).markDirty(); sender.addChatMessage(new ChatComponentText(INFO + "War cooldown skipping is now " + (WAR_COOLDOWNS_DISABLED ? "ENABLED" : "DISABLED") + ".")); return; }
+		if(cmd.equals("ignorewarcooldowncheck")) { WAR_COOLDOWNS_DISABLED = !WAR_COOLDOWNS_DISABLED; ClowderData.getData(sender.getEntityWorld()).markDirty(); sender.addChatMessage(new ChatComponentText(INFO + "War cooldown checks are now " + (WAR_COOLDOWNS_DISABLED ? "IGNORED" : "ENFORCED") + ".")); return; }
+		if(cmd.equals("ignorewaronlinecheck")) { WAR_ONLINE_CHECK_DISABLED = !WAR_ONLINE_CHECK_DISABLED; ClowderData.getData(sender.getEntityWorld()).markDirty(); sender.addChatMessage(new ChatComponentText(INFO + "War online checks are now " + (WAR_ONLINE_CHECK_DISABLED ? "IGNORED" : "ENFORCED") + ".")); return; }
+		if(cmd.equals("ignorewarstatecheck")) { WAR_STATE_CHECK_DISABLED = !WAR_STATE_CHECK_DISABLED; ClowderData.getData(sender.getEntityWorld()).markDirty(); sender.addChatMessage(new ChatComponentText(INFO + "War state checks are now " + (WAR_STATE_CHECK_DISABLED ? "IGNORED" : "ENFORCED") + ".")); return; }
 		if(cmd.equals("skipwarcooldown")) {
 			for (Clowder c : Clowder.clowders) { c.noWarUntil.clear(); c.formerAllyNoWarUntil.clear(); }
 			sender.addChatMessage(new ChatComponentText(INFO + "All faction war cooldowns have been reset to 0."));
@@ -147,6 +150,7 @@ public class CommandClowderAdmin extends CommandBase {
 		}
 		if(cmd.equals("enablelegacywar")) {
 			LEGACY_WAR_ENABLED = !LEGACY_WAR_ENABLED;
+			ClowderData.getData(sender.getEntityWorld()).markDirty();
 			if(LEGACY_WAR_ENABLED) { WAR_COOLDOWNS_DISABLED = true; WAR_ONLINE_CHECK_DISABLED = true; WAR_STATE_CHECK_DISABLED = true; }
 			sender.addChatMessage(new ChatComponentText(INFO + "Legacy war mode is now " + (LEGACY_WAR_ENABLED ? "ENABLED" : "DISABLED") + "."));
 			return;
@@ -387,7 +391,7 @@ public class CommandClowderAdmin extends CommandBase {
 
 							int posX = xCoord + x * 16;
 							int posZ = zCoord + z * 16;
-							CoordPair loc = ClowderTerritory.getCoordPair(posX, posZ);
+							CoordPair loc = ClowderTerritory.getCoordPair(player.worldObj, posX, posZ);
 							
 							if(shape == 0 || Math.sqrt(Math.pow(x, 2) + Math.pow(z, 2)) < radius) {
 								ClowderTerritory.setZoneForCoord(player.worldObj, loc, zone);

--- a/src/main/java/com/hfr/data/ClowderData.java
+++ b/src/main/java/com/hfr/data/ClowderData.java
@@ -2,6 +2,8 @@ package com.hfr.data;
 
 import com.hfr.clowder.Clowder;
 import com.hfr.clowder.ClowderTerritory;
+import com.hfr.command.CommandClowderAdmin;
+import com.hfr.config.XFConfig;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -84,6 +86,7 @@ public class ClowderData extends WorldSavedData {
 
 		data = (ClowderData)storageWorld.perWorldStorage.loadData(ClowderData.class, "hfr_clowder");
 		if(data == null) {
+			CommandClowderAdmin.WARENABLED = XFConfig.warEnabledDefault;
 			storageWorld.perWorldStorage.setData("hfr_clowder", new ClowderData("hfr_clowder"));
 			data = (ClowderData)storageWorld.perWorldStorage.loadData(ClowderData.class, "hfr_clowder");
 		}

--- a/src/main/java/com/hfr/inventory/gui/GUIFlag.java
+++ b/src/main/java/com/hfr/inventory/gui/GUIFlag.java
@@ -42,6 +42,7 @@ public class GUIFlag extends GuiContainer {
 
 		float prestige = diFurnace.prestige;
 		float prestigeReq = diFurnace.prestigeReq;
+		float prestigeGen = diFurnace.prestigeGen;
 		int color = prestigeReq <= prestige ? 0x55FF55 : 0xFF5555;
 
 		String cityName = diFurnace.name == null || diFurnace.name.isEmpty() ? "Unnamed" : diFurnace.name;
@@ -53,7 +54,8 @@ public class GUIFlag extends GuiContainer {
 		this.fontRendererObj.drawString("Radius: " + XFConfig.cityRadius(diFurnace.cityLevel) + " Upkeep: " + Clowder.round(XFConfig.cityUpkeep(diFurnace.cityLevel)), 50, 42, 0xFFFFFF);
 		this.fontRendererObj.drawString("Owner: " + this.fontRendererObj.trimStringToWidth(ownerName, 82), 50, 53, 0xFFFFFF);
 		this.fontRendererObj.drawString("Prestige: " + Clowder.round(prestige), 50, 64, 0xFFFFFF);
-		this.fontRendererObj.drawString("Required: " + Clowder.round(prestigeReq), 50, 75, color);
+		this.fontRendererObj.drawString("Gain: " + Clowder.round(prestigeGen) + "/h", 50, 75, 0xFFFFFF);
+		this.fontRendererObj.drawString("Required: " + Clowder.round(prestigeReq), 50, 86, color);
 
 		if(isHelpHovered(x, y)) {
 			this.func_146283_a(Arrays.asList(new String[] {"Flag functions", "Claims are city-based", "Use /c city upgrade to level up", "Each level adds 1 chunk radius", "Capital max radius: 6 chunks", "Founding and upgrades require prestige"}), x - guiLeft, y - guiTop);

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityCap.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityCap.java
@@ -140,7 +140,7 @@ public class TileEntityCap extends TileEntityMachineBase implements ITerritoryPr
 
 				int posX = xCoord + x * 16;
 				int posZ = zCoord + z * 16;
-				CoordPair loc = ClowderTerritory.getCoordPair(posX, posZ);
+				CoordPair loc = ClowderTerritory.getCoordPair(worldObj, posX, posZ);
 				
 				TerritoryMeta meta = ClowderTerritory.getMetaFromCoords(loc);
 				

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -50,6 +50,8 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	public float prestige;
 	@SideOnly(Side.CLIENT)
 	public float prestigeReq;
+	@SideOnly(Side.CLIENT)
+	public float prestigeGen;
 	public String customFlagHash = "";
 
 	public TileEntityFlag() {
@@ -205,18 +207,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 					PacketDispatcher.wrapper.sendToAllAround(packet, new TargetPoint(this.worldObj.provider.dimensionId, xCoord, yCoord, zCoord, 250));
 				}
 
-			if(owner != null) {
-				this.updateGauge(owner.flag.ordinal(), 0, 250);
-				this.updateGauge(owner.color, 1, 250);
-				this.updateGauge(Float.floatToIntBits(owner.getPrestige()), 4, 20);
-				this.updateGauge(Float.floatToIntBits(owner.getPrestigeReq()), 5, 20);
-				this.updateGauge(cityLevel.ordinal(), 6, 20);
-			} else {
-				this.updateGauge(ClowderFlag.NONE.ordinal(), 0, 250);
-				this.updateGauge(0xFFFFFF, 1, 250);
-				this.updateGauge(0, 4, 20);
-				this.updateGauge(0, 5, 20);
-			}
+			syncPrestigeGauges();
 			this.updateGauge(mode, 2, 25);
 			this.updateGauge((int) (height * 100F), 3, 100);
 			
@@ -236,6 +227,23 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 		}
 	}
 	
+	public void syncPrestigeGauges() {
+		if(owner != null) {
+			this.updateGauge(owner.flag.ordinal(), 0, 250);
+			this.updateGauge(owner.color, 1, 250);
+			this.updateGauge(Float.floatToIntBits(owner.getPrestige()), 4, 20);
+			this.updateGauge(Float.floatToIntBits(owner.getPrestigeReq()), 5, 20);
+			this.updateGauge(Float.floatToIntBits(owner.getPrestigeGen()), 7, 20);
+			this.updateGauge(cityLevel.ordinal(), 6, 20);
+		} else {
+			this.updateGauge(ClowderFlag.NONE.ordinal(), 0, 250);
+			this.updateGauge(0xFFFFFF, 1, 250);
+			this.updateGauge(0, 4, 20);
+			this.updateGauge(0, 5, 20);
+			this.updateGauge(0, 7, 20);
+		}
+	}
+
 	public void processGauge(int val, int id) {
 		
 		switch(id) {
@@ -245,6 +253,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 		case 3: height = val * 0.01F; break;
 		case 4: prestige = Float.intBitsToFloat(val); break;
 		case 5: prestigeReq = Float.intBitsToFloat(val); break;
+		case 7: prestigeGen = Float.intBitsToFloat(val); break;
 		case 6: cityLevel = CityLevel.byOrdinal(val); break;
 		}
 	}
@@ -365,7 +374,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 
 				int posX = xCoord + x * 16;
 				int posZ = zCoord + z * 16;
-				CoordPair loc = ClowderTerritory.getCoordPair(posX, posZ);
+				CoordPair loc = ClowderTerritory.getCoordPair(worldObj, posX, posZ);
 				
 				TerritoryMeta meta = ClowderTerritory.getMetaFromCoords(loc);
 				
@@ -411,27 +420,27 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	
 	public boolean checkBorder(int x, int z) {
 
-		CoordPair loc = ClowderTerritory.getCoordPair(x, z);
+		CoordPair loc = ClowderTerritory.getCoordPair(worldObj, x, z);
 		Ownership owner = ClowderTerritory.getOwnerFromCoords(loc);
 		if(owner.zone != Zone.FACTION || owner.owner != this.owner)
 			return false;
 		
-		CoordPair loc1 = ClowderTerritory.getCoordPair(x + 16, z);
+		CoordPair loc1 = ClowderTerritory.getCoordPair(worldObj, x + 16, z);
 		Ownership owner1 = ClowderTerritory.getOwnerFromCoords(loc1);
 		if(owner1.zone == Zone.WILDERNESS || owner1.owner != this.owner)
 			return true;
 		
-		CoordPair loc2 = ClowderTerritory.getCoordPair(x - 16, z);
+		CoordPair loc2 = ClowderTerritory.getCoordPair(worldObj, x - 16, z);
 		Ownership owner2 = ClowderTerritory.getOwnerFromCoords(loc2);
 		if(owner2.zone == Zone.WILDERNESS || owner2.owner != this.owner)
 			return true;
 		
-		CoordPair loc3 = ClowderTerritory.getCoordPair(x, z + 16);
+		CoordPair loc3 = ClowderTerritory.getCoordPair(worldObj, x, z + 16);
 		Ownership owner3 = ClowderTerritory.getOwnerFromCoords(loc3);
 		if(owner3.zone == Zone.WILDERNESS || owner3.owner != this.owner)
 			return true;
 		
-		CoordPair loc4 = ClowderTerritory.getCoordPair(x, z - 16);
+		CoordPair loc4 = ClowderTerritory.getCoordPair(worldObj, x, z - 16);
 		Ownership owner4 = ClowderTerritory.getOwnerFromCoords(loc4);
 		if(owner4.zone == Zone.WILDERNESS || owner4.owner != this.owner)
 			return true;

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineBlastFurnace.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineBlastFurnace.java
@@ -61,7 +61,7 @@ public class TileEntityMachineBlastFurnace extends TileEntityMachineBase {
 			
 			if(operational()) {
 				
-				Ownership o = ClowderTerritory.getOwnerFromInts(xCoord, zCoord);
+				Ownership o = ClowderTerritory.getOwnerFromInts(worldObj, xCoord, zCoord);
 				
 				if(owner != o.owner) {
 					

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineFederalReserve.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineFederalReserve.java
@@ -39,7 +39,7 @@ public class TileEntityMachineFederalReserve extends TileEntityMachineBase {
 
             if(operational() && hasSpace() && slots[4] == null) {
 
-                Ownership o = ClowderTerritory.getOwnerFromInts(xCoord, zCoord);
+                Ownership o = ClowderTerritory.getOwnerFromInts(worldObj, xCoord, zCoord);
 
                 if(owner != o.owner) {
 

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineGrainmill.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineGrainmill.java
@@ -43,7 +43,7 @@ public class TileEntityMachineGrainmill extends TileEntityMachineBase {
 			
 			if(operational()) {
 				
-				Ownership o = ClowderTerritory.getOwnerFromInts(xCoord, zCoord);
+				Ownership o = ClowderTerritory.getOwnerFromInts(worldObj, xCoord, zCoord);
 				
 				if(owner != o.owner) {
 					

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineTemple.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineTemple.java
@@ -28,7 +28,7 @@ public class TileEntityMachineTemple extends TileEntityMachineBase {
 		
 		if(!worldObj.isRemote) {
 
-			Ownership o = ClowderTerritory.getOwnerFromInts(xCoord, zCoord);
+			Ownership o = ClowderTerritory.getOwnerFromInts(worldObj, xCoord, zCoord);
 			if(o != null && o.zone == Zone.FACTION) {
 				if(owner != o.owner) {
 					if(owner != null)

--- a/src/main/java/com/hfr/tileentity/machine/TileEntityMachineUni.java
+++ b/src/main/java/com/hfr/tileentity/machine/TileEntityMachineUni.java
@@ -39,7 +39,7 @@ public class TileEntityMachineUni extends TileEntityMachineBase {
 			
 			if(operational() && hasSpace() && slots[4] == null) {
 				
-				Ownership o = ClowderTerritory.getOwnerFromInts(xCoord, zCoord);
+				Ownership o = ClowderTerritory.getOwnerFromInts(worldObj, xCoord, zCoord);
 				
 				if(owner != o.owner) {
 					

--- a/src/main/java/com/hfr/tileentity/prop/TileEntityProp.java
+++ b/src/main/java/com/hfr/tileentity/prop/TileEntityProp.java
@@ -73,7 +73,7 @@ public class TileEntityProp extends TileEntity {
 				}
 			}
 			
-			Ownership o = ClowderTerritory.getOwnerFromInts(xCoord, zCoord);
+			Ownership o = ClowderTerritory.getOwnerFromInts(worldObj, xCoord, zCoord);
 			
 			/// WARP UPDATE ///
 			if(!warp.isEmpty()) {

--- a/src/main/java/com/hfr/tileentity/prop/TileEntityStatue.java
+++ b/src/main/java/com/hfr/tileentity/prop/TileEntityStatue.java
@@ -38,7 +38,7 @@ public class TileEntityStatue extends TileEntityMachineBase {
 			
 			if(this.operational()) {
 				
-				Ownership o = ClowderTerritory.getOwnerFromInts(xCoord, zCoord);
+				Ownership o = ClowderTerritory.getOwnerFromInts(worldObj, xCoord, zCoord);
 				
 				if(owner != o.owner) {
 					


### PR DESCRIPTION
### Motivation

- Ensure prestige buildings, warp/medical tents, and other structures resolve and persist their owning claim using the tile entity's actual world/dimension rather than assuming the overworld.
- Prevent alliances and runtime war toggles from being lost across restarts by storing/restoring ally names and admin war state in the saved world data.
- Give players immediate feedback in the City Center GUI when prestige generation changes while keeping the hourly prestige tick unchanged.
- Provide safe migration for legacy saves that lack dimension fields.

### Description

- Converted many claim lookups to use dimension-aware APIs by passing the `World` into `ClowderTerritory.getOwnerFromInts` and `ClowderTerritory.getCoordPair` calls across machine, prop, temple, statue, tent, flag and tile-entity classes. 
- Updated prestige bookkeeping and UI: `Clowder.addPrestigeGen` now calls `refreshPrestigeDisplays` to immediately refresh City Center flags; `GUIFlag` displays a `Gain: <amount>/h` line; `TileEntityFlag` got `syncPrestigeGauges()` and a `prestigeGen` gauge. 
- Improved ally persistence: ally name strings are saved (`alliesS`) and restored to runtime references on load via `restoreAllyReferences`; `saveClowder` now syncs ally names before writing. 
- Added runtime war-state persistence: `ClowderData` stores/loads admin war toggles and `CommandClowderAdmin` marks `ClowderData` dirty when toggling settings so runtime choices persist. 
- Added legacy migration and logging for missing dimension fields (homes, warps, ally warps) defaulting to dimension `0`, and preserved prior dimension-aware city/admin-claim and war-runtime persistence work. 

### Testing

- Performed a full project build to verify compilation after API changes and the mod jar was produced successfully. 
- No automated unit tests exist in the codebase, so no unit test suite was run.
- Manual verification notes and checks are recorded in `changelog.md` and `docs/server-administration.md` for multi-dimension persistence and City Center GUI behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4360d2fe5c83299bdbf1d561019b6e)