### PR TITLE
Fix relocated City Center territory state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Pull request: fix relocated City Center territory lookup
+
+- Fixed the shifted block-to-chunk conversion mismatch that made relocated City Centers at affected X coordinates look unclaimed, and made territory ownership reads use the same legacy-compatible shifted X/Z rule as claim writes.
+- Verified relocation commit metadata against the faction UUID, stable city ID, dimension, and new flag coordinates before removing the old center, preserving rollback when claim generation is incomplete.
+
 # Pull request: configurable development identity and cooldown administration
 
 - Added centralized `AUTO`/`UUID`/`NAME` faction identity resolution while retaining UUID-secure packaged online production behavior.

--- a/src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
+++ b/src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
@@ -75,7 +75,9 @@ public final class CityCenterRelocationManager {
         if(!(te instanceof TileEntityFlag)) return "The source City Center is invalid.";
         TileEntityFlag flag = (TileEntityFlag)te;
         TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords(player.worldObj, x, z);
-        if(flag.owner != faction || !flag.isClaimed || flag.height < 1F || meta == null || meta.owner == null || meta.owner.owner != faction || !flag.getCityId().equals(meta.cityId))
+        if(!sameFaction(flag.owner, faction) || !flag.isClaimed || flag.height < 1F || meta == null || meta.owner == null
+            || !sameFaction(meta.owner.owner, faction) || !flag.getCityId().equals(meta.cityId)
+            || meta.dimensionId != dim || meta.flagX != x || meta.flagY != y || meta.flagZ != z)
             return "This is not a claimed City Center owned by your faction.";
         return cooldownError(faction, flag.getCityId(), System.currentTimeMillis());
     }
@@ -136,13 +138,14 @@ public final class CityCenterRelocationManager {
         for(int dx=-2; dx<=2; dx++) for(int dz=-2; dz<=2; dz++)
             if(!world.canBlockSeeTheSky(x+dx, y+1, z+dz) || !world.getBlock(x+dx,y-1,z+dz).isSideSolid(world,x+dx,y-1,z+dz,UP)) return "The City Center requires a sky-accessible 5 by 5 foundation.";
         TileEntity oldTe = world.getTileEntity(faction.relocationX, faction.relocationY, faction.relocationZ);
-        if(world.getBlock(faction.relocationX, faction.relocationY, faction.relocationZ) != ModBlocks.clowder_flag || !(oldTe instanceof TileEntityFlag) || ((TileEntityFlag)oldTe).owner != faction || !faction.relocationCityId.equals(((TileEntityFlag)oldTe).getCityId())) return "The source City Center changed; the move cannot continue.";
+        if(world.getBlock(faction.relocationX, faction.relocationY, faction.relocationZ) != ModBlocks.clowder_flag || !(oldTe instanceof TileEntityFlag) || !sameFaction(((TileEntityFlag)oldTe).owner, faction) || !faction.relocationCityId.equals(((TileEntityFlag)oldTe).getCityId())) return "The source City Center changed; the move cannot continue.";
         int radius = ((TileEntityFlag)oldTe).getRadius();
         for(int dx=-radius; dx<=radius; dx++) for(int dz=-radius; dz<=radius; dz++) if(Math.sqrt(dx*dx+dz*dz)<radius) {
             TerritoryMeta meta = ClowderTerritory.getMetaFromCoords(ClowderTerritory.getCoordPair(world, x+dx*16, z+dz*16));
             if(meta != null && !faction.relocationCityId.equals(meta.cityId)) return meta.owner != null && (meta.owner.zone == Zone.SAFEZONE || meta.owner.zone == Zone.WARZONE) ? "The new radius intersects a protected zone." : "The new radius intersects another city or faction claim.";
         }
-        String spacing = ClowderTerritory.getCityPlacementErrorIgnoring(world.provider.dimensionId, x >> 4, z >> 4, faction.relocationCityId);
+        CoordPair center = ClowderTerritory.getCoordPair(world, x, z);
+        String spacing = ClowderTerritory.getCityPlacementErrorIgnoring(world.provider.dimensionId, center.x, center.z, faction.relocationCityId);
         return spacing;
     }
 
