### PR TITLE
Fix NEI runtime error by adding public zero-arg machine handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fix NEI machine handler reflection constructors
+
+- Split the shared Xenofactions machine NEI implementation into public per-category handlers with zero-argument constructors so GTNH NEI can recreate registered handlers reflectively during recipe and usage lookup.
+- Kept the shared machine recipe behavior, overlay identifiers, catalysts, rendering, copied `ItemStack` handling, and Stone Drops NEI handler behavior intact.
+
 ## Fix NEI machine handler compile error
 
 - Added explicit braces to the machine NEI recipe loading control flow to prevent dangling `else` binding in Foundry Casting and Fishing Net lookups.

--- a/src/main/java/com/hfr/nei/NEIXenoFactionsConfig.java
+++ b/src/main/java/com/hfr/nei/NEIXenoFactionsConfig.java
@@ -17,11 +17,11 @@ public class NEIXenoFactionsConfig implements IConfigureNEI {
         XenoFactionsStoneDropHandler handler = new XenoFactionsStoneDropHandler();
         API.registerRecipeHandler(handler);
         API.registerUsageHandler(handler);
-        register(new XenoFactionsMachineHandler(XenoFactionsMachineHandler.BLAST), new ItemStack(ModBlocks.machine_blastfurnace));
-        register(new XenoFactionsMachineHandler(XenoFactionsMachineHandler.FOUNDRY_MELT), new ItemStack(ModBlocks.machine_foundry));
-        register(new XenoFactionsMachineHandler(XenoFactionsMachineHandler.FOUNDRY_CAST), new ItemStack(ModBlocks.machine_foundry));
-        register(new XenoFactionsMachineHandler(XenoFactionsMachineHandler.NET), new ItemStack(ModBlocks.machine_net));
-        register(new XenoFactionsMachineHandler(XenoFactionsMachineHandler.WIND), new ItemStack(ModBlocks.machine_windmill));
+        register(new XenoFactionsBlastFurnaceHandler(), new ItemStack(ModBlocks.machine_blastfurnace));
+        register(new XenoFactionsFoundryMeltingHandler(), new ItemStack(ModBlocks.machine_foundry));
+        register(new XenoFactionsFoundryCastingHandler(), new ItemStack(ModBlocks.machine_foundry));
+        register(new XenoFactionsFishingNetHandler(), new ItemStack(ModBlocks.machine_net));
+        register(new XenoFactionsWindmillHandler(), new ItemStack(ModBlocks.machine_windmill));
     }
 
     private void register(XenoFactionsMachineHandler handler, ItemStack catalyst) {

--- a/src/main/java/com/hfr/nei/XenoFactionsBlastFurnaceHandler.java
+++ b/src/main/java/com/hfr/nei/XenoFactionsBlastFurnaceHandler.java
@@ -1,0 +1,11 @@
+package com.hfr.nei;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class XenoFactionsBlastFurnaceHandler extends XenoFactionsMachineHandler {
+    public XenoFactionsBlastFurnaceHandler() {
+        super(BLAST);
+    }
+}

--- a/src/main/java/com/hfr/nei/XenoFactionsFishingNetHandler.java
+++ b/src/main/java/com/hfr/nei/XenoFactionsFishingNetHandler.java
@@ -1,0 +1,11 @@
+package com.hfr.nei;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class XenoFactionsFishingNetHandler extends XenoFactionsMachineHandler {
+    public XenoFactionsFishingNetHandler() {
+        super(NET);
+    }
+}

--- a/src/main/java/com/hfr/nei/XenoFactionsFoundryCastingHandler.java
+++ b/src/main/java/com/hfr/nei/XenoFactionsFoundryCastingHandler.java
@@ -1,0 +1,11 @@
+package com.hfr.nei;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class XenoFactionsFoundryCastingHandler extends XenoFactionsMachineHandler {
+    public XenoFactionsFoundryCastingHandler() {
+        super(FOUNDRY_CAST);
+    }
+}

--- a/src/main/java/com/hfr/nei/XenoFactionsFoundryMeltingHandler.java
+++ b/src/main/java/com/hfr/nei/XenoFactionsFoundryMeltingHandler.java
@@ -1,0 +1,11 @@
+package com.hfr.nei;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class XenoFactionsFoundryMeltingHandler extends XenoFactionsMachineHandler {
+    public XenoFactionsFoundryMeltingHandler() {
+        super(FOUNDRY_MELT);
+    }
+}

--- a/src/main/java/com/hfr/nei/XenoFactionsMachineHandler.java
+++ b/src/main/java/com/hfr/nei/XenoFactionsMachineHandler.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Locale;
 
 @SideOnly(Side.CLIENT)
-public class XenoFactionsMachineHandler extends TemplateRecipeHandler {
+public abstract class XenoFactionsMachineHandler extends TemplateRecipeHandler {
     public static final String BLAST = "hfr.blast_furnace";
     public static final String FOUNDRY_MELT = "hfr.foundry_melting";
     public static final String FOUNDRY_CAST = "hfr.foundry_casting";
@@ -33,7 +33,12 @@ public class XenoFactionsMachineHandler extends TemplateRecipeHandler {
     private static final DecimalFormat NUM = new DecimalFormat("0.######", DecimalFormatSymbols.getInstance(Locale.US));
     private final String id;
 
-    public XenoFactionsMachineHandler(String id) { this.id = id; }
+    protected XenoFactionsMachineHandler(String id) {
+        if (id == null || id.isEmpty()) {
+            throw new IllegalArgumentException("NEI machine handler id must not be null or empty");
+        }
+        this.id = id;
+    }
     public String getRecipeName() { return tr("hfr.nei." + key() + ".title"); }
     public String getGuiTexture() { return "textures/gui/options_background.png"; }
     public String getOverlayIdentifier() { return id; }

--- a/src/main/java/com/hfr/nei/XenoFactionsWindmillHandler.java
+++ b/src/main/java/com/hfr/nei/XenoFactionsWindmillHandler.java
@@ -1,0 +1,11 @@
+package com.hfr.nei;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class XenoFactionsWindmillHandler extends XenoFactionsMachineHandler {
+    public XenoFactionsWindmillHandler() {
+        super(WIND);
+    }
+}


### PR DESCRIPTION
### Motivation

- NEI (GTNH) reflectively instantiates registered `TemplateRecipeHandler` implementations using a public zero-argument constructor, which caused a `NoSuchMethodException` for the current `XenoFactionsMachineHandler` that only exposed a parameterized constructor.
- The fix must preserve per-category overlays and behavior while allowing NEI to create distinct handler instances per category instead of a single generic handler.
- Keep `XenoFactionsMachineHandler` as the shared implementation but prevent it from being registered directly so NEI never needs to call a non-existent zero-arg constructor on it.

### Description

- Made `XenoFactionsMachineHandler` `abstract` and changed its constructor to `protected XenoFactionsMachineHandler(String id)` with validation that `id` is not null or empty, preserving the final `id` field and all existing recipe, rendering and helper methods (`loadAll`, `loadMatching`, `drawBackground`, `drawExtras`, `SimpleRecipe`, etc.).
- Added five public client-only concrete handler classes each in their own file under `src/main/java/com/hfr/nei`: `XenoFactionsBlastFurnaceHandler`, `XenoFactionsFoundryMeltingHandler`, `XenoFactionsFoundryCastingHandler`, `XenoFactionsFishingNetHandler`, and `XenoFactionsWindmillHandler`, each marked `@SideOnly(Side.CLIENT)` and exposing an explicit public zero-argument constructor calling `super(...)` with the correct overlay constant.
- Updated `NEIXenoFactionsConfig.loadConfig()` to register the new concrete handler instances (and keep the existing `register` helper, NEI recipe/usage registration calls and catalysts), and preserved the Stone Drops handler registration.
- Documented the change in `CHANGELOG.md` and committed all changes on the working branch.

### Testing

- Disassembled the GTNH NEI `TemplateRecipeHandler.newInstance()` with `javap` and confirmed it uses `getClass().getConstructor().newInstance()`, verifying the need for public zero-arg constructors.
- Ran a local verification script that asserts each concrete handler class is public and has a public zero-argument constructor mapped to the correct overlay constant and confirmed `NEIXenoFactionsConfig` no longer registers `new XenoFactionsMachineHandler(...)` (script passed).
- Attempted automated builds (`gradle --offline compileJava` and `gradle --offline clean build`) which reached compilation but failed due to pre-existing unrelated missing HBM development dependencies (`com.hbm.*`), and those failures are not caused by the NEI handler changes; therefore full `runClient` / runtime NEI lookups could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a739864ad7c8323a6d6a5a46afec60e)