### PR TITLE
Add configurable player identity (AUTO/UUID/NAME) and admin cooldown-clear command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Pull request: configurable development identity and cooldown administration
+
+- Added centralized `AUTO`/`UUID`/`NAME` faction identity resolution while retaining UUID-secure packaged online production behavior.
+- Added stable `devUsername`/`devUuid` client properties and documented GTNH/RFG development launch behavior.
+- Added `/xc clearcreationcooldown <player-or-uuid>` and its reset alias with offline lookup, ambiguity protection, completion, and immediate persistence.
+- Made creation cooldown lookup and expired-entry cleanup follow the effective identity mode.
+
 ## Safe two-phase City Center relocation
 
 - Replaced normal leader City Center breaking with a leader-only confirmation popup and persistent, server-authoritative pending relocation. The old center and claims remain active until an atomic placement succeeds.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ bytecode, and MCP stable mappings 12. Start the IDE client with the checked-in
 gradle runClient
 ```
 
+The GTNH/RFG launcher otherwise supplies a generated `Player###` username and development UUID; that generated
+identity is not a durable contract and may differ between launches. Xenofactions configures stable, credential-free
+defaults (`DevPlayer`, UUID `45564450-4c41-5945-5200-000000000001`). Override independent clients with
+`gradle runClient -PdevUsername=PlayerOne -PdevUuid=<standard-uuid>`. These map to Minecraft 1.7.10's supported
+`--username` and `--uuid` arguments. Never commit account tokens or passwords.
+
+Faction identity defaults to `AUTO`: deobfuscated development and `online-mode=false` servers use normalized profile
+names, while packaged `online-mode=true` servers retain secure UUID authorization. Explicit `NAME` is only for
+development/offline testing because username reuse or changes are not protected. `/xc clearcreationcooldown
+<player-or-uuid>` (alias `resetcreationcooldown`) clears one online or offline player's creation penalty.
+
 Put ordinary Forge release JARs (including the normal JourneyMap 1.7.10 JAR)
 directly in [`devmods/`](devmods/). Production mods refer to Minecraft with SRG
 names such as `func_135052_a`; before `runClient`, RetroFuturaGradle remaps those

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ tasks.named('compileJava') {
 
 tasks.named('runClient') {
     dependsOn(prepareDevModsTask)
+    username.set(providers.gradleProperty('devUsername').orElse('DevPlayer'))
+    userUUID.set(providers.gradleProperty('devUuid').orElse('45564450-4c41-5945-5200-000000000001'))
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -121,6 +121,7 @@ Usage: `/xclowder help`; aliases: `/xclowder`, `/xc`; permission level: 3.
 | `/xc endnewplayerprotection` | End starter protection timers. |
 | `/xc resetbuildgrace <faction>` or `/xc rbg <faction>` | Reset faction build grace. |
 | `/xc endbuildgrace <faction>` or `/xc ebg <faction>` | End faction build grace. |
+| `/xc clearcreationcooldown <player-or-uuid>` or `/xc resetcreationcooldown ...` | Clear one online or offline player creation cooldown. UUIDs, live/cached profiles, and stored names are supported; ambiguity fails closed. |
 | `/xc warenable` | Enable war declarations. |
 | `/xc wardisable` | Disable war declarations and clear active wars. |
 | `/xc skipwarcooldowns` | Toggle global war cooldown bypass. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,6 +8,14 @@ config/hfr.cfg
 
 Restart the server after changing configuration unless the generated config comment explicitly says otherwise.
 
+## Player identity
+
+`XENOFACTIONS_09C_PLAYER_IDENTITY.playerIdentityMode` accepts case-insensitive `AUTO`, `UUID`, or `NAME` and defaults to `AUTO`. `AUTO` selects `NAME` in Forge's deobfuscated development environment or with `online-mode=false`, and `UUID` on a packaged online-mode server. Invalid values fail closed to `UUID`. Startup logs both modes and warns prominently for `NAME`; debug logging does not affect selection.
+
+`UUID` uses the authenticated UUID and is secure production behavior; last-known names never authorize. `NAME` uses the trimmed, `Locale.ROOT`-lowercase `GameProfile` name so test membership survives transient UUID changes, but cannot protect against username reuse or changes. Ambiguous stored names fail closed.
+
+`runClient` uses `DevPlayer` and deterministic UUID `45564450-4c41-5945-5200-000000000001`. Override them with `gradle runClient -PdevUsername=PlayerOne -PdevUuid=<standard-uuid>`; RFG supplies `--username` and `--uuid`. Without explicit identity the underlying launcher may generate `Player###`-style identities that are not guaranteed stable between launches. No credentials are required.
+
 ## Main feature toggles
 
 Category: `XENOFACTIONS_01_MODULES`
@@ -239,3 +247,6 @@ automatic entries. The success log message is:
 ## Faction creation cooldown data
 
 Regular leader-run `/c disband <faction name>` writes faction creation penalties to `clowder_faction_creation_cooldowns.json` in the server root. Entries are absolute real-time expiration timestamps keyed by player UUID where possible, with last-known names and normalized-name fallbacks for unresolved offline profiles. These cooldowns block only `/c create`; applications, invitations, and joining are unchanged.
+
+
+The cooldown JSON contains `uuids` and normalized `nameFallbacks`; entries contain epoch-millisecond `expiresAt` and `lastKnownName`. `/xc clearcreationcooldown <player-or-uuid>` (alias `resetcreationcooldown`) works for online/offline targets and saves successful changes immediately via temporary-file replacement.

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,10 @@ forgeVersion = 10.13.4.1614
 channel = stable
 mappingsVersion = 12
 remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
-developmentEnvironmentUserName =
+developmentEnvironmentUserName = DevPlayer
+# Override with -PdevelopmentEnvironmentUserName or -PdevUsername; see README.
+devUsername = DevPlayer
+devUuid = 45564450-4c41-5945-5200-000000000001
 enableModernJavaSyntax = false
 enableGenericInjection = true
 generateGradleTokenClass =

--- a/src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
+++ b/src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
@@ -67,7 +67,7 @@ public final class CityCenterRelocationManager {
         if(!XFConfig.cityRelocationEnabled) return "City Center relocation is disabled.";
         if(player == null || player instanceof net.minecraftforge.common.util.FakePlayer) return "Only a real faction leader may relocate a City Center.";
         Clowder faction = Clowder.getClowderFromPlayer(player);
-        if(faction == null || !faction.isOwner(player.getUniqueID())) return "Only the faction leader may relocate a City Center.";
+        if(faction == null || !faction.isOwner(player)) return "Only the faction leader may relocate a City Center.";
         if(!faction.activeWars.isEmpty()) { clear(faction, player.worldObj); return "City Centers cannot be moved during an active war."; }
         if(hasPending(faction)) return "Your faction already has a pending City Center move.";
         if(player.worldObj.provider.dimensionId != dim || player.worldObj.getBlock(x, y, z) != ModBlocks.clowder_flag) return "The source City Center no longer exists.";
@@ -115,7 +115,7 @@ public final class CityCenterRelocationManager {
         if(world.isRemote) return true;
         if(!(player instanceof EntityPlayerMP) || player instanceof net.minecraftforge.common.util.FakePlayer) return fail(player, "Relocation tokens may only be placed by a real player.");
         Clowder faction = Clowder.getClowderFromPlayer(player);
-        if(faction == null || !faction.isOwner(player.getUniqueID()) || !hasPending(faction)) return fail(player, "This relocation token is no longer authorized.");
+        if(faction == null || !faction.isOwner(player) || !hasPending(faction)) return fail(player, "This relocation token is no longer authorized.");
         if(!faction.activeWars.isEmpty()) { clear(faction, world); return fail(player, "The move was canceled because your faction entered a war."); }
         NBTTagCompound tag = token.stackTagCompound;
         if(!faction.relocationId.equals(tag.getString("relocationId")) || !faction.uuid.equals(tag.getString("factionUuid")) || !faction.relocationCityId.equals(tag.getString("cityId"))) return fail(player, "This relocation token does not match the pending move.");

--- a/src/main/java/com/hfr/clowder/Clowder.java
+++ b/src/main/java/com/hfr/clowder/Clowder.java
@@ -961,8 +961,14 @@ public class Clowder {
 			return false;
 
 
-		members.put(name, time());
-		legacyInverseMap.put(name, this);
+		EntityPlayer player = world.getPlayerEntityByName(name);
+		UUID uuid = PlayerIdentityService.uuid(player);
+		String profileName = PlayerIdentityService.profileName(player);
+		if(uuid == null || profileName.isEmpty()) return false;
+		members.put(profileName, time());
+		memberRecords.put(uuid, new FactionMemberRecord(uuid, profileName, time(), FactionRole.MEMBER));
+		legacyInverseMap.put(profileName, this);
+		recalculateIMap();
 
 		ClowderData.getData(world).markDirty();
 
@@ -977,6 +983,11 @@ public class Clowder {
 		members.remove(name);
 		officers.remove(name);
 		legacyInverseMap.remove(name);
+		String normalized = PlayerIdentityService.normalizeName(name);
+		UUID removeUuid = null;
+		for(FactionMemberRecord record : memberRecords.values()) if(normalized.equals(PlayerIdentityService.normalizeName(record.lastKnownName))) { if(removeUuid != null) return false; removeUuid = record.playerUuid; }
+		if(removeUuid != null) memberRecords.remove(removeUuid);
+		recalculateIMap();
 
 		ClowderData.getData(world).markDirty();
 
@@ -1018,11 +1029,12 @@ public class Clowder {
 
 	public boolean transferOwnership(World world, String key) {
 
-		if (members.get(key) == null)
-			return false;
-
+		FactionMemberRecord next = findMemberByName(key);
+		if(next == null) return false;
+		for(FactionMemberRecord record : memberRecords.values()) if(record.role == FactionRole.OWNER) record.role = FactionRole.OFFICER;
+		next.role = FactionRole.OWNER;
 		officers.remove(key);
-		leader = key;
+		leader = next.lastKnownName;
 		ClowderData.getData(world).markDirty();
 
 		return true;
@@ -1034,6 +1046,8 @@ public class Clowder {
 			return;
 
 		officers.add(name);
+		FactionMemberRecord record = findMemberByName(name);
+		if(record != null && record.role == FactionRole.MEMBER) record.role = FactionRole.OFFICER;
 		this.save(world);
 	}
 
@@ -1043,12 +1057,25 @@ public class Clowder {
 			return;
 
 		officers.remove(name);
+		FactionMemberRecord record = findMemberByName(name);
+		if(record != null && record.role == FactionRole.OFFICER) record.role = FactionRole.MEMBER;
 		this.save(world);
 	}
 
 	public int getPermLevel(String name) {
-		// Deliberately fail closed. Usernames must never authorize faction actions.
-		return 0;
+		if(!PlayerIdentityService.usesNames()) return 0;
+		FactionMemberRecord record = findMemberByName(name);
+		return record == null ? 0 : record.role.getPermissionLevel();
+	}
+
+	private FactionMemberRecord findMemberByName(String name) {
+		String key = PlayerIdentityService.normalizeName(name);
+		FactionMemberRecord match = null;
+		for(FactionMemberRecord record : memberRecords.values()) if(key.equals(PlayerIdentityService.normalizeName(record.lastKnownName))) {
+			if(match != null) { if(MainRegistry.logger != null) MainRegistry.logger.error("Ambiguous member name '" + key + "' in " + this.name); return null; }
+			match = record;
+		}
+		return match;
 	}
 
 	public FactionMemberRecord getMember(UUID playerUuid) { return memberRecords.get(playerUuid); }
@@ -1056,12 +1083,31 @@ public class Clowder {
 	public boolean isOwner(UUID playerUuid) { FactionMemberRecord r = getMember(playerUuid); return r != null && r.role == FactionRole.OWNER; }
 	public boolean isOfficer(UUID playerUuid) { FactionMemberRecord r = getMember(playerUuid); return r != null && r.role == FactionRole.OFFICER; }
 	public int getPermLevel(UUID playerUuid) { FactionMemberRecord r = getMember(playerUuid); return r == null ? 0 : r.role.getPermissionLevel(); }
-	public int getPermLevel(EntityPlayer player) { return player == null ? 0 : getPermLevel(player.getUniqueID()); }
+	public int getPermLevel(EntityPlayer player) {
+		FactionMemberRecord record = findMember(player);
+		return record == null ? 0 : record.role.getPermissionLevel();
+	}
+
+	public FactionMemberRecord findMember(EntityPlayer player) {
+		if(player == null) return null;
+		if(!PlayerIdentityService.usesNames()) return getMember(PlayerIdentityService.uuid(player));
+		String key = PlayerIdentityService.normalizeName(PlayerIdentityService.profileName(player));
+		FactionMemberRecord match = null;
+		for(FactionMemberRecord candidate : memberRecords.values()) {
+			if(candidate == null || !key.equals(PlayerIdentityService.normalizeName(candidate.lastKnownName))) continue;
+			if(match != null) {
+				if(MainRegistry.logger != null) MainRegistry.logger.error("Ambiguous faction member name '" + key + "' in " + name + "; authorization denied.");
+				return null;
+			}
+			match = candidate;
+		}
+		return match;
+	}
 
 	public boolean updateLastKnownName(EntityPlayer player) {
 		if (player == null) return false;
-		FactionMemberRecord record = getMember(player.getUniqueID());
-		String name = player.getGameProfile().getName();
+		FactionMemberRecord record = findMember(player);
+		String name = PlayerIdentityService.profileName(player);
 		if (record == null || name == null || name.equals(record.lastKnownName)) return false;
 		record.lastKnownName = name;
 		ClowderData data = ClowderData.getData(player.worldObj);
@@ -1184,7 +1230,7 @@ public class Clowder {
 	}
 
 	public boolean isOwner(EntityPlayer player) {
-		return player != null && isOwner(player.getUniqueID());
+		return player != null && getPermLevel(player) == FactionRole.OWNER.getPermissionLevel();
 	}
 
 	public void mergeWith(Clowder target, World world) {
@@ -2252,7 +2298,19 @@ public class Clowder {
 	}
 
 	public static Clowder getClowderFromPlayer(EntityPlayer player) {
-		return player == null ? null : getClowderFromPlayerUuid(player.getUniqueID());
+		if(player == null) return null;
+		if(!PlayerIdentityService.usesNames()) return getClowderFromPlayerUuid(PlayerIdentityService.uuid(player));
+		String key = PlayerIdentityService.normalizeName(PlayerIdentityService.profileName(player));
+		Clowder match = null;
+		for(Clowder faction : clowders) {
+			if(faction.findMember(player) == null) continue;
+			if(match != null) {
+				if(MainRegistry.logger != null) MainRegistry.logger.error("Ambiguous player name '" + key + "' occurs in multiple factions; authorization denied.");
+				return null;
+			}
+			match = faction;
+		}
+		return match;
 	}
 
 	public static Clowder getClowderFromPlayerUuid(UUID playerUuid) { return playerUuid == null ? null : inverseMap.get(playerUuid); }

--- a/src/main/java/com/hfr/clowder/ClowderEvents.java
+++ b/src/main/java/com/hfr/clowder/ClowderEvents.java
@@ -981,6 +981,8 @@ public void onEntityJoinWorld(EntityJoinWorldEvent event) {
 	@SubscribeEvent
 	public void onPlayerLogin(PlayerLoggedInEvent event) {
 
+		Clowder loginFaction = Clowder.getClowderFromPlayer(event.player);
+		if(loginFaction != null) loginFaction.updateLastKnownName(event.player);
 		if(event.player instanceof EntityPlayerMP) Clowder.syncNameplateDataAll();
 
 		if(event.player != null)

--- a/src/main/java/com/hfr/clowder/FactionCreationCooldownData.java
+++ b/src/main/java/com/hfr/clowder/FactionCreationCooldownData.java
@@ -11,6 +11,8 @@ import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import com.google.gson.Gson;
@@ -60,7 +62,7 @@ public class FactionCreationCooldownData {
             reader.close();
             DATA = store == null || store.uuids == null ? new HashMap<String, CooldownEntry>() : store.uuids;
             FALLBACKS = store == null || store.nameFallbacks == null ? new HashMap<String, CooldownEntry>() : store.nameFallbacks;
-            cleanExpired(System.currentTimeMillis());
+            if(cleanExpired(System.currentTimeMillis())) save();
         } catch(Exception e) {
             log("Failed to load faction creation cooldowns", e);
             DATA = new HashMap<String, CooldownEntry>();
@@ -88,21 +90,92 @@ public class FactionCreationCooldownData {
         }
     }
 
+    public static long getCooldownUntil(EntityPlayer player) {
+        boolean changed = cleanExpired(System.currentTimeMillis());
+        CooldownEntry entry = null;
+        if(player != null && PlayerIdentityService.usesNames()) {
+            String name = PlayerIdentityService.normalizeName(PlayerIdentityService.profileName(player));
+            entry = FALLBACKS.get(name);
+            for(CooldownEntry candidate : DATA.values()) {
+                if(candidate != null && name.equals(PlayerIdentityService.normalizeName(candidate.lastKnownName))) {
+                    if(entry != null && entry != candidate) entry = entry.expiresAt >= candidate.expiresAt ? entry : candidate;
+                    else entry = candidate;
+                }
+            }
+        } else if(player != null && PlayerIdentityService.uuid(player) != null) {
+            entry = DATA.get(PlayerIdentityService.uuid(player).toString());
+        }
+        if(changed) save();
+        return entry == null ? 0L : entry.expiresAt;
+    }
+
+    /** Retains the old UUID-only read API for callers and data tooling. */
     public static long getCooldownUntil(UUID uuid) {
-        cleanExpired(System.currentTimeMillis());
+        boolean changed = cleanExpired(System.currentTimeMillis());
         CooldownEntry entry = uuid == null ? null : DATA.get(uuid.toString());
+        if(changed) save();
         return entry == null ? 0L : entry.expiresAt;
     }
 
     public static void migrateFallback(EntityPlayer player) {
-        if(player == null || player.getUniqueID() == null)
-            return;
-        String key = normalize(player.getDisplayName());
-        CooldownEntry fallback = FALLBACKS.remove(key);
-        if(fallback != null) {
-            putUuid(player.getUniqueID(), player.getDisplayName(), fallback.expiresAt);
+        if(player == null) return;
+        UUID uuid = PlayerIdentityService.uuid(player);
+        String name = PlayerIdentityService.profileName(player);
+        if(uuid == null || PlayerIdentityService.normalizeName(name).isEmpty()) return;
+        CooldownEntry fallback = FALLBACKS.get(PlayerIdentityService.normalizeName(name));
+        if(fallback != null && !PlayerIdentityService.usesNames()) {
+            FALLBACKS.remove(PlayerIdentityService.normalizeName(name));
+            putUuid(uuid, name, fallback.expiresAt);
             save();
         }
+    }
+
+    public static final class ClearResult {
+        public final boolean ambiguous;
+        public final UUID uuid;
+        public final String name;
+        public final long removedExpiration;
+        public final int removedEntries;
+        private ClearResult(boolean ambiguous, UUID uuid, String name, long expiration, int count) {
+            this.ambiguous = ambiguous; this.uuid = uuid; this.name = name; this.removedExpiration = expiration; this.removedEntries = count;
+        }
+    }
+
+    public static ClearResult clear(UUID uuid) { return clearRepresentations(uuid, null); }
+    public static ClearResult clearNormalizedName(String name) { return clearRepresentations(null, name); }
+
+    public static ClearResult clearTarget(String target, World world) {
+        if(target == null || target.trim().isEmpty()) return new ClearResult(true, null, "", 0L, 0);
+        try { return clearRepresentations(UUID.fromString(target.trim()), null); }
+        catch(IllegalArgumentException notUuid) { }
+        EntityPlayer online = world == null ? null : world.getPlayerEntityByName(target);
+        GameProfile profile = online == null ? PlayerIdentityService.cachedProfile(target) : online.getGameProfile();
+        return clearRepresentations(profile == null ? null : profile.getId(), profile == null ? target : profile.getName());
+    }
+
+    public static ClearResult clearRepresentations(UUID uuid, String suppliedName) {
+        cleanExpired(System.currentTimeMillis());
+        String normalized = PlayerIdentityService.normalizeName(suppliedName);
+        List<String> matchingUuids = new ArrayList<String>();
+        if(uuid != null && DATA.containsKey(uuid.toString())) matchingUuids.add(uuid.toString());
+        if(!normalized.isEmpty()) for(Map.Entry<String, CooldownEntry> entry : DATA.entrySet())
+            if(entry.getValue() != null && normalized.equals(PlayerIdentityService.normalizeName(entry.getValue().lastKnownName)) && !matchingUuids.contains(entry.getKey())) matchingUuids.add(entry.getKey());
+        if(!normalized.isEmpty() && matchingUuids.size() > 1) {
+            log("Ambiguous cooldown identity '" + normalized + "' matches " + matchingUuids.size() + " UUID entries; nothing cleared", null);
+            return new ClearResult(true, null, suppliedName, 0L, 0);
+        }
+        long expiration = 0L; int count = 0; String knownName = suppliedName;
+        for(String key : matchingUuids) {
+            CooldownEntry removed = DATA.remove(key);
+            if(removed != null) { count++; expiration = Math.max(expiration, removed.expiresAt); if(knownName == null || knownName.isEmpty()) knownName = removed.lastKnownName; }
+        }
+        String finalName = PlayerIdentityService.normalizeName(knownName);
+        if(!finalName.isEmpty()) {
+            CooldownEntry removed = FALLBACKS.remove(finalName);
+            if(removed != null) { count++; expiration = Math.max(expiration, removed.expiresAt); }
+        }
+        if(count > 0) save();
+        return new ClearResult(false, uuid, knownName == null ? "" : knownName, expiration, count);
     }
 
     public static Map<String, String> snapshotFactionMembers(Clowder clowder, World world) {
@@ -163,18 +236,19 @@ public class FactionCreationCooldownData {
         return null;
     }
 
-    private static void cleanExpired(long now) {
-        clean(DATA, now);
-        clean(FALLBACKS, now);
+    private static boolean cleanExpired(long now) {
+        return clean(DATA, now) | clean(FALLBACKS, now);
     }
 
-    private static void clean(Map<String, CooldownEntry> map, long now) {
+    private static boolean clean(Map<String, CooldownEntry> map, long now) {
+        int oldSize = map.size();
         Map<String, CooldownEntry> keep = new HashMap<String, CooldownEntry>();
         for(Map.Entry<String, CooldownEntry> entry : map.entrySet())
             if(entry.getValue() != null && entry.getValue().expiresAt > now)
                 keep.put(entry.getKey(), entry.getValue());
         map.clear();
         map.putAll(keep);
+        return oldSize != map.size();
     }
 
     public static String formatRemaining(long ms) {
@@ -186,7 +260,7 @@ public class FactionCreationCooldownData {
         return days + "d " + hours + "h " + minutes + "m";
     }
 
-    private static String normalize(String name) { return name == null ? "" : name.trim().toLowerCase(); }
+    private static String normalize(String name) { return PlayerIdentityService.normalizeName(name); }
 
     private static void log(String msg, Throwable t) {
         if(MainRegistry.logger != null) {

--- a/src/main/java/com/hfr/clowder/PlayerIdentityService.java
+++ b/src/main/java/com/hfr/clowder/PlayerIdentityService.java
@@ -1,0 +1,65 @@
+package com.hfr.clowder;
+
+import java.lang.reflect.Method;
+import java.util.Locale;
+import java.util.UUID;
+
+import com.hfr.config.XFConfig;
+import com.hfr.main.MainRegistry;
+import com.mojang.authlib.GameProfile;
+
+import net.minecraft.launchwrapper.Launch;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.server.MinecraftServer;
+
+/** Single authority for faction player identity decisions. Never performs a network profile lookup. */
+public final class PlayerIdentityService {
+    public enum Mode { AUTO, UUID, NAME }
+    private static Mode configuredMode = Mode.UUID;
+    private static Mode effectiveMode = Mode.UUID;
+
+    private PlayerIdentityService() { }
+
+    public static void initialize(MinecraftServer server) {
+        String configured = XFConfig.playerIdentityMode == null ? "" : XFConfig.playerIdentityMode.trim();
+        try { configuredMode = Mode.valueOf(configured.toUpperCase(Locale.ROOT)); }
+        catch (IllegalArgumentException invalid) {
+            configuredMode = Mode.UUID;
+            log("Invalid playerIdentityMode '" + configured + "'; failing closed to UUID.");
+        }
+        effectiveMode = configuredMode;
+        if(configuredMode == Mode.AUTO) {
+            boolean deobfuscated = Boolean.TRUE.equals(Launch.blackboard.get("fml.deobfuscatedEnvironment"));
+            boolean online = server != null && server.isServerInOnlineMode();
+            effectiveMode = deobfuscated || !online ? Mode.NAME : Mode.UUID;
+        }
+        log("Player identity mode: configured=" + configuredMode + ", effective=" + effectiveMode + ".");
+        if(effectiveMode == Mode.NAME)
+            log("WARNING: NAME PLAYER IDENTITY IS ENABLED. Usernames authorize faction access and do not protect against username reuse or changes. Use UUID on online production servers.");
+    }
+
+    public static Mode getEffectiveMode() { return effectiveMode; }
+    public static boolean usesNames() { return effectiveMode == Mode.NAME; }
+    public static String normalizeName(String name) { return name == null ? "" : name.trim().toLowerCase(Locale.ROOT); }
+    public static String profileName(EntityPlayer player) {
+        GameProfile profile = player == null ? null : player.getGameProfile();
+        return profile == null ? "" : profile.getName();
+    }
+    public static UUID uuid(EntityPlayer player) {
+        GameProfile profile = player == null ? null : player.getGameProfile();
+        return profile == null ? null : profile.getId();
+    }
+    public static GameProfile cachedProfile(String name) {
+        if(normalizeName(name).isEmpty() || MinecraftServer.getServer() == null) return null;
+        try {
+            Object cache = MinecraftServer.getServer().func_152358_ax();
+            Method method = cache.getClass().getMethod("func_152655_a", String.class);
+            Object value = method.invoke(cache, name.trim());
+            return value instanceof GameProfile ? (GameProfile)value : null;
+        } catch(Exception failure) {
+            log("Could not read cached profile for '" + name + "': " + failure.getClass().getSimpleName());
+            return null;
+        }
+    }
+    private static void log(String message) { if(MainRegistry.logger != null) MainRegistry.logger.warn(message); }
+}

--- a/src/main/java/com/hfr/command/CommandClowder.java
+++ b/src/main/java/com/hfr/command/CommandClowder.java
@@ -406,7 +406,7 @@ private void cmdCreate(ICommandSender sender, String name) {
 
 		if(factionName.isEmpty()) { sender.addChatMessage(new ChatComponentText(ERROR + "Faction name cannot be empty.")); return; }
 		FactionCreationCooldownData.migrateFallback(player);
-		long cooldownUntil = FactionCreationCooldownData.getCooldownUntil(player.getUniqueID());
+		long cooldownUntil = FactionCreationCooldownData.getCooldownUntil(player);
 		if(cooldownUntil > System.currentTimeMillis()) { sender.addChatMessage(new ChatComponentText(ERROR + "You cannot create a faction for " + FactionCreationCooldownData.formatRemaining(cooldownUntil - System.currentTimeMillis()) + ". You may still apply to or join factions.")); return; }
 
 		if(Clowder.getClowderFromPlayer(player) == null) {

--- a/src/main/java/com/hfr/command/CommandClowderAdmin.java
+++ b/src/main/java/com/hfr/command/CommandClowderAdmin.java
@@ -9,6 +9,7 @@ import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.CoordPair;
 import com.hfr.clowder.ClowderTerritory.Zone;
 import com.hfr.clowder.ClowderEvents;
+import com.hfr.clowder.FactionCreationCooldownData;
 import com.hfr.clowder.PlayerProtectionData;
 import com.hfr.config.XFConfig;
 import com.hfr.guide.XFGuideBook;
@@ -71,6 +72,7 @@ public class CommandClowderAdmin extends CommandBase {
 		String cmd = args[0].toLowerCase();
 
 		if(cmd.equals("help") || cmd.equals("man")) { cmdHelp(sender, args.length > 1 ? args[1] : "1"); return; }
+		if(cmd.equals("clearcreationcooldown") || cmd.equals("resetcreationcooldown")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdClearCreationCooldown(sender, args[1]); return; }
 		if(cmd.equals("forcejoin") || cmd.equals("fj")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdForcejoin(sender, joinArgs(args, 1)); return; }
 		if(cmd.equals("forcekick") || cmd.equals("fk")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdForcekick(sender, args[1]); return; }
 		if(cmd.equals("forcedisband") || cmd.equals("fd")) { if(!requireArgs(sender, cmd, args, 2)) return; cmdForcedisband(sender, joinArgs(args, 1)); return; }
@@ -177,6 +179,7 @@ public class CommandClowderAdmin extends CommandBase {
 	}
 
 	private String getUsageFor(String cmd) {
+		if(cmd.equals("clearcreationcooldown") || cmd.equals("resetcreationcooldown")) return "/xc clearcreationcooldown <player-or-uuid>";
 		if(cmd.equals("forcejoin") || cmd.equals("fj")) return "/xc forcejoin <faction>";
 		if(cmd.equals("forcekick") || cmd.equals("fk")) return "/xc forcekick <player>";
 		if(cmd.equals("forcedisband") || cmd.equals("fd")) return "/xc forcedisband <faction>";
@@ -210,6 +213,7 @@ public class CommandClowderAdmin extends CommandBase {
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-forcedisband <faction>" + TITLE + " - Forcefully disbands a faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-forcerename <name>" + TITLE + " - Forcefully renames your faction"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-hijack" + TITLE + " - Forcefully overrides faction leadership"));
+			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-clearcreationcooldown <player-or-uuid>" + TITLE + " - Clears an online or offline player creation cooldown"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-deletedata" + TITLE + " - Deletes all clowder data (CAUTION!!)"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-disband <faction>" + TITLE + " - Disbands your faction with confirmation"));
 			sender.addChatMessage(new ChatComponentText(COMMAND_ADMIN + "-rename <name>" + TITLE + " - Renames your faction"));
@@ -273,7 +277,7 @@ public class CommandClowderAdmin extends CommandBase {
 		
 		if(clowder != null) {
 			
-			if(!clowder.isOwner(kickee.getUniqueID())) {
+			if(!clowder.isOwner(kickee)) {
 				
 				clowder.removeMember(player.worldObj, kickee.getDisplayName());
 				sender.addChatMessage(new ChatComponentText(INFO + "You have kicked " + kickee.getDisplayName() + " from the faction " + clowder.getDecoratedName() + "!"));
@@ -334,7 +338,7 @@ public class CommandClowderAdmin extends CommandBase {
 		
 		if(clowder != null) {
 			
-			if(!clowder.isOwner(player.getUniqueID())) {
+			if(!clowder.isOwner(player)) {
 				
 				clowder.transferOwnership(player.worldObj, player.getDisplayName());
 				sender.addChatMessage(new ChatComponentText(INFO + "You have assumed ownership of this faction!"));
@@ -583,13 +587,25 @@ public class CommandClowderAdmin extends CommandBase {
 		}
 	}
 	
+	private void cmdClearCreationCooldown(ICommandSender sender, String target) {
+		FactionCreationCooldownData.ClearResult result = FactionCreationCooldownData.clearTarget(target, sender.getEntityWorld());
+		if(result.ambiguous) {
+			sender.addChatMessage(new ChatComponentText(ERROR + "Player identity is malformed or ambiguous; no cooldown was cleared."));
+			return;
+		}
+		String identity = result.name == null || result.name.isEmpty() ? target : result.name;
+		if(result.uuid != null) identity += " (" + result.uuid + ")";
+		if(result.removedEntries == 0) sender.addChatMessage(new ChatComponentText(INFO + identity + " has no active faction creation cooldown."));
+		else sender.addChatMessage(new ChatComponentText(INFO + "Cleared faction creation cooldown for " + identity + "; removed expiration " + result.removedExpiration + "."));
+	}
+
 	@Override
     public List addTabCompletionOptions(ICommandSender sender, String[] args) {
 		if(args.length == 1)
 			return getListOfStringsMatchingLastWord(args, getAdminCommandNames());
 
 		String cmd = args[0].toLowerCase();
-		if(cmd.equals("forcekick") || cmd.equals("fk"))
+		if(cmd.equals("forcekick") || cmd.equals("fk") || cmd.equals("clearcreationcooldown") || cmd.equals("resetcreationcooldown"))
 			return getListOfStringsMatchingLastWord(args, MinecraftServer.getServer().getAllUsernames());
 
 		if(isFactionCompletionCommand(cmd))
@@ -599,7 +615,7 @@ public class CommandClowderAdmin extends CommandBase {
     }
 
 	private String[] getAdminCommandNames() {
-		return new String[] { "help", "forcejoin", "fj", "forcekick", "fk", "forcedisband", "fd", "forcerename", "fr",
+		return new String[] { "help", "clearcreationcooldown", "resetcreationcooldown", "forcejoin", "fj", "forcekick", "fk", "forcedisband", "fd", "forcerename", "fr",
 				"hijack", "hi", "deletedata", "deldat", "setclaim", "sc", "addprestige", "ap", "disband", "rename",
 				"warenable", "wardisable", "newplayerprotection", "resetnewplayerprotection", "endnewplayerprotection",
 				"skipwarcooldowns", "ignorewarcooldowncheck", "ignorewaronlinecheck", "ignorewarstatecheck",

--- a/src/main/java/com/hfr/config/XFConfig.java
+++ b/src/main/java/com/hfr/config/XFConfig.java
@@ -30,6 +30,7 @@ public final class XFConfig {
 	public static final String CAT_CUSTOM_FLAGS = "XENOFACTIONS_08_CUSTOM_FLAGS";
 	public static final String CAT_DYNMAP = "XENOFACTIONS_09_DYNMAP";
 	public static final String CAT_JOURNEYMAP = "XENOFACTIONS_09B_JOURNEYMAP_CLIENT";
+	public static final String CAT_PLAYER_IDENTITY = "XENOFACTIONS_09C_PLAYER_IDENTITY";
 
 	public static final String CAT_LEGACY_MACHINES = "XENOFACTIONS_10_MACHINES_POWER";
 	public static final String CAT_LEGACY_DEFENSE = "XENOFACTIONS_11_RADAR_FORCEFIELD";
@@ -56,6 +57,7 @@ public final class XFConfig {
 	public static boolean enableNEIIntegration = true;
 	public static boolean warEnabledDefault = false;
 	public static boolean enableDebugLogging = false;
+	public static String playerIdentityMode = "AUTO";
 
 	public static float startingPrestige = 250F;
 	public static float basePrestigeGen = 25F;
@@ -161,6 +163,7 @@ public final class XFConfig {
 		enableConquestFlagsCommand = bool(config, CAT_MODULES, "enableConquestFlagsCommand", enableConquestFlagsCommand, "Enables the /xflags command that grants conquest flags while wars are enabled.");
 		enableGuideBook = bool(config, CAT_MODULES, "enableGuideBook", enableGuideBook, "Registers the optional Guide-API Xenofactions Handbook when Guide-API is installed.");
 		enableNEIIntegration = bool(config, CAT_MODULES, "enableNEIIntegration", enableNEIIntegration, "Enables optional Not Enough Items recipe/usage display handlers when NEI is installed.");
+		playerIdentityMode = string(config, CAT_PLAYER_IDENTITY, "playerIdentityMode", playerIdentityMode, "AUTO uses NAME in deobfuscated development or offline-mode servers and UUID otherwise. UUID is secure; NAME is development/offline compatibility only.");
 
 		startingPrestige = flt(config, CAT_PRESTIGE_GENERATION, "startingPrestige", startingPrestige, 0F, 1000000F, "Prestige granted to newly-created factions.");
 		basePrestigeGen = flt(config, CAT_PRESTIGE_GENERATION, "basePrestigeGeneration", basePrestigeGen, 0F, 100000F, "Base hourly prestige generation for factions.");
@@ -283,6 +286,7 @@ public final class XFConfig {
 		config.addCustomCategoryComment(CAT_CUSTOM_FLAGS, "08 - Custom faction flag import safety limits and cache/reload behaviour.");
 		config.addCustomCategoryComment(CAT_DYNMAP, "09 - Optional Dynmap marker styling, labels, and refresh timing.");
 		config.addCustomCategoryComment(CAT_JOURNEYMAP, "09B - Optional JourneyMap 5.2.x client claim overlay styling and city territory labels.");
+		config.addCustomCategoryComment(CAT_PLAYER_IDENTITY, "09C - Server player identity policy. NAME is only for development/offline compatibility; UUID is secure production behavior.");
 		config.addCustomCategoryComment(CAT_LEGACY_MACHINES, "10 - Legacy machine and power settings moved under the Xenofactions category flow.");
 		config.addCustomCategoryComment(CAT_LEGACY_DEFENSE, "11 - Legacy radar and forcefield settings.");
 		config.addCustomCategoryComment(CAT_LEGACY_WEAPONS, "12 - Legacy missile, nuke, railgun, and explosive weapon settings.");

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -3,6 +3,7 @@ package com.hfr.main;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
@@ -850,6 +851,7 @@ public class MainRegistry
 
 	@Mod.EventHandler
 	public void serverStarting(FMLServerStartingEvent event) {
+		com.hfr.clowder.PlayerIdentityService.initialize(MinecraftServer.getServer());
 		// Main faction system commands
 		event.registerServerCommand(new CommandClowder());
 		event.registerServerCommand(new CommandClowderChat());


### PR DESCRIPTION
### Motivation

- Provide a single, auditable player identity policy that preserves secure UUID authorization in production while enabling stable name-based identity for deobfuscated development and offline testing.
- Centralize identity logic so faction lookup, permission checks, and cooldowns follow one effective mode rather than scattering environment checks across code.
- Allow server operators to clear a player's faction-creation cooldown (online or offline) safely, including ambiguity protection and immediate persistence.

### Description

- Added a centralized `PlayerIdentityService` to resolve effective identity mode (`AUTO`/`UUID`/`NAME`), normalize names with `Locale.ROOT`, read cached profiles without network lookups, and expose helper methods such as `uuid(...)`, `profileName(...)`, `cachedProfile(...)`, and `usesNames()`; logs configured and effective modes and warns when `NAME` is effective. (`src/main/java/com/hfr/clowder/PlayerIdentityService.java`)
- Introduced `playerIdentityMode` config under a new category `XENOFACTIONS_09C_PLAYER_IDENTITY` with default `AUTO` and config loading wiring in `XFConfig`. (`src/main/java/com/hfr/config/XFConfig.java`, `docs/configuration.md`)
- Hooked identity initialization at server start via `PlayerIdentityService.initialize(...)` in server startup. (`src/main/java/com/hfr/main/MainRegistry.java`)
- Refactored faction identity usage to consult the identity service: membership, permission checks, ownership checks, name updates on login, and faction lookup now resolve per effective mode and reject ambiguous name matches. (`src/main/java/com/hfr/clowder/Clowder.java`, `src/main/java/com/hfr/clowder/ClowderEvents.java`)
- Refactored `FactionCreationCooldownData` to follow the effective identity mode, clean expired entries lazily, and expose a public `ClearResult` API and `clearTarget(...)` / `clearRepresentations(...)` helpers that accept UUIDs, live player names, or offline/cached names and return structured results describing removals and ambiguity. (`src/main/java/com/hfr/clowder/FactionCreationCooldownData.java`)
- Added admin command `/xc clearcreationcooldown <player-or-uuid>` with alias `resetcreationcooldown`, with help text, usage string, tab completion for online names, console support, ambiguity handling, and immediate save on successful clears. The command uses the `FactionCreationCooldownData` public API rather than touching internal maps. (`src/main/java/com/hfr/command/CommandClowderAdmin.java`, `docs/commands.md`)
- Kept UUID-first behavior intact; in `UUID` effective mode name metadata remains display-only and never authorizes actions; in `NAME` mode normalized `lastKnownName` compatibility lookups are used for membership and cooldowns.
- Added deterministic development run-client identity properties: `devUsername` and `devUuid` defaults and wiring into the `runClient` Gradle task so IDE/Gradle development runs can use stable `--username`/`--uuid` without changing production behavior. (`build.gradle`, `gradle.properties`, `README.md`)
- Documentation updates: `docs/configuration.md`, `docs/commands.md`, `README.md`, and `CHANGELOG.md` describing the new config option, `AUTO` resolution rules, security caveats for `NAME`, the `devUsername`/`devUuid` launch defaults, and the new admin command and cooldown JSON shape.

### Testing

- Ran source checks and repository validations such as `git diff --check` and `git status` to confirm changes produce no repository-format warnings; these checks succeeded for edited source files.
- Attempted an offline Gradle compile (`gradle --offline compileJava` / `gradle --offline build`) to exercise Java 8 / Forge 1.7.10 compilation paths; the build progressed to project compilation but ultimately failed due to missing optional development dependencies (HBM-related classes referenced elsewhere in the project) and the absence of the Gradle wrapper in the checkout, not because of the identity or cooldown changes; the newly added identity/cooldown code itself did not introduce reported type errors in the compilation logs derived from the attempted build.
- Verified the Gradle run-task API supports setting a username/UUID for the development launcher (`RunMinecraftTask` introspection) and wired `devUsername`/`devUuid` properties into `runClient` accordingly; documented the launch behavior and overrides in `README.md` and `docs/configuration.md`.
- Tried creating the PR via GitHub CLI in this environment; PR creation did not complete due to missing GitHub authentication in the environment (manual publishing / CI should create the PR). 

If you want, I can split this into smaller commits, adjust help wording, or run additional static checks; run/build validation on a machine with the full development dependencies (HBM jars and a configured Gradle wrapper) will allow a full compile verification and runtime testing of the `AUTO` resolution and `clearcreationcooldown` command end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73ccf3e6fc832399db6ab5bcbee172)