@@ -160,6 +163,12 @@ public final class CityCenterRelocationManager {
             faction.addPrestige(-cost, world); charged = true;
             ClowderTerritory.removeClaimsForCityId(world, faction.relocationCityId, false);
             newFlag.generateClaim();
+            TerritoryMeta centerMeta = ClowderTerritory.getMetaFromIntCoords(world, x, z);
+            if(centerMeta == null || centerMeta.owner == null || !sameFaction(centerMeta.owner.owner, faction)
+                || !faction.relocationCityId.equals(centerMeta.cityId) || centerMeta.dimensionId != world.provider.dimensionId
+                || centerMeta.flagX != x || centerMeta.flagY != y || centerMeta.flagZ != z)
+                throw new IllegalStateException("destination claim metadata was not generated");
+            newFlag.markDirty();
             GUARDED_REMOVAL.set(key(world,faction.relocationX,faction.relocationY,faction.relocationZ));
             try { world.setBlockToAir(faction.relocationX,faction.relocationY,faction.relocationZ); } finally { GUARDED_REMOVAL.remove(); }
             moveHomeIfNeeded(faction, oldTerritory, oldHomeX, oldHomeY, oldHomeZ, oldHomeDim, x, y, z, world);
@@ -202,5 +211,8 @@ public final class CityCenterRelocationManager {
     public static boolean isGuardedRemoval(World w,int x,int y,int z){return key(w,x,y,z).equals(GUARDED_REMOVAL.get());}
     private static String key(World w,int x,int y,int z){return System.identityHashCode(w)+":"+w.provider.dimensionId+":"+x+":"+y+":"+z;}
     private static boolean fail(EntityPlayer p,String s){message(p,s);return false;}
+    private static boolean sameFaction(Clowder first, Clowder second) {
+        return first == second || first != null && second != null && first.uuid != null && first.uuid.equals(second.uuid);
+    }
     private static void message(EntityPlayer p,String s){if(p!=null)p.addChatMessage(new ChatComponentText(EnumChatFormatting.RED+s));}
 }

--- a/src/main/java/com/hfr/clowder/ClowderTerritory.java
+++ b/src/main/java/com/hfr/clowder/ClowderTerritory.java
@@ -357,10 +357,7 @@ public class ClowderTerritory {
 	public static Ownership getOwnerFromInts(World world, int x, int z) { return getOwnerFromInts(getDimensionId(world), x, z); }
 
 	public static Ownership getOwnerFromInts(int dimensionId, int x, int z) {
-
-		z += 1;
-		
-		return getOwner(dimensionId, x / 16, z / 16);
+		return getOwnerFromCoords(getCoordPair(dimensionId, x, z));
 	}
 	
 	//returns the ownership information of the chunk
@@ -408,10 +405,7 @@ public class ClowderTerritory {
 	public static TerritoryMeta getMetaFromIntCoords(World world, int x, int z) { return getMetaFromIntCoords(getDimensionId(world), x, z); }
 
 	public static TerritoryMeta getMetaFromIntCoords(int dimensionId, int x, int z) {
-
-		z += 1;
-		
-		return getMetaFromInts(dimensionId, x / 16, z / 16);
+		return getMetaFromCoords(getCoordPair(dimensionId, x, z));
 	}
 	
 	//returns the ownership information of the chunk

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -384,7 +384,8 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 	public void generateClaim() {
 		
 		int rad = Math.min(getRadius(), CityLevel.maxRadius());
-		String placementError = ClowderTerritory.getCityPlacementError(worldObj, xCoord >> 4, zCoord >> 4);
+		CoordPair center = ClowderTerritory.getCoordPair(worldObj, xCoord, zCoord);
+		String placementError = ClowderTerritory.getCityPlacementError(worldObj, center.x, center.z);
 		if(placementError != null && ClowderTerritory.getMetaFromIntCoords(worldObj, xCoord, zCoord) == null)
 			return;
 		

--- a/src/test/java/com/hfr/clowder/ClowderTerritoryCoordinateTest.java
+++ b/src/test/java/com/hfr/clowder/ClowderTerritoryCoordinateTest.java
@@ -1,0 +1,42 @@
+package com.hfr.clowder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.hfr.clowder.ClowderTerritory.CoordPair;
+import com.hfr.clowder.ClowderTerritory.Ownership;
+import com.hfr.clowder.ClowderTerritory.TerritoryMeta;
+import com.hfr.clowder.ClowderTerritory.Zone;
+
+public class ClowderTerritoryCoordinateTest {
+    private static final int[] BLOCK_COORDINATES = {-17, -16, -15, -1, 0, 15, 16, 31};
+    private static final int[] SHIFTED_CHUNKS = {-1, 0, 0, 0, 0, 1, 1, 2};
+
+    @After
+    public void clearTerritories() {
+        ClowderTerritory.territories.clear();
+    }
+
+    @Test
+    public void legacyShiftedConversionIsConsistentOnBothAxes() {
+        for(int xIndex = 0; xIndex < BLOCK_COORDINATES.length; xIndex++) {
+            for(int zIndex = 0; zIndex < BLOCK_COORDINATES.length; zIndex++) {
+                int x = BLOCK_COORDINATES[xIndex];
+                int z = BLOCK_COORDINATES[zIndex];
+                CoordPair pair = ClowderTerritory.getCoordPair(7, x, z);
+                assertEquals(SHIFTED_CHUNKS[xIndex], pair.x);
+                assertEquals(SHIFTED_CHUNKS[zIndex], pair.z);
+
+                Ownership ownership = new Ownership(Zone.SAFEZONE);
+                TerritoryMeta meta = new TerritoryMeta(ownership);
+                ClowderTerritory.territories.put(pair, meta);
+                assertSame(meta, ClowderTerritory.getMetaFromIntCoords(7, x, z));
+                assertSame(ownership, ClowderTerritory.getOwnerFromInts(7, x, z));
+                ClowderTerritory.territories.clear();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- A coordinate-conversion mismatch caused relocated City Centers to appear unclaimed because `getCoordPair` adjusted both X and Z while `getMetaFromIntCoords`/`getOwnerFromInts` only adjusted Z, breaking `CityCenterRelocationManager.validateStart` for some block positions.
- The intent is to make territory reads and writes use one shared legacy-compatible block->chunk rule so relocated flags remain authoritative after moves and across saves.

### Description

- Make territory reads use the same conversion as writes by having `getMetaFromIntCoords` and `getOwnerFromInts` delegate to `getCoordPair` so the legacy shifted X/Z rule is applied consistently (no on-disk format change).  
- Use `getCoordPair(...)` in `TileEntityFlag.generateClaim()` and in relocation spacing checks so claim generation and validation use identical chunk coordinates.  
- Strengthen relocation validation in `CityCenterRelocationManager.validateStart` to compare faction identity via a new `sameFaction` helper (UUID-aware), require `TerritoryMeta.dimensionId/flagX/flagY/flagZ` to match the source, and require `cityId` equality.  
- Make the relocation commit verify that the destination chunk metadata was actually generated for the correct faction, stable `cityId`, dimension, and flag coordinates before removing the old flag, and mark the new flag dirty; keep the existing atomic rollback behavior.  
- Add a focused unit test `ClowderTerritoryCoordinateTest` that exercises negative, positive, and chunk-edge block coordinates (the 64 X/Z combinations requested) to assert the legacy shifted conversion is consistent for both axes.  
- Document the fix in `CHANGELOG.md` and commit as `Fix relocated City Center territory state` while preserving stable city IDs, ownership checks, and existing relocation semantics.

### Testing

- Ran `git diff --check` and `git diff --cached --check` which reported no index issues after the change.  
- Executed a focused Python validation that checked the legacy shifted conversion for all 64 requested X/Z coordinate combinations and succeeded.  
- Added `src/test/java/com/hfr/clowder/ClowderTerritoryCoordinateTest.java` to exercise the conversion and territory lookup behavior (the test file was added but full Gradle/JUnit execution was not run here).  
- Did not run `./gradlew build` or start a Forge 1.7.10 development server per the instruction not to compile or produce binaries; those runtime integration checks are still recommended before merging to verify relocation behavior across save/load and chunk reloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73d23c650c8323a55d0ac8a517d643)