### PR TITLE
Fix flag beacon renderer state handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Fix flag beacon renderer state restoration
+
+- Reworked `FlagBeamRenderer` to use OpenGL attribute stacks instead of querying individual render states, removing the `GL_CURRENT_COLOR`/`FloatBuffer` path that could crash LWJGL 2.
+- Kept the full-height flag beacon centered on the flag block with tile-entity-relative translation and local beam vertices around X/Z `0.5`.
+
 # Fix flag beam color buffer collision
 
 - Renamed the saved OpenGL color buffer in `FlagBeamRenderer` to avoid colliding with the existing render color parameter while preserving beam rendering and color restoration.

--- a/src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java
+++ b/src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java
@@ -1,8 +1,5 @@
 package com.hfr.render.tileentity;
 
-import java.nio.FloatBuffer;
-
-import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -23,47 +20,44 @@ final class FlagBeamRenderer {
         int red = (beamColor >> 16) & 255;
         int green = (beamColor >> 8) & 255;
         int blue = beamColor & 255;
-        double localStartY = -te.yCoord;
 
-        boolean lightingEnabled = GL11.glIsEnabled(GL11.GL_LIGHTING);
-        boolean cullEnabled = GL11.glIsEnabled(GL11.GL_CULL_FACE);
-        boolean blendEnabled = GL11.glIsEnabled(GL11.GL_BLEND);
-        boolean depthMask = GL11.glGetBoolean(GL11.GL_DEPTH_WRITEMASK);
-        int alphaFunc = GL11.glGetInteger(GL11.GL_ALPHA_TEST_FUNC);
-        float alphaRef = GL11.glGetFloat(GL11.GL_ALPHA_TEST_REF);
-        FloatBuffer previousColor = BufferUtils.createFloatBuffer(4);
-        GL11.glGetFloat(GL11.GL_CURRENT_COLOR, previousColor);
+        double beamRenderY = y - te.yCoord;
 
+        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
         GL11.glPushMatrix();
-        GL11.glTranslated(x, y + localStartY, z);
-        GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
-        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, 10497.0F);
-        GL11.glTexParameterf(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, 10497.0F);
-        GL11.glDisable(GL11.GL_LIGHTING);
-        GL11.glDisable(GL11.GL_CULL_FACE);
-        GL11.glEnable(GL11.GL_BLEND);
-        OpenGlHelper.glBlendFunc(770, 771, 1, 0);
-        GL11.glDepthMask(false);
-        renderBeamQuads(te, interp, red, green, blue);
-        GL11.glDepthMask(depthMask);
-        setEnabled(GL11.GL_BLEND, blendEnabled);
-        setEnabled(GL11.GL_CULL_FACE, cullEnabled);
-        setEnabled(GL11.GL_LIGHTING, lightingEnabled);
-        GL11.glAlphaFunc(alphaFunc, alphaRef);
-        GL11.glColor4f(
-                previousColor.get(0),
-                previousColor.get(1),
-                previousColor.get(2),
-                previousColor.get(3)
-        );
-        GL11.glPopMatrix();
-    }
 
-    private static void setEnabled(int capability, boolean enabled) {
-        if(enabled) {
-            GL11.glEnable(capability);
-        } else {
-            GL11.glDisable(capability);
+        try {
+            GL11.glTranslated(x, beamRenderY, z);
+
+            GL11.glEnable(GL11.GL_TEXTURE_2D);
+            GL11.glEnable(GL11.GL_DEPTH_TEST);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glDisable(GL11.GL_LIGHTING);
+            GL11.glDisable(GL11.GL_CULL_FACE);
+
+            GL11.glAlphaFunc(GL11.GL_GREATER, 0.1F);
+            GL11.glDepthMask(false);
+
+            OpenGlHelper.glBlendFunc(770, 771, 1, 0);
+
+            GL11.glTexParameterf(
+                    GL11.GL_TEXTURE_2D,
+                    GL11.GL_TEXTURE_WRAP_S,
+                    GL11.GL_REPEAT
+            );
+
+            GL11.glTexParameterf(
+                    GL11.GL_TEXTURE_2D,
+                    GL11.GL_TEXTURE_WRAP_T,
+                    GL11.GL_REPEAT
+            );
+
+            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+
+            renderBeamQuads(te, interp, red, green, blue);
+        } finally {
+            GL11.glPopMatrix();
+            GL11.glPopAttrib();
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent LWJGL2 crash caused by querying `GL_CURRENT_COLOR` into a 4-float buffer by removing manual OpenGL state queries and using attribute stacks so the beacon can render at the flag without crashing.
- Keep the beacon visually identical: single full-height beam centered on the flag block and preserve the original beam geometry and bounding box behavior.

### Description
- Changed `src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java` to remove all manual OpenGL state queries and restores and instead use `GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS)` and a `try/finally` with `glPushMatrix`/`glPopMatrix`/`glPopAttrib` to restore GL state; the method now performs a single translation `GL11.glTranslated(x, y - te.yCoord, z)` and sets the required GL state (texture, depth test, blend, lighting, cull, alpha func, depth mask) before drawing the beam quads.
- Removed the `FloatBuffer`/`BufferUtils` imports, all calls to `GL11.glIsEnabled`, `GL11.glGetBoolean`, `GL11.glGetInteger`, and `GL11.glGetFloat`, and deleted the `setEnabled(...)` helper; beam geometry (`renderBeamQuads`) was preserved and continues to use local X/Z values around `0.5D` and Y from `0` to `BEAM_HEIGHT`.
- Kept `RenderFlag` and `RenderFlagBig` call order unchanged so the beacon is rendered before the flag model matrix begins and each large flag renders exactly one shared beacon; updated `CHANGELOG.md` with a short note describing the fix.

### Testing
- Changed files: `src/main/java/com/hfr/render/tileentity/FlagBeamRenderer.java`, `CHANGELOG.md`.
- Confirmed that all `glGetFloat` and `FloatBuffer` state-query code was removed from `FlagBeamRenderer.java` by searching the source and inspecting the file.
- `gradle compileJava` (online) failed during project configuration due to external resolver errors (HTTP 403 from `nexus.gtnewhorizons.com`) so a full online compile could not complete in this environment.
- `gradle --offline compileJava` reached the `:compileJava` task but the full project compilation failed due to missing optional HBM classes (e.g., `com.hbm.extprop.HbmLivingProps`), which are unrelated to the `FlagBeamRenderer` change; the modified renderer file itself contains no remaining references to `FloatBuffer` or `glGetFloat`.
- `gradle runClient` (and offline variants) did not launch the client in this environment due to configuration/dependency resolution issues, so in-game verification could not be executed here (see above errors for details).

Notes on beacon centering: the renderer now calls `GL11.glTranslated(x, y - te.yCoord, z)` once using the camera-relative tile-entity coordinates passed in by the tile-entity renderer, and the beam quads keep their local X/Z coordinates centered on `0.5D`, which produces a world-space beam centered at `x + 0.5D` and `z + 0.5D` as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a726fbbb328832382f0c83c9a729e1b)