### PR TITLE
Fix flag obstruction and add vertical beacon beams for flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Fix flag obstruction checks and add flag beams
+
+- Fixed flag obstruction placement checks to compare the placed block Y coordinate against nearby flag block Y coordinates instead of using the column surface height, allowing blocks below flags while preserving above-flag obstruction protection.
+- Added client-only translucent beacon beams for loaded city and territory flags using the vanilla beacon beam texture and the owning faction color.
+- Expanded flag tile entity render bounds from world Y 0 through Y 256 so the full beam remains visible after culling and chunk reloads.
+
 # Add JourneyMap city territory labels
 
 - Added JourneyMap city territory labels that render once per city territory on enabled minimap and fullscreen claim overlays, using city names instead of internal faction/group IDs.

--- a/src/main/java/com/hfr/clowder/ClowderEvents.java
+++ b/src/main/java/com/hfr/clowder/ClowderEvents.java
@@ -473,11 +473,13 @@ public void handleChatServer(ServerChatEvent event) {
 				for (int i = x - 2; i <= x + 2; i++) {
 					for (int j = z - 2; j <= z + 2; j++) {
 
-						int topY = player.worldObj.getHeightValue(i, j);
-						int minY = Math.max(0, topY - 12); // don’t go lower than world bottom
+						if(!player.worldObj.blockExists(i, y, j))
+							continue;
 
-						// Check only within 12 blocks below flag surface
-						for (int checkY = topY; checkY >= minY; checkY--) {
+						int minY = Math.max(0, y - 12);
+
+						// Only block placements that are above a nearby flag.
+						for (int checkY = y; checkY >= minY; checkY--) {
 							if (player.worldObj.getBlock(i, checkY, j) == ModBlocks.clowder_flag) {
 								player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Please refrain from obstructing the flag."));
 								return false;

--- a/src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java
+++ b/src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java
@@ -1,0 +1,78 @@
+package com.hfr.render.tileentity;
+
+import org.lwjgl.opengl.GL11;
+
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.ResourceLocation;
+
+final class FlagBeamRenderer {
+
+    static final ResourceLocation BEACON_BEAM = new ResourceLocation("textures/entity/beacon_beam.png");
+    private static final int BEAM_HEIGHT = 256;
+
+    private FlagBeamRenderer() { }
+
+    static void render(TileEntity te, double x, double y, double z, float interp, int color) {
+        int beamColor = color == 0 ? 0xFFFFFF : color;
+        int red = (beamColor >> 16) & 255;
+        int green = (beamColor >> 8) & 255;
+        int blue = beamColor & 255;
+        double localStartY = -te.yCoord;
+
+        GL11.glPushMatrix();
+        GL11.glTranslated(x, y + localStartY, z);
+        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
+        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, 10497.0F);
+        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, 10497.0F);
+        GL11.glDisable(GL11.GL_LIGHTING);
+        GL11.glDisable(GL11.GL_CULL_FACE);
+        GL11.glEnable(GL11.GL_BLEND);
+        OpenGlHelper.glBlendFunc(770, 771, 1, 0);
+        GL11.glDepthMask(false);
+        renderBeamQuads(te, interp, red, green, blue);
+        GL11.glDepthMask(true);
+        GL11.glDisable(GL11.GL_BLEND);
+        GL11.glEnable(GL11.GL_CULL_FACE);
+        GL11.glEnable(GL11.GL_LIGHTING);
+        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        GL11.glPopMatrix();
+    }
+
+    private static void renderBeamQuads(TileEntity te, float interp, int red, int green, int blue) {
+        Tessellator tessellator = Tessellator.instance;
+        float f2 = (float)te.getWorldObj().getTotalWorldTime() + interp;
+        float f3 = -f2 * 0.2F - (float)MathHelper.floor_float(-f2 * 0.1F);
+        double rotation = (double)f2 * 0.025D * -1.5D;
+        double radius = 0.2D;
+        double x1 = 0.5D + Math.cos(rotation + 2.356194490192345D) * radius;
+        double z1 = 0.5D + Math.sin(rotation + 2.356194490192345D) * radius;
+        double x2 = 0.5D + Math.cos(rotation + (Math.PI / 4D)) * radius;
+        double z2 = 0.5D + Math.sin(rotation + (Math.PI / 4D)) * radius;
+        double x3 = 0.5D + Math.cos(rotation + 3.9269908169872414D) * radius;
+        double z3 = 0.5D + Math.sin(rotation + 3.9269908169872414D) * radius;
+        double x4 = 0.5D + Math.cos(rotation + 5.497787143782138D) * radius;
+        double z4 = 0.5D + Math.sin(rotation + 5.497787143782138D) * radius;
+        double minU = 0.0D;
+        double maxU = 1.0D;
+        double minV = -1.0F + f3;
+        double maxV = BEAM_HEIGHT + minV;
+
+        tessellator.startDrawingQuads();
+        tessellator.setColorRGBA(red, green, blue, 96);
+        addFace(tessellator, x1, z1, x2, z2, minU, maxU, minV, maxV);
+        addFace(tessellator, x4, z4, x3, z3, minU, maxU, minV, maxV);
+        addFace(tessellator, x2, z2, x4, z4, minU, maxU, minV, maxV);
+        addFace(tessellator, x3, z3, x1, z1, minU, maxU, minV, maxV);
+        tessellator.draw();
+    }
+
+    private static void addFace(Tessellator tessellator, double x1, double z1, double x2, double z2, double minU, double maxU, double minV, double maxV) {
+        tessellator.addVertexWithUV(x1, BEAM_HEIGHT, z1, maxU, maxV);
+        tessellator.addVertexWithUV(x1, 0.0D, z1, maxU, minV);
+        tessellator.addVertexWithUV(x2, 0.0D, z2, minU, minV);
+        tessellator.addVertexWithUV(x2, BEAM_HEIGHT, z2, minU, maxV);
+    }
+}

--- a/src/main/java/com/hfr/render/tileentity/RenderFlag.java
+++ b/src/main/java/com/hfr/render/tileentity/RenderFlag.java
@@ -34,6 +34,8 @@ public class RenderFlag extends TileEntitySpecialRenderer {
 		}
         
         TileEntityFlag flagpole = (TileEntityFlag)te;
+        bindTexture(FlagBeamRenderer.BEACON_BEAM);
+        FlagBeamRenderer.render(te, x, y, z, p_147500_8_, flagpole.color);
 		
         bindTexture(ResourceManager.flag_tex);
         

--- a/src/main/java/com/hfr/render/tileentity/RenderFlagBig.java
+++ b/src/main/java/com/hfr/render/tileentity/RenderFlagBig.java
@@ -38,6 +38,8 @@ public class RenderFlagBig extends TileEntitySpecialRenderer {
 		}
         
         TileEntityFlagBig flagpole = (TileEntityFlagBig)te;
+        bindTexture(FlagBeamRenderer.BEACON_BEAM);
+        FlagBeamRenderer.render(te, x, y, z, interp, flagpole.color);
 		
         bindTexture(ResourceManager.flag_tex);
         

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -64,6 +64,12 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
+	public AxisAlignedBB getRenderBoundingBox() {
+		return AxisAlignedBB.getBoundingBox(xCoord, 0, zCoord, xCoord + 1, 256, zCoord + 1);
+	}
+
+	@Override
 	public void updateEntity() {
 
 

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
@@ -61,6 +61,12 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
+	public AxisAlignedBB getRenderBoundingBox() {
+		return AxisAlignedBB.getBoundingBox(xCoord, 0, zCoord, xCoord + 1, 256, zCoord + 1);
+	}
+
+	@Override
 	public void updateEntity() {
 
 


### PR DESCRIPTION
### Motivation
- Fix an incorrect flag obstruction check that blocked placements below flags by using column surface height instead of the placed-block Y, and add a visible, non-gameplay beacon beam per loaded flag to aid players and admins.\
- Keep all behavior server-authoritative for obstruction messages and keep all rendering client-only, preserving existing flag models, textures, ownership, and claim behavior.\
- Preserve Minecraft Forge 1.7.10 and Java 8 compatibility and avoid adding libraries or changing saved data formats.\

### Description
- Corrected the obstruction check in `ClowderEvents.canPlace` so the server-side scan starts from the placement target Y (`y`) and searches downward up to 12 blocks; the code now skips columns whose chunk is not loaded (`blockExists`) and sends the exact message `Please refrain from obstructing the flag.` only when placement is actually blocked. Changed file: `src/main/java/com/hfr/clowder/ClowderEvents.java`.\
- Added a small, client-only `FlagBeamRenderer` that reuses the vanilla beacon beam texture and renders one translucent vertical beam per loaded flag centered on the flag block X/Z; the beam spans world Y `0` through `256` and uses the owning clowder/faction color with white fallback. New file: `src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java`.\
- Integrated beam rendering into the existing flag renderers so the existing flag model, image, and animation are preserved: `RenderFlag` and `RenderFlagBig` now bind the beacon texture and call the beam renderer before drawing the flag model. Modified files: `src/main/java/com/hfr/render/tileentity/RenderFlag.java` and `src/main/java/com/hfr/render/tileentity/RenderFlagBig.java`.\
- Expanded the flag tile entity client render bounding boxes to cover world Y `0` through `256` so Minecraft won't cull the beam to the block bounds; modified files: `src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java` and `src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java`.\
- Recorded the change in the top of the `CHANGELOG.md` per repository documentation policy. Modified file: `CHANGELOG.md`.\

### Testing
- Ran `git diff --check` to ensure no whitespace/errors in diffs; this succeeded.\
- Attempted `gradle compileJava` but the build configuration failed during dependency resolution due to external GTNH Gradle metadata returning HTTP 403, so full compilation could not be completed in this environment.\
- Could not run the Forge 1.7.10 development client or a dedicated server here because Gradle configuration failed and `./gradlew` is not available in the repo root in this environment, so in-game placement and render verification were not executed.\

Changed files
- CHANGELOG.md\
- src/main/java/com/hfr/clowder/ClowderEvents.java\
- src/main/java/com/hfr/render/tileentity/RenderFlag.java\
- src/main/java/com/hfr/render/tileentity/RenderFlagBig.java\
- src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java (new)\
- src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java\
- src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java\

Explanation of the incorrect obstruction check
- The original check used `world.getHeightValue(i, j)` (the column surface), and scanned downward from that surface to find flags; when placing a block below an exposed flag the surface value could still be at-or-above the flag, causing the higher flag to be detected and incorrectly block the lower placement.\

How the Y comparison was corrected
- The new logic uses the actual target placement Y (`y` passed to the event handler) and searches downward from `y` to `max(0, y - 12)`, so placements with `targetY < flagY` do not find flags that are higher in the same X/Z column; placements above flags continue to find and block when appropriate. The check still preserves the existing horizontal range and exact-column semantics and preserves the exact message `Please refrain from obstructing the flag.` and the authoritative server-only behavior.\

How the beam converts world Y 0..256 into renderer-local coordinates
- The beam renderer is invoked from the tile entity special renderer which receives local renderer coordinates; the renderer computes a local translation of `localStartY = -te.yCoord` and translates to `y + localStartY` before drawing, so drawing from local Y `0`..`256` produces a world-space beam from world Y `0` through `256` regardless of `te.yCoord` (flagY). This preserves a fixed world vertical extent for every flag while keeping per-tile renderer math minimal and allocation-free during rendering.\

Build and test results
- `git diff --check`: succeeded.\
- `gradle compileJava`: blocked during dependency resolution (GTNH Gradle metadata requests returned HTTP 403), so compilation/test-run did not complete.\
- `gh pr create`: not executed due to missing GitHub authentication in this environment.\

Tests not completed in this environment (manual/in-game verification required)
- Starting a Forge 1.7.10 development client and confirming the in-game placement behavior (below-flag allowed, above-flag blocked once).\
- Starting/validating a dedicated server to ensure no server-side classpath leakage of client-only rendering classes.\
- Rendering checks for two loaded flags with different faction colors, chunk unload/reload duplication checks, and OpenGL error/leak checks (these require running the client).\

If you want, I can provide a short test plan with exact reproduction steps and expected outcomes for local verification in a Forge dev environment, or revert the change if CI/compile shows issues after your build system runs the full project.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72663753408323afbac98f563b8dc9)