### PR TITLE
Allow breaking orphaned City Centers without starting relocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Pull request: remove orphaned City Centers safely
+
+- Orphaned City Centers left behind by disbanded factions can now be broken and removed without dropping a City Center item or starting relocation.
+
 # Pull request: prevent relocated City Center GUI crashes
 
 - Changed the slotless City Center interface into an informational screen so opening it no longer replaces the player's active inventory container or crashes after relocation.

--- a/src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
+++ b/src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
@@ -41,6 +41,30 @@ public final class CityCenterRelocationManager {
     public static void schedule(Runnable task) { if(task != null) SERVER_TASKS.add(task); }
     public static void runScheduledTasks() { Runnable task; while((task = SERVER_TASKS.poll()) != null) task.run(); }
 
+    /**
+     * Returns whether a City Center has lost its faction. This is deliberately
+     * based on the registered faction list rather than names, so it also handles
+     * stale tile references left by disbanding and null references restored from
+     * old saves.
+     */
+    public static boolean isOrphaned(TileEntityFlag flag) {
+        return flag != null && !isLiveFactionOwner(flag.owner, Clowder.clowders);
+    }
+
+    static boolean isLiveFactionOwner(Clowder owner, Iterable<Clowder> registeredFactions) {
+        if(owner == null || registeredFactions == null) return false;
+        String ownerUuid = normalizedUuid(owner.uuid);
+        for(Clowder registered : registeredFactions) {
+            if(registered == owner) return true;
+            if(registered != null && !ownerUuid.isEmpty() && ownerUuid.equals(normalizedUuid(registered.uuid))) return true;
+        }
+        return false;
+    }
+
+    private static String normalizedUuid(String uuid) {
+        return uuid == null ? "" : uuid.trim();
+    }
+
     public static double horizontalDistance(int x1, int z1, int x2, int z2) {
         long dx = (long)x2 - x1, dz = (long)z2 - z1;
         return Math.sqrt(dx * dx + dz * dz);

--- a/src/main/java/com/hfr/clowder/ClowderEvents.java
+++ b/src/main/java/com/hfr/clowder/ClowderEvents.java
@@ -314,11 +314,17 @@ public void handleChatServer(ServerChatEvent event) {
 				EntityPlayer player = ((BreakEvent)event).getPlayer();
 				Clowder clowder = Clowder.getClowderFromPlayer(player);
 				if(b == ModBlocks.clowder_flag && !player.inventory.hasItem(ModItems.debug)) {
+					TileEntity te = event.world.getTileEntity(x, y, z);
+					if(!event.world.isRemote && te instanceof TileEntityFlag && CityCenterRelocationManager.isOrphaned((TileEntityFlag)te)) {
+						event.setCanceled(true);
+						// The false argument suppresses harvesting while func_147480_a still invokes Flag.breakBlock.
+						event.world.func_147480_a(x, y, z, false);
+						return;
+					}
 					event.setCanceled(true);
 					String relocationError = CityCenterRelocationManager.validateStart(player, event.world.provider.dimensionId, x, y, z);
 					if(relocationError != null) player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + relocationError));
 					else if(player instanceof net.minecraft.entity.player.EntityPlayerMP) {
-						TileEntity te = event.world.getTileEntity(x, y, z);
 						String cityName = te instanceof TileEntityFlag ? ((TileEntityFlag)te).name : "City";
 						PacketDispatcher.wrapper.sendTo(new CityRelocationGuiPacket(event.world.provider.dimensionId, x, y, z, cityName), (net.minecraft.entity.player.EntityPlayerMP)player);
 					} else player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Unable to open relocation confirmation."));

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import com.hfr.clowder.Clowder;
 import com.hfr.clowder.ClowderFlag;
 import com.hfr.clowder.CityLevel;
+import com.hfr.clowder.CityCenterRelocationManager;
 import com.hfr.config.XFConfig;
 import com.hfr.clowder.ClowderTerritory;
 import com.hfr.clowder.ClowderTerritory.CoordPair;
@@ -96,7 +97,7 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 		if(!worldObj.isRemote) {
 			
 			//remove disbanded clowders
-			if(!Clowder.clowders.contains(owner) && owner != null) {
+			if(owner != null && CityCenterRelocationManager.isOrphaned(this)) {
 				MainRegistry.logger.info("Deleting clowder from flag " + xCoord + " " + yCoord + " " + zCoord + " due to clowder not being in the clowder list! (disband?)");
 				owner = null;
 			}

--- a/src/test/java/com/hfr/clowder/CityCenterRelocationRulesTest.java
+++ b/src/test/java/com/hfr/clowder/CityCenterRelocationRulesTest.java
@@ -5,12 +5,42 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.Test;
 
 import com.hfr.config.XFConfig;
+import com.hfr.tileentity.clowder.TileEntityFlag;
 
 public class CityCenterRelocationRulesTest {
+    @Test
+    public void nullAndUnregisteredOwnersAreOrphaned() {
+        assertEquals(true, CityCenterRelocationManager.isOrphaned(new TileEntityFlag()));
+        assertEquals(false, CityCenterRelocationManager.isLiveFactionOwner(null, Collections.<Clowder>emptyList()));
+        Clowder owner=new Clowder(); owner.uuid="owner-id";
+        assertEquals(false, CityCenterRelocationManager.isLiveFactionOwner(owner, Collections.<Clowder>emptyList()));
+    }
+
+    @Test
+    public void registeredInstanceIsLiveEvenWithoutUuid() {
+        Clowder owner=new Clowder(); owner.uuid=null;
+        assertEquals(true, CityCenterRelocationManager.isLiveFactionOwner(owner, Arrays.asList(owner)));
+        owner.uuid="";
+        assertEquals(true, CityCenterRelocationManager.isLiveFactionOwner(owner, Arrays.asList(owner)));
+    }
+
+    @Test
+    public void equivalentRegisteredUuidIsLiveButEmptyUuidsDoNotMatch() {
+        Clowder owner=new Clowder(), reloaded=new Clowder();
+        owner.uuid="faction-id"; reloaded.uuid="faction-id";
+        assertEquals(true, CityCenterRelocationManager.isLiveFactionOwner(owner, Arrays.asList(reloaded)));
+        owner.uuid=null; reloaded.uuid=null;
+        assertEquals(false, CityCenterRelocationManager.isLiveFactionOwner(owner, Arrays.asList(reloaded)));
+        owner.uuid=""; reloaded.uuid="";
+        assertEquals(false, CityCenterRelocationManager.isLiveFactionOwner(owner, Arrays.asList(reloaded)));
+    }
+
     @Test
     public void prestigeUsesHorizontalDistanceAndConfiguredFreeAllowance() {
         float oldBase=XFConfig.cityRelocationBasePrestigeCost, oldRate=XFConfig.cityRelocationPrestigePerExtraBlock;


### PR DESCRIPTION
### Motivation

- Fix a bug where a City Center left after a faction disband could not be removed because `ClowderEvents.clowderBlockEvent` intercepted the break and always ran relocation validation, which returned an owner-only error when the tile referenced a disbanded (stale or null) faction. 
- The code change makes orphan detection the server-side source of truth so flags whose `TileEntityFlag.owner` is null or no longer registered in `Clowder.clowders` are treated as orphaned and removable without triggering relocation logic.

### Description

- Add `CityCenterRelocationManager.isOrphaned` and `isLiveFactionOwner` so ownership is considered live only when the same registered instance remains or a registered faction has the same non-empty UUID, and handle null/empty UUIDs safely. (Updated `src/main/java/com/hfr/clowder/CityCenterRelocationManager.java`.)
- Short-circuit the relocation confirmation path in `ClowderEvents.clowderBlockEvent` by checking for orphans first and, when orphaned, cancel the normal `BreakEvent` handling and call `world.func_147480_a(x, y, z, false)` to destroy the block server-side without drops or creating relocation state. (Updated `src/main/java/com/hfr/clowder/ClowderEvents.java`.)
- Make `TileEntityFlag.updateEntity` use the same orphan detection to clear stale owners restored from saves or left after disbanding, preventing stale owner logic from reaching relocation validation. (Updated `src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java`.)
- Add focused regression tests that assert null owners, unregistered instances, registered instances, and equivalent UUID matches are classified correctly, and add a changelog entry describing the behavioral change. (Updated `src/test/java/com/hfr/clowder/CityCenterRelocationRulesTest.java` and `CHANGELOG.md`.)

### Testing

- `git diff --check` was run and passed successfully. 
- `git status --short --branch` confirmed the changes were committed as `Fix orphaned City Center removal`. 
- Attempting `./gradlew test` and `./gradlew build` could not run in this environment because the repository root does not contain a runnable Gradle wrapper, so full project tests/build were not executed here. 
- Forge 1.7.10 manual server verification was not performed in this non-interactive environment and should be performed following the manual verification steps in the task description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73e4a5632883238ae0f0389a4f3f8f)