### PR TITLE
Fix variable name collision in FlagBeamRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Fix flag beam color buffer collision
+
+- Renamed the saved OpenGL color buffer in `FlagBeamRenderer` to avoid colliding with the existing render color parameter while preserving beam rendering and color restoration.
+
 # Fix flag beacon coordinate space
 
 - Moved normal and large flag beacon rendering before the flag model translation and metadata rotation so tile entity render coordinates are applied exactly once.

--- a/src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java
+++ b/src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java
@@ -31,8 +31,8 @@ final class FlagBeamRenderer {
         boolean depthMask = GL11.glGetBoolean(GL11.GL_DEPTH_WRITEMASK);
         int alphaFunc = GL11.glGetInteger(GL11.GL_ALPHA_TEST_FUNC);
         float alphaRef = GL11.glGetFloat(GL11.GL_ALPHA_TEST_REF);
-        FloatBuffer color = BufferUtils.createFloatBuffer(4);
-        GL11.glGetFloat(GL11.GL_CURRENT_COLOR, color);
+        FloatBuffer previousColor = BufferUtils.createFloatBuffer(4);
+        GL11.glGetFloat(GL11.GL_CURRENT_COLOR, previousColor);
 
         GL11.glPushMatrix();
         GL11.glTranslated(x, y + localStartY, z);
@@ -50,7 +50,12 @@ final class FlagBeamRenderer {
         setEnabled(GL11.GL_CULL_FACE, cullEnabled);
         setEnabled(GL11.GL_LIGHTING, lightingEnabled);
         GL11.glAlphaFunc(alphaFunc, alphaRef);
-        GL11.glColor4f(color.get(0), color.get(1), color.get(2), color.get(3));
+        GL11.glColor4f(
+                previousColor.get(0),
+                previousColor.get(1),
+                previousColor.get(2),
+                previousColor.get(3)
+        );
         GL11.glPopMatrix();
     }
 


### PR DESCRIPTION
### Motivation
- Fix a Java compile error caused by a local `FloatBuffer` variable named `color` colliding with the method parameter `int color` in `FlagBeamRenderer.render(...)`.

### Description
- Renamed the saved OpenGL `FloatBuffer` from `color` to `previousColor` and updated `GL11.glGetFloat` and the later `GL11.glColor4f` restoration to reference `previousColor`.
- Kept the `int color` method parameter and `beamColor` computation unchanged and preserved beam position, height, texture, color, and renderer call order.
- Updated `CHANGELOG.md` with a short entry describing the fix.
- Changed files: `src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java`, `CHANGELOG.md`.

### Testing
- Verified via source inspection that there are no `FloatBuffer color` declarations in `render(...)` and that only the `int color` parameter uses the name `color`, while `previousColor` is used for the saved OpenGL color.
- Ran `gradle build`, which failed during configuration due to external repository resolution for `com.gtnewhorizons:gtnhgradle` returning HTTP 403 and therefore did not reach `compileJava`, indicating the failure is environmental and unrelated to this local change.
- Ran `git diff --check` and static checks which reported no whitespace errors.
- Confirmed `compileJava` was not executed because the Gradle configuration error prevented full build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a726e3becfc8323be5ef6384c49f2e8)