### PR TITLE
Rebuild city territory after City Center relocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Pull request: rebuild territory after City Center relocation
+
+- City Center relocation now rebuilds the city's circular territory around the destination and removes stale territory around the old center.
+
 # Pull request: remove orphaned City Centers safely
 
 - Orphaned City Centers left behind by disbanded factions can now be broken and removed without dropping a City Center item or starting relocation.

--- a/src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
+++ b/src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
@@ -188,8 +188,13 @@ public final class CityCenterRelocationManager {
     private static boolean commit(EntityPlayerMP player, int tokenSlot, Clowder faction, World world, int x, int y, int z, float cost) {
         TileEntityFlag oldFlag = (TileEntityFlag)world.getTileEntity(faction.relocationX, faction.relocationY, faction.relocationZ);
         NBTTagCompound saved = new NBTTagCompound(); oldFlag.writeToNBT(saved);
+        int oldBlockMetadata = world.getBlockMetadata(faction.relocationX, faction.relocationY, faction.relocationZ);
         Map<CoordPair, TerritoryMeta> oldTerritory = copyTerritory();
         int oldHomeX=faction.homeX, oldHomeY=faction.homeY, oldHomeZ=faction.homeZ, oldHomeDim=faction.homeDim; boolean oldHomeSet=faction.homeSet;
+        String oldRelocationId=faction.relocationId, oldRelocationCityId=faction.relocationCityId;
+        long oldRelocationStarted=faction.relocationStarted, oldRelocationExpires=faction.relocationExpires;
+        List<Long> oldHistory=faction.cityRelocationHistory.get(oldRelocationCityId);
+        oldHistory=oldHistory == null ? null : new ArrayList<Long>(oldHistory);
         ItemStack savedToken = player.inventory.mainInventory[tokenSlot].copy();
         boolean charged = false, consumed = false; String phase = "placing destination";
         try {
@@ -200,13 +205,16 @@ public final class CityCenterRelocationManager {
             phase = "restoring destination tile";
             TileEntityFlag newFlag=(TileEntityFlag)te; newFlag.readFromNBT(destinationNbt); newFlag.setCityId(faction.relocationCityId);
             newFlag.restoreOwnerForRelocation(faction); newFlag.markDirty(); world.markBlockForUpdate(x, y, z);
-            phase = "updating city metadata";
-            updateMovedCityClaims(faction, faction.relocationCityId, world.provider.dimensionId, x, y, z, newFlag.name, newFlag.cityLevel.ordinal());
-            if(ClowderTerritory.findCityMeta(faction.relocationCityId, world.provider.dimensionId, x, y, z, faction.uuid) == null)
-                throw new IllegalStateException("destination claim metadata was not updated");
+            phase = "rebuilding city territory";
+            ClowderTerritory.rebuildCityClaims(ClowderTerritory.territories, faction, faction.relocationCityId,
+                world.provider.dimensionId, x, y, z, newFlag.name, newFlag.cityLevel.ordinal(), newFlag.getRadius());
+            faction.reconcileCitiesFounded(world);
             phase = "removing source";
             GUARDED_REMOVAL.set(key(world,faction.relocationX,faction.relocationY,faction.relocationZ));
-            try { world.setBlockToAir(faction.relocationX,faction.relocationY,faction.relocationZ); } finally { GUARDED_REMOVAL.remove(); }
+            try {
+                if(!world.setBlockToAir(faction.relocationX,faction.relocationY,faction.relocationZ))
+                    throw new IllegalStateException("source City Center could not be removed");
+            } finally { GUARDED_REMOVAL.remove(); }
             moveHomeIfNeeded(faction, oldTerritory, oldHomeX, oldHomeY, oldHomeZ, oldHomeDim, x, y, z, world);
             ClowderData.getData(world).markDirty(); com.hfr.dynmap.XFDynmapIntegration.markDirty();
             world.markBlockForUpdate(x, y, z);
@@ -230,11 +238,17 @@ public final class CityCenterRelocationManager {
             }
             if(world.getBlock(x,y,z)==ModBlocks.clowder_flag) { GUARDED_REMOVAL.set(key(world,x,y,z)); try { world.setBlockToAir(x,y,z); } finally { GUARDED_REMOVAL.remove(); } }
             ClowderTerritory.territories.clear(); ClowderTerritory.territories.putAll(oldTerritory);
-            if(world.getBlock(faction.relocationX,faction.relocationY,faction.relocationZ)!=ModBlocks.clowder_flag) world.setBlock(faction.relocationX,faction.relocationY,faction.relocationZ,ModBlocks.clowder_flag);
+            if(world.getBlock(faction.relocationX,faction.relocationY,faction.relocationZ)!=ModBlocks.clowder_flag)
+                world.setBlock(faction.relocationX,faction.relocationY,faction.relocationZ,ModBlocks.clowder_flag,oldBlockMetadata,3);
             TileEntity restored=world.getTileEntity(faction.relocationX,faction.relocationY,faction.relocationZ); if(restored instanceof TileEntityFlag) ((TileEntityFlag)restored).readFromNBT(saved);
             world.markBlockForUpdate(faction.relocationX,faction.relocationY,faction.relocationZ);
             faction.homeX=oldHomeX; faction.homeY=oldHomeY; faction.homeZ=oldHomeZ; faction.homeDim=oldHomeDim; faction.homeSet=oldHomeSet;
-            faction.save(world); ClowderData.getData(world).markDirty();
+            faction.relocationId=oldRelocationId; faction.relocationCityId=oldRelocationCityId;
+            faction.relocationStarted=oldRelocationStarted; faction.relocationExpires=oldRelocationExpires;
+            if(oldHistory == null) faction.cityRelocationHistory.remove(oldRelocationCityId);
+            else faction.cityRelocationHistory.put(oldRelocationCityId,oldHistory);
+            faction.reconcileCitiesFounded(world);
+            faction.save(world); ClowderData.getData(world).markDirty(); com.hfr.dynmap.XFDynmapIntegration.markDirty();
             return fail(player, "The relocation failed and the original city was restored.");
         }
     }
@@ -243,22 +257,15 @@ public final class CityCenterRelocationManager {
         Map<CoordPair, TerritoryMeta> result = new HashMap<CoordPair, TerritoryMeta>();
         for(Map.Entry<CoordPair, TerritoryMeta> entry : ClowderTerritory.territories.entrySet()) {
             TerritoryMeta meta = entry.getValue();
-            if(meta == null) { result.put(entry.getKey(), null); continue; }
-            TerritoryMeta copy = new TerritoryMeta(meta.owner, meta.flagX, meta.flagY, meta.flagZ);
+            CoordPair key = entry.getKey();
+            CoordPair copiedKey = new CoordPair(key.dimensionId, key.x, key.z);
+            if(meta == null) { result.put(copiedKey, null); continue; }
+            ClowderTerritory.Ownership ownership = meta.owner == null ? null : new ClowderTerritory.Ownership(meta.owner.zone, meta.owner.owner);
+            TerritoryMeta copy = new TerritoryMeta(ownership, meta.flagX, meta.flagY, meta.flagZ);
             copy.dimensionId=meta.dimensionId; copy.name=meta.name; copy.cityId=meta.cityId;
-            copy.cityName=meta.cityName; copy.cityLevel=meta.cityLevel; result.put(entry.getKey(), copy);
+            copy.cityName=meta.cityName; copy.cityLevel=meta.cityLevel; result.put(copiedKey, copy);
         }
         return result;
-    }
-
-    private static void updateMovedCityClaims(Clowder faction, String cityId, int dim, int x, int y, int z, String name, int level) {
-        int changed=0;
-        for(TerritoryMeta meta : ClowderTerritory.territories.values()) if(meta != null && cityId.equals(meta.cityId)) {
-            if(meta.owner == null || meta.owner.zone != Zone.FACTION || !sameFaction(meta.owner.owner, faction))
-                throw new IllegalStateException("moved city claim owner changed");
-            meta.dimensionId=dim; meta.flagX=x; meta.flagY=y; meta.flagZ=z; meta.name=name; meta.cityName=name; meta.cityLevel=level; changed++;
-        }
-        if(changed == 0) throw new IllegalStateException("moved city has no territory metadata");
     }
 
     private static void moveHomeIfNeeded(Clowder f, Map<CoordPair,TerritoryMeta> oldClaims, int hx,int hy,int hz,int hd,int nx,int ny,int nz,World world) {

--- a/src/main/java/com/hfr/clowder/ClowderTerritory.java
+++ b/src/main/java/com/hfr/clowder/ClowderTerritory.java
@@ -2,7 +2,11 @@ package com.hfr.clowder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import com.hfr.config.XFConfig;
 import com.hfr.data.ClowderData;
@@ -32,6 +36,68 @@ public class ClowderTerritory {
 	public static final int WILDERNESS_COLOR = 0xFFFFFF;
 	
 	public static HashMap<CoordPair, TerritoryMeta> territories = new HashMap();
+
+	/**
+	 * The canonical City Center shape.  Block-to-chunk conversion intentionally
+	 * goes through getCoordPair so old worlds retain the mod's legacy +1 and
+	 * integer-division behaviour at negative coordinates.
+	 */
+	public static Set<CoordPair> getCityClaimCoordinates(int dimensionId, int flagX, int flagZ, int radius) {
+		Set<CoordPair> result = new LinkedHashSet<CoordPair>();
+		int boundedRadius = Math.min(radius, CityLevel.maxRadius());
+		for(int x = -CityLevel.maxRadius(); x <= CityLevel.maxRadius(); x++) {
+			for(int z = -CityLevel.maxRadius(); z <= CityLevel.maxRadius(); z++) {
+				if(Math.sqrt((double)x * x + (double)z * z) < boundedRadius)
+					result.add(getCoordPair(dimensionId, flagX + x * 16, flagZ + z * 16));
+			}
+		}
+		return result;
+	}
+
+	/** Atomically replaces one city's claims without touching occupied or unrelated coordinates. */
+	public static Set<CoordPair> rebuildCityClaims(Map<CoordPair, TerritoryMeta> territory, Clowder faction,
+		String cityId, int dimensionId, int flagX, int flagY, int flagZ, String cityName, int cityLevel, int radius) {
+		if(territory == null || faction == null || cityId == null || cityId.isEmpty())
+			throw new IllegalArgumentException("invalid city rebuild arguments");
+		Set<CoordPair> expected = getCityClaimCoordinates(dimensionId, flagX, flagZ, radius);
+		for(CoordPair coordinate : expected) {
+			TerritoryMeta existing = territory.get(coordinate);
+			if(existing != null && !cityId.equals(existing.cityId))
+				throw new IllegalStateException("city rebuild overlaps occupied territory at " + coordinate);
+		}
+
+		Map<CoordPair, TerritoryMeta> replacement = new HashMap<CoordPair, TerritoryMeta>(territory);
+		for(CoordPair coordinate : new ArrayList<CoordPair>(replacement.keySet())) {
+			TerritoryMeta meta = replacement.get(coordinate);
+			if(meta != null && coordinate.dimensionId == dimensionId && cityId.equals(meta.cityId)) replacement.remove(coordinate);
+		}
+		for(CoordPair coordinate : expected) {
+			TerritoryMeta meta = new TerritoryMeta(new Ownership(Zone.FACTION, faction), flagX, flagY, flagZ);
+			meta.dimensionId = dimensionId; meta.name = cityName; meta.cityName = cityName;
+			meta.cityId = cityId; meta.cityLevel = cityLevel;
+			replacement.put(coordinate, meta);
+		}
+		verifyCityClaims(replacement, faction, cityId, dimensionId, flagX, flagY, flagZ, cityName, cityLevel, expected);
+		territory.clear(); territory.putAll(replacement);
+		return expected;
+	}
+
+	public static void verifyCityClaims(Map<CoordPair, TerritoryMeta> territory, Clowder faction, String cityId,
+		int dimensionId, int flagX, int flagY, int flagZ, String cityName, int cityLevel, Set<CoordPair> expected) {
+		Set<CoordPair> actual = new HashSet<CoordPair>();
+		for(Map.Entry<CoordPair, TerritoryMeta> entry : territory.entrySet()) {
+			TerritoryMeta meta = entry.getValue();
+			if(meta == null || !cityId.equals(meta.cityId)) continue;
+			if(entry.getKey().dimensionId != dimensionId || meta.dimensionId != dimensionId || meta.owner == null
+				|| meta.owner.zone != Zone.FACTION || meta.owner.owner != faction || meta.flagX != flagX
+				|| meta.flagY != flagY || meta.flagZ != flagZ || !cityName.equals(meta.name)
+				|| !cityName.equals(meta.cityName) || meta.cityLevel != cityLevel)
+				throw new IllegalStateException("rebuilt city metadata verification failed at " + entry.getKey());
+			actual.add(entry.getKey());
+		}
+		if(!actual.equals(expected) || !actual.contains(getCoordPair(dimensionId, flagX, flagZ)))
+			throw new IllegalStateException("rebuilt city territory geometry verification failed");
+	}
 	
 	//the chunk coords in the CodePair wrapper class
 	public static CoordPair getCoordPair(int x, int z) { return getCoordPair(0, x, z); }

--- a/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
+++ b/src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
@@ -398,17 +398,12 @@ public class TileEntityFlag extends TileEntityMachineBase implements ITerritoryP
 		if(placementError != null && ClowderTerritory.getMetaFromIntCoords(worldObj, xCoord, zCoord) == null)
 			return;
 		
+		java.util.Set<CoordPair> expected = ClowderTerritory.getCityClaimCoordinates(worldObj.provider.dimensionId, xCoord, zCoord, rad);
 		for(int x = -CityLevel.maxRadius(); x <= CityLevel.maxRadius(); x++) {
 			for(int z = -CityLevel.maxRadius(); z <= CityLevel.maxRadius(); z++) {
-
-				int posX = xCoord + x * 16;
-				int posZ = zCoord + z * 16;
-				CoordPair loc = ClowderTerritory.getCoordPair(worldObj, posX, posZ);
-				
+				CoordPair loc = ClowderTerritory.getCoordPair(worldObj, xCoord + x * 16, zCoord + z * 16);
 				TerritoryMeta meta = ClowderTerritory.getMetaFromCoords(loc);
-				
-				double dist = Math.sqrt(Math.pow(x, 2) + Math.pow(z, 2));
-				if(dist < rad) {
+				if(expected.contains(loc)) {
 					if(meta == null || !meta.checkPersistence(worldObj, loc) || (meta.flagX == xCoord && meta.flagY == yCoord && meta.flagZ == zCoord)) {
 						ClowderTerritory.setOwnerForCoord(worldObj, loc, owner, xCoord, yCoord, zCoord, name, getCityId());
 						TerritoryMeta newMeta = ClowderTerritory.getMetaFromCoords(loc);

--- a/src/test/java/com/hfr/clowder/CityCenterRelocationRulesTest.java
+++ b/src/test/java/com/hfr/clowder/CityCenterRelocationRulesTest.java
@@ -3,17 +3,26 @@ package com.hfr.clowder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import org.junit.Test;
+import org.junit.After;
 
 import com.hfr.config.XFConfig;
 import com.hfr.tileentity.clowder.TileEntityFlag;
 
 public class CityCenterRelocationRulesTest {
+    @After
+    public void clearTerritory() { ClowderTerritory.territories.clear(); }
+
     @Test
     public void nullAndUnregisteredOwnersAreOrphaned() {
         assertEquals(true, CityCenterRelocationManager.isOrphaned(new TileEntityFlag()));
@@ -65,5 +74,75 @@ public class CityCenterRelocationRulesTest {
         faction.cityRelocationHistory.get(city).add(Long.valueOf(now+30L*60L*1000L));
         assertNotNull(CityCenterRelocationManager.cooldownError(faction,city,now+30L*60L*1000L));
         assertNull(CityCenterRelocationManager.cooldownError(faction,city,now+169L*60L*60L*1000L));
+    }
+
+    @Test
+    public void relocationMovesCircularGeometryOneChunkEastAndPreservesUnrelatedClaims() {
+        Clowder faction=new Clowder(); faction.uuid="owner";
+        Clowder other=new Clowder(); other.uuid="other";
+        String city="stable-city"; int radius=3, y=70;
+        Set<ClowderTerritory.CoordPair> oldShape=ClowderTerritory.getCityClaimCoordinates(0,0,0,radius);
+        ClowderTerritory.rebuildCityClaims(ClowderTerritory.territories,faction,city,0,0,y,0,"Alpha",2,radius);
+        ClowderTerritory.CoordPair otherAt=new ClowderTerritory.CoordPair(0,20,20);
+        ClowderTerritory.TerritoryMeta otherMeta=meta(other,"other-city",320,y,320,"Beta",1);
+        ClowderTerritory.territories.put(otherAt,otherMeta);
+        ClowderTerritory.CoordPair safeAt=new ClowderTerritory.CoordPair(0,21,20);
+        ClowderTerritory.TerritoryMeta safeMeta=new ClowderTerritory.TerritoryMeta(ClowderTerritory.SAFEZONE);
+        ClowderTerritory.territories.put(safeAt,safeMeta);
+
+        Set<ClowderTerritory.CoordPair> moved=ClowderTerritory.rebuildCityClaims(
+            ClowderTerritory.territories,faction,city,0,16,y,0,"Alpha",2,radius);
+
+        assertEquals(ClowderTerritory.getCityClaimCoordinates(0,16,0,radius),moved);
+        assertEquals(moved.size(),count(city));
+        assertTrue(moved.contains(ClowderTerritory.getCoordPair(0,16,0)));
+        for(Map.Entry<ClowderTerritory.CoordPair,ClowderTerritory.TerritoryMeta> entry:ClowderTerritory.territories.entrySet()) {
+            if(city.equals(entry.getValue().cityId)) {
+                assertEquals(16,entry.getValue().flagX); assertEquals(y,entry.getValue().flagY);
+                assertEquals(0,entry.getValue().flagZ); assertSame(faction,entry.getValue().owner.owner);
+            }
+        }
+        Set<ClowderTerritory.CoordPair> western=new java.util.HashSet<ClowderTerritory.CoordPair>(oldShape); western.removeAll(moved);
+        Set<ClowderTerritory.CoordPair> eastern=new java.util.HashSet<ClowderTerritory.CoordPair>(moved); eastern.removeAll(oldShape);
+        assertTrue(!western.isEmpty() && !eastern.isEmpty());
+        for(ClowderTerritory.CoordPair coordinate:western) assertNull(ClowderTerritory.territories.get(coordinate));
+        for(ClowderTerritory.CoordPair coordinate:eastern) assertEquals(city,ClowderTerritory.territories.get(coordinate).cityId);
+        assertSame(otherMeta,ClowderTerritory.territories.get(otherAt));
+        assertSame(safeMeta,ClowderTerritory.territories.get(safeAt));
+    }
+
+    @Test
+    public void failedRebuildIsAtomicAndRepeatedMovesUseLatestCenter() {
+        Clowder faction=new Clowder(); faction.uuid="owner"; String city="stable";
+        ClowderTerritory.rebuildCityClaims(ClowderTerritory.territories,faction,city,0,0,64,0,"City",0,2);
+        ClowderTerritory.CoordPair collision=ClowderTerritory.getCoordPair(0,32,0);
+        ClowderTerritory.TerritoryMeta protectedMeta=new ClowderTerritory.TerritoryMeta(ClowderTerritory.WARZONE);
+        ClowderTerritory.territories.put(collision,protectedMeta);
+        Map<ClowderTerritory.CoordPair,ClowderTerritory.TerritoryMeta> before=new HashMap<ClowderTerritory.CoordPair,ClowderTerritory.TerritoryMeta>(ClowderTerritory.territories);
+        try {
+            ClowderTerritory.rebuildCityClaims(ClowderTerritory.territories,faction,city,0,16,64,0,"City",0,2);
+            throw new AssertionError("expected overlap failure");
+        } catch(IllegalStateException expected) { assertEquals(before,ClowderTerritory.territories); }
+        ClowderTerritory.territories.remove(collision);
+        ClowderTerritory.rebuildCityClaims(ClowderTerritory.territories,faction,city,0,16,64,0,"City",0,2);
+        Set<ClowderTerritory.CoordPair> latest=ClowderTerritory.rebuildCityClaims(ClowderTerritory.territories,faction,city,0,16,64,16,"City",0,2);
+        assertEquals(latest.size(),count(city));
+        for(ClowderTerritory.TerritoryMeta meta:ClowderTerritory.territories.values()) if(city.equals(meta.cityId)) assertEquals(16,meta.flagZ);
+    }
+
+    @Test
+    public void cityShapeUsesLegacyConversionAcrossChunkBoundaries() {
+        int[] blocks={-17,-16,-1,0,15,16};
+        for(int x:blocks) for(int z:blocks) {
+            Set<ClowderTerritory.CoordPair> shape=ClowderTerritory.getCityClaimCoordinates(-1,x,z,1);
+            assertEquals(1,shape.size());
+            assertTrue(shape.contains(ClowderTerritory.getCoordPair(-1,x,z)));
+        }
+    }
+
+    private static int count(String city) { int count=0; for(ClowderTerritory.TerritoryMeta meta:ClowderTerritory.territories.values()) if(city.equals(meta.cityId)) count++; return count; }
+    private static ClowderTerritory.TerritoryMeta meta(Clowder owner,String id,int x,int y,int z,String name,int level) {
+        ClowderTerritory.TerritoryMeta meta=new ClowderTerritory.TerritoryMeta(new ClowderTerritory.Ownership(ClowderTerritory.Zone.FACTION,owner),x,y,z);
+        meta.cityId=id; meta.name=name; meta.cityName=name; meta.cityLevel=level; return meta;
     }
 }


### PR DESCRIPTION
### Motivation

- Fix relocation logic so moving a City Center rebuilds the city's territory geometry around the destination instead of only updating metadata on existing entries.
- Ensure relocation is atomic, server-authoritative, and reversible on failure while preserving unrelated territory and protected zones.

### Description

- Add a canonical city-shape helper and reuse it for both normal generation and relocation to guarantee identical circular geometry and legacy block-to-chunk conversion at negative coordinates; introduced `getCityClaimCoordinates(...)`. (src/main/java/com/hfr/clowder/ClowderTerritory.java)
- Implement atomic territory replacement and verification routines: `rebuildCityClaims(...)` and `verifyCityClaims(...)` that build the expected chunk set, validate no protected overlaps, replace claims in one operation, and verify metadata. (src/main/java/com/hfr/clowder/ClowderTerritory.java)
- Update `TileEntityFlag.generateClaim()` to use the shared canonical coordinate set so normal city generation and relocation share the same shape rules. (src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java)
- Replace metadata-only relocation with a full territory rebuild during the relocation commit and strengthen rollback to restore: a deep copy of the territory, original source block metadata and tile NBT, faction relocation state and history, faction home, consumed token (if it was consumed), prestige, and mark persistent data and Dynmap dirty after success. Also verify rebuilt territory before removing the source flag. (src/main/java/com/hfr/clowder/CityCenterRelocationManager.java)
- Preserve existing behaviors: stable city IDs, faction ownership, city name/level, dimension checks, and existing radius rules; avoid replacing claims owned by other factions/zones by verifying before mutating territory.
- Add tests that assert geometry and metadata move as expected, that failures are atomic, that legacy chunk conversions behave correctly, and that unrelated/special-zone claims are preserved. (src/test/java/com/hfr/clowder/CityCenterRelocationRulesTest.java)
- Add concise CHANGELOG entry noting the relocation rebuild behavior. (CHANGELOG.md)

Files changed:
- src/main/java/com/hfr/clowder/ClowderTerritory.java
- src/main/java/com/hfr/clowder/CityCenterRelocationManager.java
- src/main/java/com/hfr/tileentity/clowder/TileEntityFlag.java
- src/test/java/com/hfr/clowder/CityCenterRelocationRulesTest.java
- CHANGELOG.md

### Testing

- Ran repository static and project checks (diff/format checks and verification that Java 8 compatibility settings are present); these checks passed.
- Added unit tests covering relocation geometry, atomic rollback, repeated relocation behavior, and legacy coordinate boundaries; tests were added under `CityCenterRelocationRulesTest` but were not executed in this environment because compiling and running the test suite would produce binary artifacts and the task constraints prohibit compiling binaries here. Therefore unit tests were not run.
- No other automated test runs (`./gradlew test` / full build) were executed for the same no-binary-compilation constraint; manual/CI test execution should run the new tests and the full build before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73e7d0df2c832393067d07dc71f705)