### PR TITLE
Add JourneyMap city territory labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Add JourneyMap city territory labels
+
+- Added JourneyMap city territory labels that render once per city territory on enabled minimap and fullscreen claim overlays, using city names instead of internal faction/group IDs.
+- Extended authoritative claim overlay snapshots with bounded city-label text and stable label positions, including flag positions when available and territory-center fallbacks.
+- Hardened claim overlay packet decoding for bounded labels and malformed multipart data while preserving the optional JourneyMap 5.2.x reflection bridge.
+
 # Remap production mods in the development client
 
 - Migrated the legacy ForgeGradle 1.2 build to the GTNH convention and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,7 @@ Category: `XENOFACTIONS_09B_JOURNEYMAP_CLIENT`
 |---|---:|---|
 | `showMinimapClaims` | `true` | Render faction city claims on rectangular or circular minimaps. |
 | `showFullscreenClaims` | `true` | Render faction city claims on the fullscreen map. |
+| `journeyMapShowTerritoryLabels` | `true` | Render one readable city-name label per city territory on enabled JourneyMap claim overlays. Labels use the city name, not internal faction or city IDs. |
 | `claimFillOpacity` | `0.18` | Faction-color fill opacity, clamped to `0.0–1.0`. |
 | `claimBorderOpacity` | `0.80` | Exposed perimeter opacity, clamped to `0.0–1.0`. |
 | `claimBorderWidth` | `1.0` | Perimeter width, clamped to `0.25–10.0` pixels. |

--- a/src/main/java/com/hfr/client/journeymap/ClientClaimOverlayCache.java
+++ b/src/main/java/com/hfr/client/journeymap/ClientClaimOverlayCache.java
@@ -25,10 +25,16 @@ public final class ClientClaimOverlayCache {
 		assembly.claims.addAll(claims); assembly.nextPart++;
 		if(assembly.nextPart == parts) {
 			HashMap<Long, Claim> lookup = new HashMap<Long, Claim>();
-			for(Claim claim : assembly.claims) lookup.put(Long.valueOf(ClaimOverlayData.chunkKey(claim.chunkX, claim.chunkZ)), claim);
+			HashMap<String, GroupBuilder> groups = new HashMap<String, GroupBuilder>();
+			for(Claim claim : assembly.claims) {
+				lookup.put(Long.valueOf(ClaimOverlayData.chunkKey(claim.chunkX, claim.chunkZ)), claim);
+				GroupBuilder group = groups.get(claim.groupId);
+				if(group == null) { group = new GroupBuilder(claim.groupId, claim.label, claim.labelX, claim.labelZ); groups.put(claim.groupId, group); }
+				group.include(claim.chunkX, claim.chunkZ);
+			}
 			HashMap<Integer, Snapshot> copy = new HashMap<Integer, Snapshot>(snapshots);
 			copy.clear(); // The server sends only the player's authoritative current dimension.
-			copy.put(Integer.valueOf(dimension), new Snapshot(assembly.claims, lookup)); snapshots = Collections.unmodifiableMap(copy);
+			copy.put(Integer.valueOf(dimension), new Snapshot(assembly.claims, lookup, groups)); snapshots = Collections.unmodifiableMap(copy);
 			assemblies.remove(Integer.valueOf(dimension));
 		}
 	}
