### PR TITLE
Keep relocated City Centers valid for later moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Pull request: keep relocated City Centers valid for later moves
+
+- Fixed relocated City Centers becoming invalid when a restored tile retained a non-canonical faction object and territory persistence compared that owner by Java object identity, which could remove the destination claim metadata after a tile tick or persistence pass.
+- Relocation now restores the canonical tile owner without faction-accounting side effects, rebuilds all claims by the stable city ID, verifies destination metadata before and after old-block removal, and permits another valid relocation while retaining strict UUID, city ID, and coordinate checks.
+
 # Pull request: prevent relocated City Center GUI crashes
 
 - Changed the slotless City Center interface into an informational screen so opening it no longer replaces the player's active inventory container or crashes after relocation.

--- a/src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
+++ b/src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
@@ -75,12 +75,62 @@ public final class CityCenterRelocationManager {
         TileEntity te = player.worldObj.getTileEntity(x, y, z);
         if(!(te instanceof TileEntityFlag)) return "The source City Center is invalid.";
         TileEntityFlag flag = (TileEntityFlag)te;
-        TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords(player.worldObj, x, z);
-        if(!sameFaction(flag.owner, faction) || !flag.isClaimed || flag.height < 1F || meta == null || meta.owner == null
-            || !sameFaction(meta.owner.owner, faction) || !flag.getCityId().equals(meta.cityId)
-            || meta.dimensionId != dim || meta.flagX != x || meta.flagY != y || meta.flagZ != z)
+        String invalidReason = getInvalidCityCenterReason(player.worldObj, faction, dim, x, y, z, flag);
+        if(invalidReason != null && isAuthoritativeRelocatedTile(faction, flag)
+            && repairRelocatedMetadata(player.worldObj, faction, flag, x, y, z)) {
+            invalidReason = getInvalidCityCenterReason(player.worldObj, faction, dim, x, y, z, flag);
+            if(invalidReason == null)
+                com.hfr.main.MainRegistry.logger.info("Repaired stale relocated City Center state for city " + flag.getCityId() + ".");
+        }
+        if(invalidReason != null) {
+            com.hfr.main.MainRegistry.logger.warn("Rejected City Center relocation at " + dim + ":" + x + "," + y + "," + z + ": " + invalidReason);
             return "This is not a claimed City Center owned by your faction.";
+        }
         return cooldownError(faction, flag.getCityId(), System.currentTimeMillis());
+    }
+
+    static String getInvalidCityCenterReason(World world, Clowder faction, int dim, int x, int y, int z, TileEntityFlag flag) {
+        if(world.getBlock(x, y, z) != ModBlocks.clowder_flag) return "block is not a City Center";
+        if(flag == null) return "tile is not a City Center tile";
+        if(!Clowder.sameFaction(flag.owner, faction)) return "tile faction UUID differs";
+        if(!flag.isClaimed) return "tile is not claimed";
+        if(flag.height < 1F) return "tile flag is lowered";
+        String cityId = flag.getCityId();
+        if(cityId == null || cityId.isEmpty()) return "tile stable city ID is empty";
+        TerritoryMeta meta = ClowderTerritory.getMetaFromIntCoords(world, x, z);
+        return getMetadataInvalidReason(faction, dim, x, y, z, cityId, meta);
+    }
+
+    static String getMetadataInvalidReason(Clowder faction, int dim, int x, int y, int z, String cityId, TerritoryMeta meta) {
+        if(meta == null) return "center territory metadata is missing";
+        if(meta.owner == null || meta.owner.owner == null) return "center territory owner is missing";
+        if(!Clowder.sameFaction(meta.owner.owner, faction)) return "metadata faction UUID differs";
+        if(!cityId.equals(meta.cityId)) return "metadata stable city ID differs";
+        if(meta.dimensionId != dim) return "metadata dimension differs";
+        if(meta.flagX != x) return "metadata flag X differs";
+        if(meta.flagY != y) return "metadata flag Y differs";
+        if(meta.flagZ != z) return "metadata flag Z differs";
+        return null;
+    }
+
+    private static boolean isAuthoritativeRelocatedTile(Clowder faction, TileEntityFlag flag) {
+        return flag != null && Clowder.sameFaction(flag.owner, faction) && flag.isClaimed && flag.height >= 1F
+            && flag.getCityId() != null && !flag.getCityId().isEmpty();
+    }
+
+    private static boolean repairRelocatedMetadata(World world, Clowder faction, TileEntityFlag flag, int x, int y, int z) {
+        TerritoryMeta center = ClowderTerritory.getMetaFromIntCoords(world, x, z);
+        if(center != null && center.cityId != null && !center.cityId.isEmpty() && !flag.getCityId().equals(center.cityId)) return false;
+        for(TerritoryMeta meta : ClowderTerritory.territories.values()) {
+            if(meta != null && meta.dimensionId == world.provider.dimensionId && meta.flagX == x && meta.flagY == y && meta.flagZ == z
+                && meta.cityId != null && !meta.cityId.isEmpty() && !flag.getCityId().equals(meta.cityId)) return false;
+        }
+        try {
+            ClowderTerritory.rebuildRelocatedCityClaims(world, flag, faction, flag.getCityId());
+            return true;
+        } catch(RuntimeException conflict) {
+            return false;
+        }
     }
 
     public static boolean start(EntityPlayerMP player, int dim, int x, int y, int z) {
@@ -141,7 +191,7 @@ public final class CityCenterRelocationManager {
         for(int dx=-2; dx<=2; dx++) for(int dz=-2; dz<=2; dz++)
             if(!world.canBlockSeeTheSky(x+dx, y+1, z+dz) || !world.getBlock(x+dx,y-1,z+dz).isSideSolid(world,x+dx,y-1,z+dz,UP)) return "The City Center requires a sky-accessible 5 by 5 foundation.";
         TileEntity oldTe = world.getTileEntity(faction.relocationX, faction.relocationY, faction.relocationZ);
-        if(world.getBlock(faction.relocationX, faction.relocationY, faction.relocationZ) != ModBlocks.clowder_flag || !(oldTe instanceof TileEntityFlag) || !sameFaction(((TileEntityFlag)oldTe).owner, faction) || !faction.relocationCityId.equals(((TileEntityFlag)oldTe).getCityId())) return "The source City Center changed; the move cannot continue.";
+        if(world.getBlock(faction.relocationX, faction.relocationY, faction.relocationZ) != ModBlocks.clowder_flag || !(oldTe instanceof TileEntityFlag) || !Clowder.sameFaction(((TileEntityFlag)oldTe).owner, faction) || !faction.relocationCityId.equals(((TileEntityFlag)oldTe).getCityId())) return "The source City Center changed; the move cannot continue.";
         int radius = ((TileEntityFlag)oldTe).getRadius();
         for(int dx=-radius; dx<=radius; dx++) for(int dz=-radius; dz<=radius; dz++) if(Math.sqrt(dx*dx+dz*dz)<radius) {
             TerritoryMeta meta = ClowderTerritory.getMetaFromCoords(ClowderTerritory.getCoordPair(world, x+dx*16, z+dz*16));
@@ -162,20 +212,17 @@ public final class CityCenterRelocationManager {
             if(!world.setBlock(x, y, z, ModBlocks.clowder_flag, world.getBlockMetadata(faction.relocationX, faction.relocationY, faction.relocationZ), 3)) throw new IllegalStateException("destination could not be placed");
             TileEntity te = world.getTileEntity(x,y,z); if(!(te instanceof TileEntityFlag)) throw new IllegalStateException("destination tile missing");
             saved.setInteger("x", x); saved.setInteger("y", y); saved.setInteger("z", z);
-            TileEntityFlag newFlag=(TileEntityFlag)te; newFlag.readFromNBT(saved); newFlag.setCityId(faction.relocationCityId); newFlag.markDirty();
+            TileEntityFlag newFlag=(TileEntityFlag)te; newFlag.readFromNBT(saved); newFlag.restoreRelocationOwner(faction); newFlag.setCityId(faction.relocationCityId); newFlag.markDirty(); world.markBlockForUpdate(x, y, z);
             faction.addPrestige(-cost, world); charged = true;
-            ClowderTerritory.removeClaimsForCityId(world, faction.relocationCityId, false);
-            newFlag.generateClaim();
-            TerritoryMeta centerMeta = ClowderTerritory.getMetaFromIntCoords(world, x, z);
-            if(centerMeta == null || centerMeta.owner == null || !sameFaction(centerMeta.owner.owner, faction)
-                || !faction.relocationCityId.equals(centerMeta.cityId) || centerMeta.dimensionId != world.provider.dimensionId
-                || centerMeta.flagX != x || centerMeta.flagY != y || centerMeta.flagZ != z)
-                throw new IllegalStateException("destination claim metadata was not generated");
+            ClowderTerritory.rebuildRelocatedCityClaims(world, newFlag, faction, faction.relocationCityId);
+            requireValidDestination(world, faction, newFlag, x, y, z, "before old City Center removal");
             newFlag.markDirty();
             GUARDED_REMOVAL.set(key(world,faction.relocationX,faction.relocationY,faction.relocationZ));
             try { world.setBlockToAir(faction.relocationX,faction.relocationY,faction.relocationZ); } finally { GUARDED_REMOVAL.remove(); }
+            requireValidDestination(world, faction, newFlag, x, y, z, "after old City Center removal");
             moveHomeIfNeeded(faction, oldTerritory, oldHomeX, oldHomeY, oldHomeZ, oldHomeDim, x, y, z, world);
             ClowderData.getData(world).markDirty(); com.hfr.dynmap.XFDynmapIntegration.markDirty();
+            requireValidDestination(world, faction, newFlag, x, y, z, "after relocation state changes");
             if(!consumeAuthorizedToken(player, tokenSlot, faction)) throw new IllegalStateException("authorized relocation token changed");
             recordSuccess(faction, faction.relocationCityId, System.currentTimeMillis());
             clear(faction, world);
@@ -186,11 +233,20 @@ public final class CityCenterRelocationManager {
             if(world.getBlock(x,y,z)==ModBlocks.clowder_flag) { GUARDED_REMOVAL.set(key(world,x,y,z)); try { world.setBlockToAir(x,y,z); } finally { GUARDED_REMOVAL.remove(); } }
             ClowderTerritory.territories.clear(); ClowderTerritory.territories.putAll(oldTerritory);
             if(world.getBlock(faction.relocationX,faction.relocationY,faction.relocationZ)!=ModBlocks.clowder_flag) world.setBlock(faction.relocationX,faction.relocationY,faction.relocationZ,ModBlocks.clowder_flag);
-            TileEntity restored=world.getTileEntity(faction.relocationX,faction.relocationY,faction.relocationZ); if(restored instanceof TileEntityFlag) ((TileEntityFlag)restored).readFromNBT(saved);
+            TileEntity restored=world.getTileEntity(faction.relocationX,faction.relocationY,faction.relocationZ); if(restored instanceof TileEntityFlag) { ((TileEntityFlag)restored).readFromNBT(saved); ((TileEntityFlag)restored).restoreRelocationOwner(faction); }
             faction.homeX=oldHomeX; faction.homeY=oldHomeY; faction.homeZ=oldHomeZ; faction.homeDim=oldHomeDim; faction.homeSet=oldHomeSet;
             faction.save(world); ClowderData.getData(world).markDirty();
             return fail(player, "The relocation failed and the original city was restored.");
         }
+    }
+
+    private static void requireValidDestination(World world, Clowder faction, TileEntityFlag flag, int x, int y, int z, String phase) {
+        TileEntity current = world.getTileEntity(x, y, z);
+        String reason = current instanceof TileEntityFlag
+            ? getInvalidCityCenterReason(world, faction, world.provider.dimensionId, x, y, z, (TileEntityFlag)current)
+            : "destination tile is missing";
+        if(reason != null || current != flag)
+            throw new IllegalStateException(phase + ": " + (reason == null ? "destination tile instance changed" : reason));
     }
 
     private static void moveHomeIfNeeded(Clowder f, Map<CoordPair,TerritoryMeta> oldClaims, int hx,int hy,int hz,int hd,int nx,int ny,int nz,World world) {
@@ -244,8 +300,5 @@ public final class CityCenterRelocationManager {
     public static boolean isGuardedRemoval(World w,int x,int y,int z){return key(w,x,y,z).equals(GUARDED_REMOVAL.get());}
     private static String key(World w,int x,int y,int z){return System.identityHashCode(w)+":"+w.provider.dimensionId+":"+x+":"+y+":"+z;}
     private static boolean fail(EntityPlayer p,String s){message(p,s);return false;}
-    private static boolean sameFaction(Clowder first, Clowder second) {
-        return first == second || first != null && second != null && first.uuid != null && first.uuid.equals(second.uuid);
-    }
     private static void message(EntityPlayer p,String s){if(p!=null)p.addChatMessage(new ChatComponentText(EnumChatFormatting.RED+s));}
 }

--- a/src/main/java/com/hfr/clowder/Clowder.java
+++ b/src/main/java/com/hfr/clowder/Clowder.java
@@ -42,6 +42,16 @@ import net.minecraftforge.common.util.ForgeDirection;
 //but with cats!
 public class Clowder {
 
+	/** Stable faction comparison for persisted gameplay state. */
+	public static boolean sameFaction(Clowder first, Clowder second) {
+		if(first == second)
+			return true;
+		return first != null && second != null
+				&& first.uuid != null && !first.uuid.isEmpty()
+				&& second.uuid != null && !second.uuid.isEmpty()
+				&& first.uuid.equals(second.uuid);
+	}
+
 	public HashMap<Clowder, Long> potentialMerges = new HashMap<>();
 
 	public static HashSet<Integer> colours = new HashSet<Integer>();

--- a/src/main/java/com/hfr/clowder/ClowderTerritory.java
+++ b/src/main/java/com/hfr/clowder/ClowderTerritory.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import com.hfr.blocks.ModBlocks;
 import com.hfr.config.XFConfig;
 import com.hfr.data.ClowderData;
 import com.hfr.main.MainRegistry;
@@ -87,7 +88,7 @@ public class ClowderTerritory {
 	public static List<TerritoryMeta> getCityClaims(Clowder owner) {
 		HashMap<String, TerritoryMeta> cities = new HashMap();
 		for(TerritoryMeta meta : territories.values()) {
-			if(meta != null && meta.owner != null && meta.owner.zone == Zone.FACTION && meta.owner.owner == owner && meta.isCityClaim()) {
+			if(meta != null && meta.owner != null && meta.owner.zone == Zone.FACTION && Clowder.sameFaction(meta.owner.owner, owner) && meta.isCityClaim()) {
 				refreshCityMetaFromTile(meta);
 				TerritoryMeta existing = cities.get(meta.cityId);
 				if(existing == null || meta.cityLevel > existing.cityLevel || (meta.flagX == existing.flagX && meta.flagY == existing.flagY && meta.flagZ == existing.flagZ))
@@ -196,6 +197,39 @@ public class ClowderTerritory {
 		if(removed > 0)
 		com.hfr.dynmap.XFDynmapIntegration.markDirty();
 		return removed;
+	}
+
+	/** Replaces all claims for one stable city with the relocated flag's complete claim set. */
+	public static void rebuildRelocatedCityClaims(World world, TileEntityFlag flag, Clowder owner, String stableCityId) {
+		if(world == null || flag == null || owner == null || stableCityId == null || stableCityId.isEmpty())
+			throw new IllegalArgumentException("invalid relocated city state");
+		int radius = Math.min(flag.getRadius(), CityLevel.maxRadius());
+		for(int x = -radius; x <= radius; x++) {
+			for(int z = -radius; z <= radius; z++) {
+				if(Math.sqrt(x * x + z * z) >= radius)
+					continue;
+				TerritoryMeta existing = territories.get(getCoordPair(world, flag.xCoord + x * 16, flag.zCoord + z * 16));
+				if(existing != null && !stableCityId.equals(existing.cityId))
+					throw new IllegalStateException("relocated city claim conflicts with another city");
+			}
+		}
+		removeClaimsForCityId(world, stableCityId, false);
+		for(int x = -radius; x <= radius; x++) {
+			for(int z = -radius; z <= radius; z++) {
+				if(Math.sqrt(x * x + z * z) >= radius)
+					continue;
+				CoordPair claim = getCoordPair(world, flag.xCoord + x * 16, flag.zCoord + z * 16);
+				setOwnerForCoord(world, claim, owner, flag.xCoord, flag.yCoord, flag.zCoord, flag.name, stableCityId);
+				TerritoryMeta meta = territories.get(claim);
+				meta.cityName = flag.name;
+				meta.cityLevel = flag.cityLevel.ordinal();
+			}
+		}
+		CoordPair center = getCoordPair(world, flag.xCoord, flag.zCoord);
+		if(!territories.containsKey(center))
+			throw new IllegalStateException("relocated city center claim was not generated");
+		ClowderData.getData(world).markDirty();
+		com.hfr.dynmap.XFDynmapIntegration.markDirty();
 	}
 
 	public static int transferCity(World world, TerritoryMeta city, Clowder newOwner) {
@@ -723,7 +757,10 @@ public class ClowderTerritory {
 					
 					double dist = Math.sqrt(Math.pow(origin.x - claim.x, 2) + Math.pow(origin.z - claim.z, 2));
 					
-					if(flag.getOwner() != own) {
+					if(flag instanceof TileEntityFlag && (world.getBlock(flagX, flagY, flagZ) != ModBlocks.clowder_flag
+							|| cityId == null || cityId.isEmpty() || !cityId.equals(((TileEntityFlag)flag).getCityId()))) {
+						return false;
+					} else if(!Clowder.sameFaction(flag.getOwner(), own)) {
 						return false;
 					} else if(dist >= r) {
 						

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -322,6 +322,13 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 		
 		this.markDirty();
 	}
+
+	/** Restores the canonical owner during relocation without capture/transfer accounting. */
+	public void restoreRelocationOwner(Clowder c) {
+		owner = c;
+		ownerName = c == null ? "" : c.name;
+		markDirty();
+	}
 	
 	public void setMode(int mode) {
 		// City Centers always use the current city level for radius/upkeep.

--- a/src/test/java/com/hfr/clowder/CityCenterRelocationValidationTest.java
+++ b/src/test/java/com/hfr/clowder/CityCenterRelocationValidationTest.java
@@ -1,0 +1,56 @@
+package com.hfr.clowder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.hfr.clowder.ClowderTerritory.Ownership;
+import com.hfr.clowder.ClowderTerritory.TerritoryMeta;
+import com.hfr.clowder.ClowderTerritory.Zone;
+
+public class CityCenterRelocationValidationTest {
+    @Test
+    public void stableFactionComparisonUsesNonEmptyUuid() {
+        Clowder canonical = faction("same");
+        Clowder reloaded = faction("same");
+        assertTrue(Clowder.sameFaction(canonical, canonical));
+        assertTrue(Clowder.sameFaction(canonical, reloaded));
+        assertFalse(Clowder.sameFaction(canonical, faction("different")));
+        assertFalse(Clowder.sameFaction(canonical, faction("")));
+    }
+
+    @Test
+    public void metadataValidationReportsExactFailedCondition() {
+        Clowder canonical = faction("faction-id");
+        TerritoryMeta meta = metadata(faction("faction-id"), "city-id", 7, -17, 70, 31);
+        assertNull(CityCenterRelocationManager.getMetadataInvalidReason(canonical, 7, -17, 70, 31, "city-id", meta));
+
+        meta.flagX = -16;
+        assertEquals("metadata flag X differs",
+            CityCenterRelocationManager.getMetadataInvalidReason(canonical, 7, -17, 70, 31, "city-id", meta));
+        meta.flagX = -17;
+        meta.owner = new Ownership(Zone.FACTION, faction("other-faction"));
+        assertEquals("metadata faction UUID differs",
+            CityCenterRelocationManager.getMetadataInvalidReason(canonical, 7, -17, 70, 31, "city-id", meta));
+        meta.owner = new Ownership(Zone.FACTION, faction("faction-id"));
+        meta.cityId = "other-city";
+        assertEquals("metadata stable city ID differs",
+            CityCenterRelocationManager.getMetadataInvalidReason(canonical, 7, -17, 70, 31, "city-id", meta));
+    }
+
+    private static Clowder faction(String uuid) {
+        Clowder faction = new Clowder();
+        faction.uuid = uuid;
+        return faction;
+    }
+
+    private static TerritoryMeta metadata(Clowder faction, String cityId, int dim, int x, int y, int z) {
+        TerritoryMeta meta = new TerritoryMeta(new Ownership(Zone.FACTION, faction), x, y, z);
+        meta.dimensionId = dim;
+        meta.cityId = cityId;
+        return meta;
+    }
+}

--- a/src/test/java/com/hfr/clowder/ClowderTerritoryCoordinateTest.java
+++ b/src/test/java/com/hfr/clowder/ClowderTerritoryCoordinateTest.java
@@ -12,8 +12,8 @@ import com.hfr.clowder.ClowderTerritory.TerritoryMeta;
 import com.hfr.clowder.ClowderTerritory.Zone;
 
 public class ClowderTerritoryCoordinateTest {
-    private static final int[] BLOCK_COORDINATES = {-17, -16, -15, -1, 0, 15, 16, 31};
-    private static final int[] SHIFTED_CHUNKS = {-1, 0, 0, 0, 0, 1, 1, 2};
+    private static final int[] BLOCK_COORDINATES = {-17, -16, -15, -2, -1, 0, 15, 16, 31};
+    private static final int[] SHIFTED_CHUNKS = {-1, 0, 0, 0, 0, 0, 1, 1, 2};
 
     @After
     public void clearTerritories() {


### PR DESCRIPTION
### Motivation

- Relocated City Centers could become invalid immediately after a relocation because territory persistence and validation compared in-memory faction objects by identity instead of stable UUIDs, causing the server to reject subsequent break/relocation attempts with "This is not a claimed City Center owned by your faction.".
- The relocation transaction validated destination metadata too early and restored the tile owner using the potentially non-canonical faction instance saved in NBT, which could be overwritten or removed by persistence passes or tile ticks.

### Description

- Added a stable faction comparison helper `Clowder.sameFaction(Clowder,Clowder)` that uses object identity as a fast path and otherwise compares non-empty faction UUIDs to treat same-UUID instances as the same faction. (`src/main/java/com/hfr/clowder/Clowder.java`)
- Introduced a relocation-safe owner restore `TileEntityFlag.restoreRelocationOwner(Clowder)` that assigns the canonical faction owner without applying capture/transfer side effects. (`src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java`)
- Implemented a claim-rebuild server operation `ClowderTerritory.rebuildRelocatedCityClaims(World, TileEntityFlag, Clowder, String)` which preflights for conflicts, removes old claims by the stable `cityId`, and writes a complete, canonical destination claim set with updated dimension and flag coordinates. (`src/main/java/com/hfr/clowder/ClowderTerritory.java`)
- Hardened persistence and city-claim checks to use `Clowder.sameFaction` and explicit `cityId`/block existence checks so a relocated canonical tile is not removed due to differing Java instances. (`src/main/java/com/hfr/clowder/ClowderTerritory.java`)
- Reworked relocation validation and commit ordering in `CityCenterRelocationManager`: split the compound check into `getInvalidCityCenterReason(...)`, added a narrow repair path that rebuilds metadata only when the destination tile is authoritative, and added `requireValidDestination(...)` checks before old-block removal, after removal, and after relocation state changes; restored the canonical owner into the relocated tile before rebuilding claims. (`src/main/java/com/hfr/clowder/CityCenterRelocationManager.java`)
- Preserved the previously introduced GUI crash fix and token synchronization/consumption semantics while making relocation atomic and safely roll-backable when validation fails. (`src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java`, `src/main/java/com/hfr/clowder/CityCenterRelocationManager.java`)
- Added focused unit tests `CityCenterRelocationValidationTest` that assert UUID-based faction equality semantics and that `getMetadataInvalidReason` reports the exact failing condition, and extended the coordinate-shift coverage in `ClowderTerritoryCoordinateTest`. (`src/test/java/com/hfr/clowder/CityCenterRelocationValidationTest.java`, `src/test/java/com/hfr/clowder/ClowderTerritoryCoordinateTest.java`)
- Added a concise `CHANGELOG.md` entry describing the root cause and the repair made. (`CHANGELOG.md`)

### Testing

- Ran repository checks: `git diff --check` and a file-type safety scan for binary assets, both succeeded in this development environment. 
- Performed working-tree validation and staged a single change commit locally; repository status checks passed in the local workspace. 
- Added unit tests (`CityCenterRelocationValidationTest`) and updated `ClowderTerritoryCoordinateTest`, but did not run `./gradlew build` or `./gradlew test` because compiling/running Java bytecode was intentionally avoided in this session. 
- Runtime verification (integrated Forge 1.7.10 server relocation lifecycle, chunk unload/reload, world save/restart, and GUI behavior) was not executed here and should be run as described in the issue reproduction steps before merging to fully validate behavior on a live server.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73d6ddba108323a9a84e1899207f76)