### PR TITLE
Fix claim overlay packet decoding for Forge 1.7.10

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Fix claim overlay packet decoding for Forge 1.7.10
+
+- Replaced an unsupported Netty `ByteBufUtil.getBytes` call with sequential `ByteBuf.readBytes` decoding while preserving packet validation and wire format.
+
 # Seed stone drops from an installed HBM MiningConfig
 
 - Added optional, reflection-only discovery of HBM's `com.hbm.config.MiningConfig` and its `excavatorBedrockDrops` list.

--- a/src/main/java/com/hfr/packet/effect/ClaimOverlayPacket.java
+++ b/src/main/java/com/hfr/packet/effect/ClaimOverlayPacket.java
@@ -12,7 +12,6 @@ import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 
 /** A bounded part of an authoritative dimension snapshot. */
 public class ClaimOverlayPacket implements IMessage {
@@ -41,7 +40,9 @@ public class ClaimOverlayPacket implements IMessage {
 		for(int i = 0; i < count && buf.readableBytes() >= 13; i++) {
 			int x = buf.readInt(), z = buf.readInt(), color = buf.readInt(), length = buf.readUnsignedByte();
 			if(length > 128 || buf.readableBytes() < length) { claims.clear(); parts = 0; return; }
-			String id = new String(ByteBufUtil.getBytes(buf, buf.readerIndex(), length), java.nio.charset.Charset.forName("UTF-8")); buf.skipBytes(length);
+			byte[] idBytes = new byte[length];
+			buf.readBytes(idBytes);
+			String id = new String(idBytes, java.nio.charset.Charset.forName("UTF-8"));
 			if(id.length() > 0) claims.add(new Claim(dimensionId, x, z, id, color));
 		}
 		if(claims.size() != count) { claims.clear(); parts = 0; }


### PR DESCRIPTION
### Motivation
- Resolve a Java compilation/runtime incompatibility caused by the unsupported Netty `ByteBufUtil.getBytes(ByteBuf,int,int)` usage in `ClaimOverlayPacket.java` while preserving the existing packet validation, wire format, and Java 8 / Forge 1.7.10 compatibility.

### Description
- Replaced the `ByteBufUtil.getBytes(...)/skipBytes(...)` approach with a length-sized `byte[]`, `buf.readBytes(idBytes)`, and `new String(idBytes, UTF-8)`; removed the unused `io.netty.buffer.ByteBufUtil` import and preserved `MAX_CLAIMS`, the 128-byte group ID limit, and all packet validation and field ordering; updated `changelog.md` to document the fix (files changed: `src/main/java/com/hfr/packet/effect/ClaimOverlayPacket.java`, `changelog.md`).

### Testing
- Performed automated source checks verifying there are no remaining `ByteBufUtil` references and that the `MAX_CLAIMS`, `length > 128`, `readBytes(idBytes)`, and `new String(idBytes, ...)` patterns are present; repository diff checks reported no warnings; a platform-specific Windows `gradlew.bat compileJava` run was not executed in this environment (wrapper is Windows-only), so a full compile should be run on Windows to fully verify the original `compileJava` error is resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71773c51908323a701649c00b4453b)