### PR TITLE
Remove vanilla 3x3 crafting grid from Stone Drops NEI page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## Remove Stone Drops NEI crafting grid background
+
+- Replaced the inherited vanilla crafting table recipe background on Xenofactions Stone Drops NEI pages with a texture-free custom slot-and-arrow background.
+- Applied the same explicit background to the custom Xenofactions machine NEI handler that also inherited the unrelated vanilla crafting table texture.
+
 ## Optional Not Enough Items integration
 
 - Added development-only Not Enough Items and CodeChickenCore dependencies through GTNH Convention's non-publishable configuration while preserving the existing `devmods` remapping flow.

--- a/src/main/java/com/hfr/nei/XenoFactionsMachineHandler.java
+++ b/src/main/java/com/hfr/nei/XenoFactionsMachineHandler.java
@@ -35,8 +35,10 @@ public class XenoFactionsMachineHandler extends TemplateRecipeHandler {
 
     public XenoFactionsMachineHandler(String id) { this.id = id; }
     public String getRecipeName() { return tr("hfr.nei." + key() + ".title"); }
-    public String getGuiTexture() { return "textures/gui/container/crafting_table.png"; }
+    public String getGuiTexture() { return "textures/gui/options_background.png"; }
     public String getOverlayIdentifier() { return id; }
+
+    public void drawBackground(int recipe) { XenoFactionsStoneDropHandler.drawCleanRecipeBackground(30, 24, 116, 24); }
 
     public void loadCraftingRecipes(String outputId, Object... results) { if (id.equals(outputId)) loadAll(); else super.loadCraftingRecipes(outputId, results); }
     public void loadCraftingRecipes(ItemStack result) { if (result == null) return; loadMatching(result, false); }

--- a/src/main/java/com/hfr/nei/XenoFactionsStoneDropHandler.java
+++ b/src/main/java/com/hfr/nei/XenoFactionsStoneDropHandler.java
@@ -8,6 +8,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.Gui;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.StatCollector;
@@ -24,8 +25,12 @@ public class XenoFactionsStoneDropHandler extends TemplateRecipeHandler {
     private static final DecimalFormat CHANCE_FORMAT = new DecimalFormat("0.######%", DecimalFormatSymbols.getInstance(Locale.US));
 
     public String getRecipeName() { return tr("hfr.nei.stone_drops.title"); }
-    public String getGuiTexture() { return "textures/gui/container/crafting_table.png"; }
+    public String getGuiTexture() { return "textures/gui/options_background.png"; }
     public String getOverlayIdentifier() { return OVERLAY_ID; }
+
+    public void drawBackground(int recipe) {
+        drawCleanRecipeBackground(25, 20, 111, 20);
+    }
 
     public void loadCraftingRecipes(String outputId, Object... results) {
         if (outputId.equals(OVERLAY_ID)) loadAll(); else super.loadCraftingRecipes(outputId, results);
@@ -52,6 +57,35 @@ public class XenoFactionsStoneDropHandler extends TemplateRecipeHandler {
         fr.drawString(trim(fr, tr("hfr.nei.label.chance") + ": " + CHANCE_FORMAT.format(c.entry.chance), 150), 18, 42, 0x404040);
         fr.drawString(trim(fr, tr("hfr.nei.label.y_range") + ": " + yRange(c.entry), 150), 18, 54, 0x404040);
         GL11.glColor4f(1, 1, 1, 1);
+    }
+
+    static void drawCleanRecipeBackground(int sourceX, int sourceY, int resultX, int resultY) {
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_DEPTH_BUFFER_BIT);
+        GL11.glDisable(GL11.GL_LIGHTING);
+        GL11.glDisable(GL11.GL_DEPTH_TEST);
+        GL11.glColor4f(1, 1, 1, 1);
+
+        drawSlotBackground(sourceX, sourceY);
+        drawSlotBackground(resultX, resultY);
+        drawArrow(sourceX + 37, sourceY + 8, resultX - 17);
+
+        GL11.glPopAttrib();
+        GL11.glColor4f(1, 1, 1, 1);
+    }
+
+    private static void drawSlotBackground(int x, int y) {
+        Gui.drawRect(x, y, x + 18, y + 18, 0xFF8B8B8B);
+        Gui.drawRect(x + 1, y + 1, x + 17, y + 17, 0xFFE0E0E0);
+        Gui.drawRect(x + 2, y + 2, x + 16, y + 16, 0xFFB8B8B8);
+    }
+
+    private static void drawArrow(int x, int centerY, int right) {
+        int color = 0xFF4A4A4A;
+        Gui.drawRect(x, centerY - 1, right - 5, centerY + 2, color);
+        Gui.drawRect(right - 5, centerY - 4, right - 2, centerY + 5, color);
+        Gui.drawRect(right - 2, centerY - 3, right + 1, centerY + 4, color);
+        Gui.drawRect(right + 1, centerY - 2, right + 4, centerY + 3, color);
+        Gui.drawRect(right + 4, centerY - 1, right + 7, centerY + 2, color);
     }
 
     private void loadAll() { for (StoneDropDisplayEntry e : snapshot()) if (e.toStack() != null) arecipes.add(new CachedStoneDrop(e)); }


### PR DESCRIPTION
### Motivation

- The Stone Drops NEI handler inherited the vanilla crafting-table GUI texture via `getGuiTexture()` which caused `TemplateRecipeHandler.drawBackground(int)` to render the 3x3 crafting grid behind the Stone Drops page.  
- The goal is to stop the unwanted vanilla grid from being drawn at the source: prevent the inherited `drawBackground` behavior rather than obscuring the grid by moving items.  
- The change also applies the same explicit background approach to another custom NEI handler that unintentionally inherited the crafting-table texture.

### Description

- Overrode `drawBackground(int)` in `XenoFactionsStoneDropHandler` to avoid calling `super.drawBackground(recipe)` and implemented `drawCleanRecipeBackground(int sourceX, int sourceY, int resultX, int resultY)` which draws a texture-free background using `Gui.drawRect` and OpenGL state push/pop.  
- The custom background draws a single `18x18` slot behind the source at `25, 20`, a single `18x18` slot behind the result at `111, 20`, and a simple right-facing arrow between them, and it resets the color to white after drawing to avoid GL state leaks.  
- Kept `getGuiTexture()` present to satisfy the NEI API but changed its return to a harmless texture (`textures/gui/options_background.png`) so the handler no longer depends on that texture for Stone Drops background rendering.  
- Applied the same explicit background call to `XenoFactionsMachineHandler` (invoking `drawCleanRecipeBackground(30, 24, 116, 24)`) and updated `CHANGELOG.md` to document the fix; changed files: `src/main/java/com/hfr/nei/XenoFactionsStoneDropHandler.java`, `src/main/java/com/hfr/nei/XenoFactionsMachineHandler.java`, and `CHANGELOG.md`.

### Testing

- Ran `git diff --check` which returned no whitespace or diff-check errors.  
- Attempted `gradle --no-daemon clean build` which failed during configuration due to external plugin/repository resolution returning HTTP 403 for GTNH Gradle artifacts, so a full automated build could not be completed in this environment.  
- Attempted `./gradlew clean build` which could not be run because the repository does not contain a Gradle wrapper script, so the local wrapper-based build was not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a738fc92a50832392abd083cd2d33de)