### PR TITLE
Fix flag beacon coordinate space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Fix flag beacon coordinate space
+
+- Moved normal and large flag beacon rendering before the flag model translation and metadata rotation so tile entity render coordinates are applied exactly once.
+- Removed the duplicate large-flag `renderFlare` beacon implementation in favor of the shared full-height `FlagBeamRenderer`.
+- Preserved the shared beam world Y 0 through Y 256 span and restored OpenGL render state after beam rendering.
+
 # Fix duplicate flag render bounding boxes
 
 - Removed duplicate flag tile entity render bounding box overrides that returned an infinite extent.

--- a/src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java
+++ b/src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java
@@ -1,5 +1,8 @@
 package com.hfr.render.tileentity;
 
+import java.nio.FloatBuffer;
+
+import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -22,6 +25,15 @@ final class FlagBeamRenderer {
         int blue = beamColor & 255;
         double localStartY = -te.yCoord;
 
+        boolean lightingEnabled = GL11.glIsEnabled(GL11.GL_LIGHTING);
+        boolean cullEnabled = GL11.glIsEnabled(GL11.GL_CULL_FACE);
+        boolean blendEnabled = GL11.glIsEnabled(GL11.GL_BLEND);
+        boolean depthMask = GL11.glGetBoolean(GL11.GL_DEPTH_WRITEMASK);
+        int alphaFunc = GL11.glGetInteger(GL11.GL_ALPHA_TEST_FUNC);
+        float alphaRef = GL11.glGetFloat(GL11.GL_ALPHA_TEST_REF);
+        FloatBuffer color = BufferUtils.createFloatBuffer(4);
+        GL11.glGetFloat(GL11.GL_CURRENT_COLOR, color);
+
         GL11.glPushMatrix();
         GL11.glTranslated(x, y + localStartY, z);
         GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
@@ -33,12 +45,21 @@ final class FlagBeamRenderer {
         OpenGlHelper.glBlendFunc(770, 771, 1, 0);
         GL11.glDepthMask(false);
         renderBeamQuads(te, interp, red, green, blue);
-        GL11.glDepthMask(true);
-        GL11.glDisable(GL11.GL_BLEND);
-        GL11.glEnable(GL11.GL_CULL_FACE);
-        GL11.glEnable(GL11.GL_LIGHTING);
-        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+        GL11.glDepthMask(depthMask);
+        setEnabled(GL11.GL_BLEND, blendEnabled);
+        setEnabled(GL11.GL_CULL_FACE, cullEnabled);
+        setEnabled(GL11.GL_LIGHTING, lightingEnabled);
+        GL11.glAlphaFunc(alphaFunc, alphaRef);
+        GL11.glColor4f(color.get(0), color.get(1), color.get(2), color.get(3));
         GL11.glPopMatrix();
+    }
+
+    private static void setEnabled(int capability, boolean enabled) {
+        if(enabled) {
+            GL11.glEnable(capability);
+        } else {
+            GL11.glDisable(capability);
+        }
     }
 
     private static void renderBeamQuads(TileEntity te, float interp, int red, int green, int blue) {

--- a/src/main/java/com/hfr/render/tileentity/RenderFlag.java
+++ b/src/main/java/com/hfr/render/tileentity/RenderFlag.java
@@ -16,6 +16,10 @@ public class RenderFlag extends TileEntitySpecialRenderer {
 	@Override
 	public void renderTileEntityAt(TileEntity te, double x, double y, double z, float p_147500_8_) {
 		
+        TileEntityFlag flagpole = (TileEntityFlag)te;
+        bindTexture(FlagBeamRenderer.BEACON_BEAM);
+        FlagBeamRenderer.render(te, x, y, z, p_147500_8_, flagpole.color);
+
         GL11.glPushMatrix();
         GL11.glTranslated(x + 0.5D, y, z + 0.5D);
         GL11.glEnable(GL11.GL_LIGHTING);
@@ -33,10 +37,6 @@ public class RenderFlag extends TileEntitySpecialRenderer {
 			GL11.glRotatef(0, 0F, 1F, 0F); break;
 		}
         
-        TileEntityFlag flagpole = (TileEntityFlag)te;
-        bindTexture(FlagBeamRenderer.BEACON_BEAM);
-        FlagBeamRenderer.render(te, x, y, z, p_147500_8_, flagpole.color);
-		
         bindTexture(ResourceManager.flag_tex);
         
         GL11.glShadeModel(GL11.GL_SMOOTH);

--- a/src/main/java/com/hfr/render/tileentity/RenderFlagBig.java
+++ b/src/main/java/com/hfr/render/tileentity/RenderFlagBig.java
@@ -8,18 +8,18 @@ import com.hfr.main.ResourceManager;
 import com.hfr.tileentity.clowder.TileEntityFlagBig;
 
 import net.minecraft.client.renderer.OpenGlHelper;
-import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
-import net.minecraft.util.ResourceLocation;
-import net.minecraft.world.World;
 
 public class RenderFlagBig extends TileEntitySpecialRenderer {
 
 	@Override
 	public void renderTileEntityAt(TileEntity te, double x, double y, double z, float interp) {
 		
+        TileEntityFlagBig flagpole = (TileEntityFlagBig)te;
+        bindTexture(FlagBeamRenderer.BEACON_BEAM);
+        FlagBeamRenderer.render(te, x, y, z, interp, flagpole.color);
+
         GL11.glPushMatrix();
         GL11.glTranslated(x + 0.5D, y, z + 0.5D);
         GL11.glEnable(GL11.GL_LIGHTING);
@@ -37,10 +37,6 @@ public class RenderFlagBig extends TileEntitySpecialRenderer {
 			GL11.glRotatef(0, 0F, 1F, 0F); break;
 		}
         
-        TileEntityFlagBig flagpole = (TileEntityFlagBig)te;
-        bindTexture(FlagBeamRenderer.BEACON_BEAM);
-        FlagBeamRenderer.render(te, x, y, z, interp, flagpole.color);
-		
         bindTexture(ResourceManager.flag_tex);
         
         GL11.glShadeModel(GL11.GL_SMOOTH);
@@ -88,121 +84,5 @@ public class RenderFlagBig extends TileEntitySpecialRenderer {
 
         GL11.glEnable(GL11.GL_CULL_FACE);
         GL11.glPopMatrix();
-        
-        GL11.glDisable(GL11.GL_FOG);
-        renderFlare(te.getWorldObj(), x, y + 10.25, z, interp);
-        GL11.glEnable(GL11.GL_FOG);
-	}
-	
-    private static final ResourceLocation field_147523_b = new ResourceLocation("textures/entity/beacon_beam.png");
-	
-	private void renderFlare(World world, double x, double y, double z, float interp) {
-		
-        float f1 = 1F;
-        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
-
-        if (f1 > 0.0F)
-        {
-            Tessellator tessellator = Tessellator.instance;
-            this.bindTexture(field_147523_b);
-            GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, 10497.0F);
-            GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, 10497.0F);
-            GL11.glDisable(GL11.GL_LIGHTING);
-            GL11.glDisable(GL11.GL_CULL_FACE);
-            GL11.glDisable(GL11.GL_BLEND);
-            GL11.glDepthMask(true);
-            OpenGlHelper.glBlendFunc(770, 1, 1, 0);
-            
-            float f2 = (float)world.getTotalWorldTime() + interp;
-            float f3 = -f2 * 0.2F - (float)MathHelper.floor_float(-f2 * 0.1F);
-            byte b0 = 1;
-            double d3 = (double)f2 * 0.025D * (1.0D - (double)(b0 & 1) * 2.5D);
-            
-            tessellator.startDrawingQuads();
-            tessellator.setColorRGBA(127, 255, 255, 32);
-            
-            double d5 = (double)b0 * 0.1D;
-            double d7 = 0.5D + Math.cos(d3 + 2.356194490192345D) * d5;
-            double d9 = 0.5D + Math.sin(d3 + 2.356194490192345D) * d5;
-            double d11 = 0.5D + Math.cos(d3 + (Math.PI / 4D)) * d5;
-            double d13 = 0.5D + Math.sin(d3 + (Math.PI / 4D)) * d5;
-            double d15 = 0.5D + Math.cos(d3 + 3.9269908169872414D) * d5;
-            double d17 = 0.5D + Math.sin(d3 + 3.9269908169872414D) * d5;
-            double d19 = 0.5D + Math.cos(d3 + 5.497787143782138D) * d5;
-            double d21 = 0.5D + Math.sin(d3 + 5.497787143782138D) * d5;
-            double d23 = (double)(256.0F * f1);
-            double d25 = 0.0D;
-            double d27 = 1.0D;
-            double d28 = (double)(-1.0F + f3);
-            double d29 = (double)(256.0F * f1) * (0.5D / d5) + d28;
-            
-            tessellator.addVertexWithUV(x + d7, y + d23, z + d9, d27, d29);
-            tessellator.addVertexWithUV(x + d7, y, z + d9, d27, d28);
-            tessellator.addVertexWithUV(x + d11, y, z + d13, d25, d28);
-            tessellator.addVertexWithUV(x + d11, y + d23, z + d13, d25, d29);
-            tessellator.addVertexWithUV(x + d19, y + d23, z + d21, d27, d29);
-            tessellator.addVertexWithUV(x + d19, y, z + d21, d27, d28);
-            tessellator.addVertexWithUV(x + d15, y, z + d17, d25, d28);
-            tessellator.addVertexWithUV(x + d15, y + d23, z + d17, d25, d29);
-            tessellator.addVertexWithUV(x + d11, y + d23, z + d13, d27, d29);
-            tessellator.addVertexWithUV(x + d11, y, z + d13, d27, d28);
-            tessellator.addVertexWithUV(x + d19, y, z + d21, d25, d28);
-            tessellator.addVertexWithUV(x + d19, y + d23, z + d21, d25, d29);
-            tessellator.addVertexWithUV(x + d15, y + d23, z + d17, d27, d29);
-            tessellator.addVertexWithUV(x + d15, y, z + d17, d27, d28);
-            tessellator.addVertexWithUV(x + d7, y, z + d9, d25, d28);
-            tessellator.addVertexWithUV(x + d7, y + d23, z + d9, d25, d29);
-            
-            tessellator.draw();
-            
-            GL11.glEnable(GL11.GL_BLEND);
-            OpenGlHelper.glBlendFunc(770, 771, 1, 0);
-            GL11.glDepthMask(false);
-            
-            tessellator.startDrawingQuads();
-            tessellator.setColorRGBA(127, 255, 255, 64);
-            
-            double pixel = 0.0625D;
-            
-            int inner = 6;
-            int outer = 16 - inner;
-            
-            double d30 = pixel * inner;
-            double d4 = pixel * inner;
-            double d6 = pixel * outer;
-            double d8 = pixel * inner;
-            double d10 = pixel * inner;
-            double d12 = pixel * outer;
-            double d14 = pixel * outer;
-            double d16 = pixel * outer;
-            double d18 = (double)(256.0F * f1);
-            double d20 = 0.0D;
-            double d22 = 1.0D;
-            double d24 = (double)(-1.0F + f3);
-            double d26 = (double)(256.0F * f1) + d24;
-            
-            tessellator.addVertexWithUV(x + d30, y + d18, z + d4, d22, d26);
-            tessellator.addVertexWithUV(x + d30, y, z + d4, d22, d24);
-            tessellator.addVertexWithUV(x + d6, y, z + d8, d20, d24);
-            tessellator.addVertexWithUV(x + d6, y + d18, z + d8, d20, d26);
-            tessellator.addVertexWithUV(x + d14, y + d18, z + d16, d22, d26);
-            tessellator.addVertexWithUV(x + d14, y, z + d16, d22, d24);
-            tessellator.addVertexWithUV(x + d10, y, z + d12, d20, d24);
-            tessellator.addVertexWithUV(x + d10, y + d18, z + d12, d20, d26);
-            tessellator.addVertexWithUV(x + d6, y + d18, z + d8, d22, d26);
-            tessellator.addVertexWithUV(x + d6, y, z + d8, d22, d24);
-            tessellator.addVertexWithUV(x + d14, y, z + d16, d20, d24);
-            tessellator.addVertexWithUV(x + d14, y + d18, z + d16, d20, d26);
-            tessellator.addVertexWithUV(x + d10, y + d18, z + d12, d22, d26);
-            tessellator.addVertexWithUV(x + d10, y, z + d12, d22, d24);
-            tessellator.addVertexWithUV(x + d30, y, z + d4, d20, d24);
-            tessellator.addVertexWithUV(x + d30, y + d18, z + d4, d20, d26);
-            
-            tessellator.draw();
-            
-            GL11.glEnable(GL11.GL_LIGHTING);
-            GL11.glEnable(GL11.GL_TEXTURE_2D);
-            GL11.glDepthMask(true);
-        }
 	}
 }


### PR DESCRIPTION
### Motivation

- The beam was rendered relative to the player because the tile-entity camera-relative coordinates were applied twice (once by the flag model transform and again inside the beam renderer), causing the beacon to follow the player instead of staying centered on the flag. 

### Description

- Moved the shared beacon call so `FlagBeamRenderer.render(...)` is invoked before the flag model `GL11.glPushMatrix()` / `glTranslated(x + 0.5D, y, z + 0.5D)` block in both `RenderFlag` and `RenderFlagBig` so tile-entity coordinates are applied exactly once. 
- Consolidated the large-flag beam by removing the duplicate `renderFlare(...)` implementation and its unused constants/imports from `RenderFlagBig`, using the shared `FlagBeamRenderer` instead. 
- Restored and preserved correct beam behavior in `FlagBeamRenderer` by keeping `localStartY = -te.yCoord` and `GL11.glTranslated(x, y + localStartY, z)` while adding OpenGL state backup/restore for lighting, culling, blending, depth mask, alpha function, and current color. 
- Changed files: `src/main/java/com/hfr/render/tileentity/RenderFlag.java`, `src/main/java/com/hfr/render/tileentity/RenderFlagBig.java`, `src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java`, and `CHANGELOG.md` (updated per project policy). 

### Testing

- Ran `git diff --check` which produced no whitespace or diff-check errors. 
- Attempted `gradle compileJava` and `gradle build` but both failed during Gradle configuration because remote Maven metadata requests for `com.gtnewhorizons:gtnhgradle:1.+` returned HTTP 403, preventing compilation. 
- In-game/manual verification was not performed because a Forge 1.7.10 client/world was not available in this environment; expected manual checks are described in the project verification steps and should confirm the beam remains centered and that large flags render a single beam.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a726cda356c8323a41ab7f18946c720)