@@ -36,15 +42,31 @@ public final class ClientClaimOverlayCache {
 	public static void clear() { snapshots = Collections.emptyMap(); assemblies.clear(); }
 
 	public static final class Snapshot {
-		public final List<Claim> claims; public final Map<Long, Claim> byChunk;
-		private Snapshot(List<Claim> claims, Map<Long, Claim> byChunk) {
+		public final List<Claim> claims; public final Map<Long, Claim> byChunk; public final List<TerritoryGroup> groups;
+		private Snapshot(List<Claim> claims, Map<Long, Claim> byChunk, Map<String, GroupBuilder> groups) {
 			this.claims = Collections.unmodifiableList(new ArrayList<Claim>(claims));
 			this.byChunk = Collections.unmodifiableMap(byChunk);
+			ArrayList<TerritoryGroup> built = new ArrayList<TerritoryGroup>();
+			for(GroupBuilder group : groups.values()) built.add(group.build());
+			this.groups = Collections.unmodifiableList(built);
 		}
 		public boolean sameGroup(int x, int z, String group) {
 			Claim neighbor = byChunk.get(Long.valueOf(ClaimOverlayData.chunkKey(x, z)));
 			return neighbor != null && group.equals(neighbor.groupId);
 		}
+	}
+	public static final class TerritoryGroup {
+		public final String groupId, label; public final int labelX, labelZ, minChunkX, minChunkZ, maxChunkX, maxChunkZ;
+		private TerritoryGroup(String groupId, String label, int labelX, int labelZ, int minChunkX, int minChunkZ, int maxChunkX, int maxChunkZ) {
+			this.groupId = groupId; this.label = label; this.labelX = labelX; this.labelZ = labelZ;
+			this.minChunkX = minChunkX; this.minChunkZ = minChunkZ; this.maxChunkX = maxChunkX; this.maxChunkZ = maxChunkZ;
+		}
+	}
+	private static final class GroupBuilder {
+		final String groupId, label; final int labelX, labelZ; int minChunkX = Integer.MAX_VALUE, minChunkZ = Integer.MAX_VALUE, maxChunkX = Integer.MIN_VALUE, maxChunkZ = Integer.MIN_VALUE;
+		GroupBuilder(String groupId, String label, int labelX, int labelZ) { this.groupId = groupId; this.label = label; this.labelX = labelX; this.labelZ = labelZ; }
+		void include(int x, int z) { if(x < minChunkX) minChunkX = x; if(z < minChunkZ) minChunkZ = z; if(x > maxChunkX) maxChunkX = x; if(z > maxChunkZ) maxChunkZ = z; }
+		TerritoryGroup build() { return new TerritoryGroup(groupId, label, labelX, labelZ, minChunkX, minChunkZ, maxChunkX, maxChunkZ); }
 	}
 	private static final class Assembly {
 		final int generation, parts; int nextPart; final ArrayList<Claim> claims = new ArrayList<Claim>();

--- a/src/main/java/com/hfr/client/journeymap/JourneyMapClaimDrawHandler.java
+++ b/src/main/java/com/hfr/client/journeymap/JourneyMapClaimDrawHandler.java
@@ -9,6 +9,7 @@ import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
 import com.hfr.client.journeymap.ClientClaimOverlayCache.Snapshot;
+import com.hfr.client.journeymap.ClientClaimOverlayCache.TerritoryGroup;
 import com.hfr.clowder.ClaimOverlayData.Claim;
 import com.hfr.config.XFConfig;
 
@@ -44,6 +45,11 @@ final class JourneyMapClaimDrawHandler implements InvocationHandler {
 		GL11.glDisable(GL11.GL_TEXTURE_2D); GL11.glEnable(GL11.GL_BLEND); GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA); GL11.glDisable(GL11.GL_ALPHA_TEST); GL11.glDisable(GL11.GL_DEPTH_TEST);
 		try {
 			for(Claim claim : snapshot.claims) renderClaim(grid, claim, snapshot, xOffset, yOffset, width, height);
+			if(XFConfig.journeyMapShowTerritoryLabels) {
+				GL11.glEnable(GL11.GL_TEXTURE_2D);
+				GL11.glColor4f(1F, 1F, 1F, 1F);
+				for(TerritoryGroup group : snapshot.groups) renderLabel(grid, group, xOffset, yOffset, width, height);
+			}
 		} finally {
 			if(texture) GL11.glEnable(GL11.GL_TEXTURE_2D); else GL11.glDisable(GL11.GL_TEXTURE_2D);
 			if(blend) GL11.glEnable(GL11.GL_BLEND); else GL11.glDisable(GL11.GL_BLEND); GL11.glBlendFunc(blendSrc, blendDst);
@@ -67,6 +73,29 @@ final class JourneyMapClaimDrawHandler implements InvocationHandler {
 		if(!snapshot.sameGroup(claim.chunkX + 1, claim.chunkZ, claim.groupId)) edge(t,p1,p2,xo,yo);
 		if(!snapshot.sameGroup(claim.chunkX, claim.chunkZ + 1, claim.groupId)) edge(t,p2,p3,xo,yo);
 		if(!snapshot.sameGroup(claim.chunkX - 1, claim.chunkZ, claim.groupId)) edge(t,p3,p0,xo,yo); t.draw();
+	}
+	private void renderLabel(Object grid, TerritoryGroup group, double xo, double yo, int width, int height) throws Exception {
+		if(group.label == null || group.label.length() == 0) return;
+		Point2D b0 = point(grid, group.minChunkX * 16D, group.minChunkZ * 16D), b1 = point(grid, (group.maxChunkX + 1) * 16D, group.minChunkZ * 16D);
+		Point2D b2 = point(grid, (group.maxChunkX + 1) * 16D, (group.maxChunkZ + 1) * 16D), b3 = point(grid, group.minChunkX * 16D, (group.maxChunkZ + 1) * 16D);
+		double minX = Math.min(Math.min(b0.getX(), b1.getX()), Math.min(b2.getX(), b3.getX())) + xo, maxX = Math.max(Math.max(b0.getX(), b1.getX()), Math.max(b2.getX(), b3.getX())) + xo;
+		double minY = Math.min(Math.min(b0.getY(), b1.getY()), Math.min(b2.getY(), b3.getY())) + yo, maxY = Math.max(Math.max(b0.getY(), b1.getY()), Math.max(b2.getY(), b3.getY())) + yo;
+		if(maxX < 0 || maxY < 0 || minX > width || minY > height || maxX - minX < 12D || maxY - minY < 8D) return;
+		Minecraft mc = Minecraft.getMinecraft(); if(mc == null || mc.fontRenderer == null) return;
+		String text = fit(group.label, Math.max(0, (int)Math.floor(maxX - minX) - 4), mc.fontRenderer);
+		if(text.length() == 0) return;
+		Point2D label = point(grid, group.labelX, group.labelZ);
+		int textWidth = mc.fontRenderer.getStringWidth(text);
+		int x = (int)Math.round(label.getX() + xo - textWidth / 2D), y = (int)Math.round(label.getY() + yo - mc.fontRenderer.FONT_HEIGHT / 2D);
+		if(x + textWidth < 0 || y + mc.fontRenderer.FONT_HEIGHT < 0 || x > width || y > height) return;
+		mc.fontRenderer.drawStringWithShadow(text, x, y, 0xFFFFFF);
+	}
+	private String fit(String label, int maxWidth, net.minecraft.client.gui.FontRenderer font) {
+		if(maxWidth <= 0 || font.getStringWidth(label) <= maxWidth) return maxWidth <= 0 ? "" : label;
+		String ellipsis = "..."; int ellipsisWidth = font.getStringWidth(ellipsis); if(ellipsisWidth > maxWidth) return "";
+		String text = label;
+		while(text.length() > 0 && font.getStringWidth(text) + ellipsisWidth > maxWidth) text = text.substring(0, text.length() - 1);
+		return text.length() == 0 ? "" : text + ellipsis;
 	}
 	private Point2D point(Object grid,double x,double z) throws Exception { return (Point2D)reflection.getBlockPixel.invoke(grid, x, z); }
 	private static void vertex(Tessellator t,Point2D p,double x,double y){t.addVertex(p.getX()+x,p.getY()+y,0);}

--- a/src/main/java/com/hfr/clowder/ClaimOverlayData.java
+++ b/src/main/java/com/hfr/clowder/ClaimOverlayData.java
@@ -2,6 +2,7 @@ package com.hfr.clowder;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -15,6 +16,18 @@ public final class ClaimOverlayData {
 
 	public static List<Claim> snapshot(int dimensionId) {
 		ArrayList<Claim> claims = new ArrayList<Claim>();
+		HashMap<String, Bounds> bounds = new HashMap<String, Bounds>();
+		for(Map.Entry<CoordPair, TerritoryMeta> entry : ClowderTerritory.territories.entrySet()) {
+			CoordPair coord = entry.getKey();
+			TerritoryMeta meta = entry.getValue();
+			if(coord == null || coord.dimensionId != dimensionId || meta == null || meta.owner == null
+					|| meta.owner.zone != Zone.FACTION || meta.owner.owner == null || !meta.isCityClaim())
+				continue;
+			String groupId = groupId(dimensionId, meta);
+			Bounds bound = bounds.get(groupId);
+			if(bound == null) { bound = new Bounds(meta); bounds.put(groupId, bound); }
+			bound.include(coord.x, coord.z);
+		}
 		for(Map.Entry<CoordPair, TerritoryMeta> entry : ClowderTerritory.territories.entrySet()) {
 			CoordPair coord = entry.getKey();
 			TerritoryMeta meta = entry.getValue();
@@ -22,12 +35,33 @@ public final class ClaimOverlayData {
 					|| meta.owner.zone != Zone.FACTION || meta.owner.owner == null || !meta.isCityClaim())
 				continue;
 			Clowder faction = meta.owner.owner;
-			String factionId = faction.uuid == null || faction.uuid.length() == 0 ? faction.name : faction.uuid;
-			String cityId = meta.cityId == null || meta.cityId.length() == 0
-					? dimensionId + ":" + meta.flagX + ":" + meta.flagY + ":" + meta.flagZ : meta.cityId;
-			claims.add(new Claim(dimensionId, coord.x, coord.z, factionId + "/" + cityId, faction.color & 0xFFFFFF));
+			String groupId = groupId(dimensionId, meta);
+			Bounds bound = bounds.get(groupId);
+			int labelX = bound == null ? coord.x * 16 + 8 : bound.labelX();
+			int labelZ = bound == null ? coord.z * 16 + 8 : bound.labelZ();
+			claims.add(new Claim(dimensionId, coord.x, coord.z, groupId, faction.color & 0xFFFFFF, cleanLabel(meta.cityName), labelX, labelZ));
 		}
 		return Collections.unmodifiableList(claims);
+	}
+
+	private static String groupId(int dimensionId, TerritoryMeta meta) {
+		return meta.cityId == null || meta.cityId.length() == 0 ? dimensionId + ":" + meta.flagX + ":" + meta.flagY + ":" + meta.flagZ : meta.cityId;
+	}
+
+	private static String cleanLabel(String label) {
+		if(label == null) return "";
+		String trimmed = label.trim();
+		int max = Math.max(1, com.hfr.config.XFConfig.claimNameMaxLength);
+		return trimmed.length() > max ? trimmed.substring(0, max) : trimmed;
+	}
+
+	private static final class Bounds {
+		final TerritoryMeta meta; int minX = Integer.MAX_VALUE, minZ = Integer.MAX_VALUE, maxX = Integer.MIN_VALUE, maxZ = Integer.MIN_VALUE;
+		Bounds(TerritoryMeta meta) { this.meta = meta; }
+		void include(int x, int z) { if(x < minX) minX = x; if(z < minZ) minZ = z; if(x > maxX) maxX = x; if(z > maxZ) maxZ = z; }
+		boolean hasValidFlag() { return meta.flagY >= 0; }
+		int labelX() { return hasValidFlag() ? meta.flagX : (minX * 16 + (maxX - minX + 1) * 8); }
+		int labelZ() { return hasValidFlag() ? meta.flagZ : (minZ * 16 + (maxZ - minZ + 1) * 8); }
 	}
 
 	public static long chunkKey(int x, int z) {
@@ -35,11 +69,15 @@ public final class ClaimOverlayData {
 	}
 
 	public static final class Claim {
-		public final int dimensionId, chunkX, chunkZ, color;
-		public final String groupId;
+		public final int dimensionId, chunkX, chunkZ, color, labelX, labelZ;
+		public final String groupId, label;
 		public Claim(int dimensionId, int chunkX, int chunkZ, String groupId, int color) {
+			this(dimensionId, chunkX, chunkZ, groupId, color, "", chunkX * 16 + 8, chunkZ * 16 + 8);
+		}
+		public Claim(int dimensionId, int chunkX, int chunkZ, String groupId, int color, String label, int labelX, int labelZ) {
 			this.dimensionId = dimensionId; this.chunkX = chunkX; this.chunkZ = chunkZ;
-			this.groupId = groupId; this.color = color & 0xFFFFFF;
+			this.groupId = groupId == null ? "" : groupId; this.color = color & 0xFFFFFF;
+			this.label = label == null ? "" : label; this.labelX = labelX; this.labelZ = labelZ;
 		}
 	}
 }

--- a/src/main/java/com/hfr/config/XFConfig.java
+++ b/src/main/java/com/hfr/config/XFConfig.java
@@ -44,6 +44,7 @@ public final class XFConfig {
 	public static boolean enableJourneyMapIntegration = true;
 	public static boolean journeyMapShowMinimapClaims = true;
 	public static boolean journeyMapShowFullscreenClaims = true;
+	public static boolean journeyMapShowTerritoryLabels = true;
 	public static double journeyMapClaimFillOpacity = 0.18D;
 	public static double journeyMapClaimBorderOpacity = 0.80D;
 	public static double journeyMapClaimBorderWidth = 1.0D;
@@ -239,6 +240,7 @@ public final class XFConfig {
 
 		journeyMapShowMinimapClaims = bool(config, CAT_JOURNEYMAP, "showMinimapClaims", journeyMapShowMinimapClaims, "Shows faction city claims on legacy JourneyMap minimaps.");
 		journeyMapShowFullscreenClaims = bool(config, CAT_JOURNEYMAP, "showFullscreenClaims", journeyMapShowFullscreenClaims, "Shows faction city claims on the legacy JourneyMap fullscreen map.");
+		journeyMapShowTerritoryLabels = bool(config, CAT_JOURNEYMAP, "journeyMapShowTerritoryLabels", journeyMapShowTerritoryLabels, "Shows one readable city-name label for each JourneyMap city territory when that map's claim overlay is enabled.");
 		journeyMapClaimFillOpacity = dbl(config, CAT_JOURNEYMAP, "claimFillOpacity", journeyMapClaimFillOpacity, 0D, 1D, "Faction-color claim fill opacity.");
 		journeyMapClaimBorderOpacity = dbl(config, CAT_JOURNEYMAP, "claimBorderOpacity", journeyMapClaimBorderOpacity, 0D, 1D, "Faction-color exposed-border opacity.");
 		journeyMapClaimBorderWidth = dbl(config, CAT_JOURNEYMAP, "claimBorderWidth", journeyMapClaimBorderWidth, 0.25D, 10D, "Exposed claim border width in pixels.");
@@ -260,6 +262,7 @@ public final class XFConfig {
 		config.addCustomCategoryComment(CAT_PROTECTION, "07 - Starter player protection and faction build-grace settings.");
 		config.addCustomCategoryComment(CAT_CUSTOM_FLAGS, "08 - Custom faction flag import safety limits and cache/reload behaviour.");
 		config.addCustomCategoryComment(CAT_DYNMAP, "09 - Optional Dynmap marker styling, labels, and refresh timing.");
+		config.addCustomCategoryComment(CAT_JOURNEYMAP, "09B - Optional JourneyMap 5.2.x client claim overlay styling and city territory labels.");
 		config.addCustomCategoryComment(CAT_LEGACY_MACHINES, "10 - Legacy machine and power settings moved under the Xenofactions category flow.");
 		config.addCustomCategoryComment(CAT_LEGACY_DEFENSE, "11 - Legacy radar and forcefield settings.");
 		config.addCustomCategoryComment(CAT_LEGACY_WEAPONS, "12 - Legacy missile, nuke, railgun, and explosive weapon settings.");

--- a/src/main/java/com/hfr/packet/effect/ClaimOverlayPacket.java
+++ b/src/main/java/com/hfr/packet/effect/ClaimOverlayPacket.java
@@ -2,6 +2,9 @@ package com.hfr.packet.effect;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CodingErrorAction;
 
 import com.hfr.clowder.ClaimOverlayData.Claim;
 import com.hfr.main.MainRegistry;
@@ -16,6 +19,10 @@ import io.netty.buffer.ByteBuf;
 /** A bounded part of an authoritative dimension snapshot. */
 public class ClaimOverlayPacket implements IMessage {
 	public static final int MAX_CLAIMS = 512;
+	public static final int MAX_GROUP_ID_BYTES = 128;
+	public static final int MAX_LABEL_BYTES = 256;
+	public static final int MAX_LABEL_CHARS = 64;
+	private static final Charset UTF_8 = Charset.forName("UTF-8");
 	private int dimensionId, generation, part, parts;
 	private List<Claim> claims = new ArrayList<Claim>();
 
@@ -26,9 +33,9 @@ public class ClaimOverlayPacket implements IMessage {
 	@Override public void toBytes(ByteBuf buf) {
 		buf.writeInt(dimensionId); buf.writeInt(generation); buf.writeShort(part); buf.writeShort(parts); buf.writeShort(claims.size());
 		for(Claim claim : claims) {
-			buf.writeInt(claim.chunkX); buf.writeInt(claim.chunkZ); buf.writeInt(claim.color);
-			byte[] id = claim.groupId.getBytes(java.nio.charset.Charset.forName("UTF-8"));
-			int length = Math.min(id.length, 128); buf.writeByte(length); buf.writeBytes(id, 0, length);
+			buf.writeInt(claim.chunkX); buf.writeInt(claim.chunkZ); buf.writeInt(claim.color); buf.writeInt(claim.labelX); buf.writeInt(claim.labelZ);
+			writeString(buf, claim.groupId, MAX_GROUP_ID_BYTES);
+			writeString(buf, claim.label, MAX_LABEL_BYTES);
 		}
 	}
 	@Override public void fromBytes(ByteBuf buf) {
@@ -37,15 +44,29 @@ public class ClaimOverlayPacket implements IMessage {
 		dimensionId = buf.readInt(); generation = buf.readInt(); part = buf.readUnsignedShort(); parts = buf.readUnsignedShort();
 		int count = buf.readUnsignedShort();
 		if(parts < 1 || parts > 4096 || part >= parts || count > MAX_CLAIMS) { claims.clear(); parts = 0; return; }
-		for(int i = 0; i < count && buf.readableBytes() >= 13; i++) {
-			int x = buf.readInt(), z = buf.readInt(), color = buf.readInt(), length = buf.readUnsignedByte();
-			if(length > 128 || buf.readableBytes() < length) { claims.clear(); parts = 0; return; }
-			byte[] idBytes = new byte[length];
-			buf.readBytes(idBytes);
-			String id = new String(idBytes, java.nio.charset.Charset.forName("UTF-8"));
-			if(id.length() > 0) claims.add(new Claim(dimensionId, x, z, id, color));
+		for(int i = 0; i < count && buf.readableBytes() >= 22; i++) {
+			int x = buf.readInt(), z = buf.readInt(), color = buf.readInt(), labelX = buf.readInt(), labelZ = buf.readInt();
+			String id = readString(buf, MAX_GROUP_ID_BYTES);
+			String label = id == null ? null : readString(buf, MAX_LABEL_BYTES);
+			if(id == null || label == null) { claims.clear(); parts = 0; return; }
+			if(id.length() > 0) claims.add(new Claim(dimensionId, x, z, id, color, label, labelX, labelZ));
 		}
 		if(claims.size() != count) { claims.clear(); parts = 0; }
+	}
+	private static void writeString(ByteBuf buf, String value, int maxBytes) {
+		byte[] bytes = (value == null ? "" : value).getBytes(UTF_8);
+		int length = Math.min(bytes.length, maxBytes); buf.writeShort(length); buf.writeBytes(bytes, 0, length);
+	}
+	private static String readString(ByteBuf buf, int maxBytes) {
+		if(buf.readableBytes() < 2) return null;
+		int length = buf.readUnsignedShort();
+		if(length < 0 || length > maxBytes || buf.readableBytes() < length) return null;
+		byte[] bytes = new byte[length]; buf.readBytes(bytes);
+		String value;
+		try {
+			value = UTF_8.newDecoder().onMalformedInput(CodingErrorAction.REPORT).onUnmappableCharacter(CodingErrorAction.REPORT).decode(java.nio.ByteBuffer.wrap(bytes)).toString();
+		} catch(CharacterCodingException failure) { return null; }
+		return value.length() > MAX_LABEL_CHARS && maxBytes == MAX_LABEL_BYTES ? null : value;
 	}
 	public static class Handler implements IMessageHandler<ClaimOverlayPacket, IMessage> {
 		@Override @SideOnly(Side.CLIENT) public IMessage onMessage(final ClaimOverlayPacket message, MessageContext ctx) {


### PR DESCRIPTION
### Motivation
- Provide a single readable city-name label per Xenofactions city territory on JourneyMap maps while preserving the existing optional, reflection-only JourneyMap 5.2.x bridge and avoiding any hard dependency on JourneyMap.
- Send a stable, server-authoritative label position and bounded UTF-8 label text to clients so renames and multipart snapshots behave predictably without creating duplicate per-chunk labels.
- Keep rendering safe and non-invasive by culling tiny/outsized labels, preserving OpenGL/font state, and rejecting malformed packet data without crashing the client.

### Description
- Extended the authoritative overlay snapshot generator to compute per-city territory bounds, pick a stable label block position (flag if available, territory center fallback), and attach a UTF-8 bounded label to each claim record using `ClaimOverlayData.snapshot` and a new bounded `Claim` constructor.
- Hardened `ClaimOverlayPacket` wire format to include `labelX/labelZ` and bounded group/label strings with safe UTF-8 decoding and length checks so malformed or oversized multipart packet parts are rejected safely.
- Added a client-side immutable territory-group model during multipart assembly in `ClientClaimOverlayCache` that precomputes one `TerritoryGroup` per unique `groupId` to ensure exactly one label is drawn per territory and to avoid per-frame regrouping.
- Updated the JourneyMap draw bridge (`JourneyMapClaimDrawHandler`) to render polygons first and then optional labels (guarded by `XFConfig.journeyMapShowTerritoryLabels`), converting world label positions to map pixels via the existing reflection helpers, fitting/clipping long names, centering text horizontally, enabling textures for font glyphs, calling `Minecraft.fontRenderer.drawStringWithShadow`, and restoring all GL state in `finally` blocks.
- Added `journeyMapShowTerritoryLabels` to `XFConfig` (default `true`) with category comment, and updated `docs/configuration.md` and `CHANGELOG.md` to document the new capability and limits.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues, which passed.
- Attempted an offline Java build (`gradle clean compileJava`) and a wrapper build (`./gradlew.bat clean compileJava`), both of which were blocked by the development environment (missing root `gradlew.bat` and remote dependency resolution returning HTTP 403 for internal GTNH Gradle artifacts), so a full compile could not be completed here.
- Performed static code and diff review and exercised multipart assembly and packet-decoding logic locally via source edits and inspections; no runtime JourneyMap client/server integration tests or in-game label verification were executed in this environment.
- Note: GitHub PR creation from this environment was attempted but not completed due to missing CLI authentication; the changes and documentation updates are included in the working tree for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7261f8d21083238a0274b7bf07fe6a)