### PR TITLE
Seed stone drops from an installed HBM MiningConfig

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+# Seed stone drops from an installed HBM MiningConfig
+
+- Added optional, reflection-only discovery of HBM's `com.hbm.config.MiningConfig` and its `excavatorBedrockDrops` list.
+- Automatically creates `config/stonedrops.json` only when the file does not already exist, preserving all administrator customizations and intentionally empty configurations.
+- Assigned harder HBM minerals to deeper Y ranges and progressively softer deposits to higher ranges, with a one-percent stone-drop chance.
+- Documented HBM default seeding and its non-overwriting behavior in the configuration reference.
+
 # Implement optional JourneyMap 1.7.10 faction claim overlays
 
 - Added an optional, client-only reflection bridge for legacy JourneyMap 5.2.x/5.2.8 without imports, binaries, patches, or a required dependency. It preserves separate minimap and fullscreen `DrawStep` proxies across JourneyMap list clears and soft resets.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,3 +206,10 @@ config/stonedrops.json
 ```
 
 Each saved entry stores item registry name, metadata, stack size, chance, optional NBT string, and optional `minY`/`maxY` range.
+
+When no `stonedrops.json` exists, Xenofactions also checks for the optional HBM mod and its
+`com.hbm.config.MiningConfig` class. If both are present, the HBM
+`excavatorBedrockDrops` entries seed the file at a one-percent chance per stone block.
+Hard minerals use deeper Y ranges, while progressively softer deposits can appear higher.
+An existing file, including an intentionally empty list, is never overwritten; use
+`/stonedrop` or edit the JSON to customize the generated defaults.

--- a/src/main/java/com/hfr/compat/HbmStoneDropIntegration.java
+++ b/src/main/java/com/hfr/compat/HbmStoneDropIntegration.java
@@ -1,0 +1,116 @@
+package com.hfr.compat;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import com.hfr.main.MainRegistry;
+
+import cpw.mods.fml.common.Loader;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+/** Optional, reflection-only defaults sourced from HBM's excavator configuration. */
+public final class HbmStoneDropIntegration {
+
+    private static final String HBM_MOD_ID = "hbm";
+    private static final String MINING_CONFIG_CLASS = "com.hbm.config.MiningConfig";
+    private static final double DEFAULT_DROP_CHANCE = 0.01D;
+
+    private HbmStoneDropIntegration() {
+    }
+
+    /**
+     * Seeds a new stone-drop configuration without making HBM a required dependency.
+     * Existing configurations are always left alone, including deliberately empty ones.
+     */
+    public static void seedDefaultsIfAvailable(boolean stoneDropFileExists) {
+        if (stoneDropFileExists || !Loader.isModLoaded(HBM_MOD_ID)) {
+            return;
+        }
+
+        try {
+            Class<?> miningConfigClass = Class.forName(MINING_CONFIG_CLASS, false,
+                    HbmStoneDropIntegration.class.getClassLoader());
+            Field dropsField = miningConfigClass.getField("excavatorBedrockDrops");
+            Object configuredDrops = dropsField.get(null);
+            if (!(configuredDrops instanceof List)) {
+                MainRegistry.logger.warn("[XF] HBM MiningConfig.excavatorBedrockDrops is not a list; stone-drop defaults were not created.");
+                return;
+            }
+
+            int added = 0;
+            for (Object configuredDrop : (List<?>) configuredDrops) {
+                if (configuredDrop instanceof String && addDrop((String) configuredDrop)) {
+                    added++;
+                }
+            }
+
+            if (added > 0) {
+                MainRegistry.saveCustomDrops();
+                MainRegistry.logger.info("[XF] Created config/stonedrops.json with " + added
+                        + " defaults from HBM MiningConfig.");
+            }
+        } catch (ClassNotFoundException e) {
+            MainRegistry.logger.info("[XF] HBM is installed without com.hbm.config.MiningConfig; stone-drop defaults were not created.");
+        } catch (Exception e) {
+            MainRegistry.logger.warn("[XF] Could not read HBM MiningConfig for stone-drop defaults: " + e.getMessage());
+        }
+    }
+
+    private static boolean addDrop(String specification) {
+        String[] values = specification.trim().split("\\s+");
+        if (values.length < 4) {
+            MainRegistry.logger.warn("[XF] Ignoring invalid HBM excavator drop: " + specification);
+            return false;
+        }
+
+        try {
+            Item item = (Item) Item.itemRegistry.getObject(values[0]);
+            if (item == null) {
+                MainRegistry.logger.warn("[XF] Ignoring missing HBM excavator item: " + values[0]);
+                return false;
+            }
+
+            int metadata = Integer.parseInt(values[1]);
+            int minimumAmount = Integer.parseInt(values[2]);
+            Integer.parseInt(values[3]); // Validate HBM's maximum-amount field as well.
+            int[] yRange = depthForMaterial(values[0]);
+
+            MainRegistry.customDrops.add(new ItemStack(item, Math.max(1, minimumAmount), metadata));
+            MainRegistry.customDropChances.add(DEFAULT_DROP_CHANCE);
+            MainRegistry.customDropMinYs.add(Integer.valueOf(yRange[0]));
+            MainRegistry.customDropMaxYs.add(Integer.valueOf(yRange[1]));
+            return true;
+        } catch (NumberFormatException e) {
+            MainRegistry.logger.warn("[XF] Ignoring invalid HBM excavator drop: " + specification);
+            return false;
+        }
+    }
+
+    /** Harder minerals are assigned deeper ranges; progressively softer deposits extend upward. */
+    static int[] depthForMaterial(String registryName) {
+        String name = registryName.toLowerCase();
+        if (containsAny(name, "fire", "uranium", "beryllium", "pollucite", "chunk_ore")) {
+            return new int[] { 1, 20 };
+        }
+        if (containsAny(name, "lithium", "tintungsten", "chromite")) {
+            return new int[] { 5, 32 };
+        }
+        if (containsAny(name, "leadzinc", "nickel", "aluminium", "heavymineral")) {
+            return new int[] { 10, 48 };
+        }
+        if (containsAny(name, "copper", "ironoxide", "evaporite", "quartz", "lapis")) {
+            return new int[] { 16, 64 };
+        }
+        return new int[] { 24, 96 };
+    }
+
+    private static boolean containsAny(String value, String... candidates) {
+        for (String candidate : candidates) {
+            if (value.contains(candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -50,6 +50,7 @@ import com.hfr.blocks.*;
 import com.hfr.blocks.machine.MachineMarket.TileEntityMarket;
 import com.hfr.clowder.*;
 import com.hfr.command.*;
+import com.hfr.compat.HbmStoneDropIntegration;
 import com.hfr.config.XFConfig;
 import com.hfr.data.*;
 import com.hfr.dynmap.XFDynmapIntegration;
@@ -766,6 +767,7 @@ public class MainRegistry
 	{
 		//in postload, long after all blocks have been registered, the buffered config is being evaluated and processed.
 		processBuffer();
+		HbmStoneDropIntegration.seedDefaultsIfAvailable(SAVE_FILE.exists());
 		XFGuideBook.register();
 		
 		try {


### PR DESCRIPTION
### Motivation

- Provide automatic stone-drop defaults when the optional HBM mod is present so servers running both mods get reasonable excavator drops without making HBM a hard dependency.
- Preserve any existing `config/stonedrops.json` (including an intentionally empty file) so administrators' customizations are never overwritten.
- Assign Y ranges that reflect mineral hardness so rarer/harder materials appear deeper and softer materials can appear higher.

### Description

- Added a reflection-only integration class `HbmStoneDropIntegration` at `src/main/java/com/hfr/compat/HbmStoneDropIntegration.java` that reads `com.hbm.config.MiningConfig.excavatorBedrockDrops`, validates entries, resolves registered items, and converts them into `MainRegistry` custom drop entries.
- The integration seeds drops only when `config/stonedrops.json` does not exist and `Loader.isModLoaded("hbm")` is true, using a default one-percent per-stone chance and material-based `depthForMaterial` Y ranges; parsed entries populate `MainRegistry.customDrops`, `customDropChances`, `customDropMinYs`, and `customDropMaxYs`, and the file is persisted via `MainRegistry.saveCustomDrops()`.
- Hooked initialization into `MainRegistry.PostLoad` by calling `HbmStoneDropIntegration.seedDefaultsIfAvailable(SAVE_FILE.exists());` so the seeding runs after items/blocks are registered without introducing a compile-time HBM dependency.
- Updated documentation and release notes by editing `docs/configuration.md` to document the optional HBM seeding behavior and by adding an entry to `changelog.md` describing the feature and non-overwriting policy.

### Testing

- Ran `git diff --cached --check` and `git diff --check` to verify there are no index/whitespace errors from the change, with the staged changes passing the checks.
- Executed Python assertion scripts that verify the new integration strings and the presence of the post-init hook, reflective class/field usage, persistence call, and expected depth endpoints in `HbmStoneDropIntegration.java`.
- Per project instructions, no binary compilation was performed and no binary files were added during these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66702185048323837db3c3f2450d69)