### PR TITLE
Add read-only `/stonedrops` command for all players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Add public stone drops list command
+
+- Added `/stonedrops [page]` as a read-only player-accessible command for viewing configured custom stone drops without changing the administrator `/stonedrop` command.
+- Documented chance percentages, raw chance values, item registry metadata, stack amounts, and Y ranges in the paginated stone-drop output.
+
 # Fix automatic HBM stone-drop integration
 
 - Fixed the real automatic HBM stone-drop failure: Xenofactions now resolves HBM's documented `modid:item metadata minimumAmount maximumAmount` specifications through the Forge 1.7.10 item/block registries after HBM post-initialization instead of relying on fragile direct item lookups.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Most player-facing faction commands are under `/clowder` or `/c`:
 /c declarewar <faction>
 ```
 
-Administrative faction commands are under `/xclowder` or `/xc` and require permission level 3 by default. Other command families include `/cc`, `/xflags`, `/xmap`, `/stonedrop`, `/xmarket`, `/xshop`, `/xmute`, `/xignore`, `/invsee`, and optional `/tdm`.
+Administrative faction commands are under `/xclowder` or `/xc` and require permission level 3 by default. All players can inspect configured custom stone drops with `/stonedrops [page]`; `/stonedrop` remains the administrator command for adding, listing, and removing custom stone drops. Other command families include `/cc`, `/xflags`, `/xmap`, `/stonedrops`, `/stonedrop`, `/xmarket`, `/xshop`, `/xmute`, `/xignore`, `/invsee`, and optional `/tdm`.
 
 See [`docs/commands.md`](docs/commands.md) for command syntax verified from source.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -150,9 +150,10 @@ Usage: `/cc <message>`; permission level: 0.
 | `/xflags` | Player | Open/list faction flag functionality. |
 | `/xmulti` | Player | Utility command registered for all players. |
 | `/xdebug <param>` | Player | Debug command registered for all players; server policy should control use. |
-| `/stonedrop <rarity> [minY] [maxY]` | Admin/moderator default | Add held item/block as a custom stone drop. |
-| `/stonedrop list` | Admin/moderator default | List configured custom stone drops. |
-| `/stonedrop remove <index>` | Admin/moderator default | Remove a custom stone drop. |
+| `/stonedrops [page]` | Player | Read-only list of custom stone drops, including chance, raw chance, item registry name, metadata, stack amount, and Y range. All players and the server console can use this command. |
+| `/stonedrop <rarity> [minY] [maxY]` | Admin/moderator default | Administrator command to add held item/block as a custom stone drop. |
+| `/stonedrop list` | Admin/moderator default | Administrator command to list configured custom stone drops. |
+| `/stonedrop remove <index>` | Admin/moderator default | Administrator command to remove a custom stone drop. |
 | `/xshop add <shop>` | Level 3 | Add a shop offer using hotbar slots: slot 1 sold item, next three slots currency. |
 | `/xshop delete <shop/index>` | Level 3 | Delete a shop offer. |
 | `/xmarket setstock ...` | Level 3 | Admin stock market control. |

--- a/src/main/java/com/hfr/command/CommandStoneDrops.java
+++ b/src/main/java/com/hfr/command/CommandStoneDrops.java
@@ -1,0 +1,155 @@
+package com.hfr.command;
+
+import com.hfr.main.MainRegistry;
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+public class CommandStoneDrops extends CommandBase {
+
+    private static final int ENTRIES_PER_PAGE = 8;
+    private static final String ERROR = EnumChatFormatting.RED.toString();
+    private static final String TITLE = EnumChatFormatting.GOLD.toString();
+    private static final String INFO = EnumChatFormatting.GREEN.toString();
+    private static final String HELP = EnumChatFormatting.DARK_GREEN.toString();
+    private static final String COMMAND = EnumChatFormatting.RED.toString();
+    private static final DecimalFormat PERCENT_FORMAT = new DecimalFormat("0.######", DecimalFormatSymbols.getInstance(Locale.US));
+
+    @Override
+    public String getCommandName() {
+        return "stonedrops";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/stonedrops [page]";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+
+    @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        return true;
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if (args.length > 1) {
+            sendUsage(sender);
+            return;
+        }
+
+        int requestedPage = 1;
+        if (args.length == 1) {
+            if (!args[0].matches("[1-9][0-9]*")) {
+                sendInvalidPage(sender);
+                return;
+            }
+            try {
+                requestedPage = Integer.parseInt(args[0]);
+            } catch (NumberFormatException e) {
+                sendInvalidPage(sender);
+                return;
+            }
+        }
+
+        int validEntryCount = getValidEntryCount();
+        if (validEntryCount <= 0) {
+            sender.addChatMessage(new ChatComponentText(INFO + "No custom stone drops are configured."));
+            return;
+        }
+
+        int totalPages = (validEntryCount + ENTRIES_PER_PAGE - 1) / ENTRIES_PER_PAGE;
+        int page = Math.min(requestedPage, totalPages);
+        int start = (page - 1) * ENTRIES_PER_PAGE;
+        int end = Math.min(start + ENTRIES_PER_PAGE, validEntryCount);
+
+        sender.addChatMessage(new ChatComponentText(TITLE + "Custom Stone Drops - Page " + page + "/" + totalPages));
+        for (int i = start; i < end; i++) {
+            ItemStack stack = MainRegistry.customDrops.get(i);
+            Double chance = MainRegistry.customDropChances.get(i);
+            Integer minY = MainRegistry.customDropMinYs.get(i);
+            Integer maxY = MainRegistry.customDropMaxYs.get(i);
+
+            sender.addChatMessage(new ChatComponentText(HELP + "#" + (i + 1) + " " + INFO + getDisplayName(stack)
+                    + HELP + " x" + getStackAmount(stack)));
+            sender.addChatMessage(new ChatComponentText(HELP + "  Registry: " + INFO + getRegistryName(stack)
+                    + HELP + " | Meta: " + INFO + getMetadata(stack)));
+            sender.addChatMessage(new ChatComponentText(HELP + "  Chance: " + INFO + formatChance(chance)
+                    + HELP + " | Raw: " + INFO + String.valueOf(chance)
+                    + HELP + " | " + INFO + formatYRange(minY, maxY)));
+        }
+
+        if (page < totalPages) {
+            sender.addChatMessage(new ChatComponentText(COMMAND + "/stonedrops " + (page + 1) + INFO + " - next page"));
+        }
+        if (page > 1) {
+            sender.addChatMessage(new ChatComponentText(COMMAND + "/stonedrops " + (page - 1) + INFO + " - previous page"));
+        }
+    }
+
+    private int getValidEntryCount() {
+        return Math.min(Math.min(MainRegistry.customDrops.size(), MainRegistry.customDropChances.size()),
+                Math.min(MainRegistry.customDropMinYs.size(), MainRegistry.customDropMaxYs.size()));
+    }
+
+    private void sendUsage(ICommandSender sender) {
+        sender.addChatMessage(new ChatComponentText(ERROR + "Usage: " + getCommandUsage(sender)));
+    }
+
+    private void sendInvalidPage(ICommandSender sender) {
+        sender.addChatMessage(new ChatComponentText(ERROR + "Invalid page. Use a positive whole number, e.g. /stonedrops 1"));
+    }
+
+    private String getDisplayName(ItemStack stack) {
+        if (stack == null || stack.getItem() == null) {
+            return "Unknown item";
+        }
+        try {
+            String displayName = stack.getDisplayName();
+            return displayName == null || displayName.length() == 0 ? "Unknown item" : displayName;
+        } catch (RuntimeException e) {
+            return "Unknown item";
+        }
+    }
+
+    private int getStackAmount(ItemStack stack) {
+        return stack == null ? 0 : stack.stackSize;
+    }
+
+    private String getRegistryName(ItemStack stack) {
+        if (stack == null || stack.getItem() == null) {
+            return "unknown";
+        }
+        String registryName = Item.itemRegistry.getNameForObject(stack.getItem());
+        return registryName == null || registryName.length() == 0 ? "unknown" : registryName;
+    }
+
+    private int getMetadata(ItemStack stack) {
+        return stack == null ? 0 : stack.getItemDamage();
+    }
+
+    private String formatChance(Double chance) {
+        if (chance == null) {
+            return "unknown per stone block";
+        }
+        return PERCENT_FORMAT.format(chance.doubleValue() * 100.0D) + "% per stone block";
+    }
+
+    private String formatYRange(Integer minY, Integer maxY) {
+        if (minY == null || maxY == null) {
+            return "Any height";
+        }
+        return "Y " + minY + "-" + maxY;
+    }
+}

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -854,6 +854,7 @@ public class MainRegistry
 		event.registerServerCommand(new CommandXDebug());
 		event.registerServerCommand(new CommandXMarket());
 		event.registerServerCommand(new CommandStoneDrop());
+		event.registerServerCommand(new CommandStoneDrops());
 		MuteManager.init();
 		if(XFConfig.enableTDM)
 			TDMKitManager.init();


### PR DESCRIPTION
### Motivation

- Provide a read-only, player-accessible command to inspect configured custom stone drops without granting administrator `/stonedrop` permissions.
- Ensure runtime safety when displaying stone-drop data by tolerating mismatched parallel lists, null `ItemStack` entries, or missing registry names.
- Document the new command and record the change in the project `CHANGELOG.md` and command docs.

### Description

- Added `com.hfr.command.CommandStoneDrops` which implements `/stonedrops [page]` with Forge 1.7.10-compatible public permissions (`getRequiredPermissionLevel() == 0` and `canCommandSenderUseCommand(...) == true`).
- The command paginates eight entries per page, validates page input as a positive whole number, clamps pages above the final page, and prints a title with the current page and total pages.
- Each displayed entry shows index, item display name (safe fallback), stack amount, item registry name (safe fallback), metadata, formatted percentage chance (e.g. `1% per stone block`), raw chance value, and Y range with `Any height` for null ranges or `Y <min>-<max>` for bounded ranges; color-coding uses existing `EnumChatFormatting` values to match Xenofactions style.
- The visible entry count is computed from the smallest of the four runtime lists (`customDrops`, `customDropChances`, `customDropMinYs`, `customDropMaxYs`) to avoid `IndexOutOfBoundsException`, and the command never mutates or reloads those lists.
- Registered the new command in `MainRegistry.serverStarting` alongside the existing administrator `CommandStoneDrop` so `/stonedrop` remains unchanged.
- Updated `docs/commands.md`, `README.md`, and `CHANGELOG.md` to document the new public command and its behavior; `CHANGELOG.md` includes a concise entry describing the addition.
- Small formatting/localization detail: `DecimalFormat` uses `Locale.US` digits to produce stable percentage output across locales.

### Testing

- Repository consistency and diff checks were run and issues (trailing whitespace) were resolved, result: passed.
- Attempted a full project build with `gradle build`, but the Gradle configuration failed during dependency resolution due to remote repository access returning HTTP 403 for `com.gtnewhorizons:gtnhgradle`, preventing compilation verification.
- No runtime/compile tests could be completed because the build did not reach Java compilation due to the external dependency resolution failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72c17288c88323923ad1d0755b6f22)