### PR TITLE
Fix duplicate getRenderBoundingBox in TileEntityFlag and TileEntityFlagBig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Fix duplicate flag render bounding boxes
+
+- Removed duplicate flag tile entity render bounding box overrides that returned an infinite extent.
+- Kept the beacon-sized render bounding boxes from world Y 0 through Y 256 for both city and territory flags.
+
 # Fix flag obstruction checks and add flag beams
 
 - Fixed flag obstruction placement checks to compare the placed block Y coordinate against nearby flag block Y coordinates instead of using the column surface height, allowing blocks below flags while preserving above-flag obstruction protection.

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -26,7 +26,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 
 public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryProvider {
@@ -558,11 +557,6 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 			}
 		}
 		nbt.setTag("items", list);
-	}
-
-	@Override
-	public AxisAlignedBB getRenderBoundingBox() {
-		return TileEntity.INFINITE_EXTENT_AABB;
 	}
 
 	@Override

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java
@@ -26,7 +26,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.MinecraftForge;
 
@@ -305,11 +304,6 @@ public class TileEntityFlagBig extends TileEntityMachineBase implements ITerrito
 		//nbt.setByteArray("tiers", tiers);
 		//nbt.setBoolean("O",oilProvince);
 		nbt.setString("P", provinceName);
-	}
-
-	@Override
-	public AxisAlignedBB getRenderBoundingBox() {
-		return TileEntity.INFINITE_EXTENT_AABB;
 	}
 
 	@Override


### PR DESCRIPTION
### Motivation

- Remove duplicate `getRenderBoundingBox()` overrides that caused Java duplicate-method compilation errors while preserving the beacon-shaped render bounds used by the client beacon renderer.

### Description

- Removed the duplicate `getRenderBoundingBox()` that returned `TileEntity.INFINITE_EXTENT_AABB` from `TileEntityFlag` and `TileEntityFlagBig`. 
- Removed the now-unused `import net.minecraft.tileentity.TileEntity;` from both files while keeping the `AxisAlignedBB` import and leaving `@Override` and `@SideOnly(Side.CLIENT)` on the retained methods. 
- Kept the beacon-sized bounding box implementation that returns `AxisAlignedBB.getBoundingBox(xCoord, 0, zCoord, xCoord + 1, 256, zCoord + 1)` in both classes and left `getMaxRenderDistanceSquared()` unchanged. 
- Added a changelog entry documenting the fix. 
- Files changed: `src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java`, `src/main/java/com/hfr/tileentity/clowder/TileEntityFlagBig.java`, and `CHANGELOG.md`.

### Testing

- Confirmed with code search that each class now has exactly one `getRenderBoundingBox()` returning the bounding box spanning world Y `0` through `256` (search passed). 
- Ran `git diff --check` and repository whitespace checks which passed. 
- Verified `java -version` for the environment (OpenJDK present). 
- Attempted project build with Gradle but `gradle build` and `gradle compileJava` failed during dependency resolution due to an external repository returning HTTP 403, so the full project compilation could not be completed in this environment. 
- Confirmed the duplicate-method compile error would be eliminated by the change, and the flag beam renderer was inspected to verify the retained bounding box supports the beam height of 256.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72683b6e94832392085e878ff0e393)