### PR TITLE
Add admin command `/xcfactiontimeoutcreationreset` to reset a player's faction creation cooldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Pull request: add faction creation cooldown reset command
+
+- Added the admin-only `/xcfactiontimeoutcreationreset <playername>` command to reset only one online or stored offline player's faction creation cooldown with immediate persistence.
+
 # Pull request: rebuild territory after City Center relocation
 
 - City Center relocation now rebuilds the city's circular territory around the destination and removes stale territory around the old center.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Most player-facing faction commands are under `/clowder` or `/c`:
 /c declarewar <faction>
 ```
 
-Administrative faction commands are under `/xclowder` or `/xc` and require permission level 3 by default. All players can inspect configured custom stone drops with `/stonedrops [page]`; `/stonedrop` remains the administrator command for adding, listing, and removing custom stone drops. Other command families include `/cc`, `/xflags`, `/xmap`, `/stonedrops`, `/stonedrop`, `/xmarket`, `/xshop`, `/xmute`, `/xignore`, `/invsee`, and optional `/tdm`.
+Administrative faction commands are under `/xclowder` or `/xc` and require permission level 3 by default. The standalone admin command `/xcfactiontimeoutcreationreset <playername>` resets only the named player's faction creation cooldown and works for stored offline players. All players can inspect configured custom stone drops with `/stonedrops [page]`; `/stonedrop` remains the administrator command for adding, listing, and removing custom stone drops. Other command families include `/cc`, `/xflags`, `/xmap`, `/stonedrops`, `/stonedrop`, `/xmarket`, `/xshop`, `/xmute`, `/xignore`, `/invsee`, and optional `/tdm`.
 
 See [`docs/commands.md`](docs/commands.md) for command syntax verified from source.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -131,6 +131,8 @@ Usage: `/xclowder help`; aliases: `/xclowder`, `/xc`; permission level: 3.
 | `/xc ignorewarstatecheck` | Toggle at-war state check bypass. |
 | `/xc enablelegacywar` | Toggle legacy war mode, bypassing modern checks. |
 
+The standalone `/xcfactiontimeoutcreationreset <playername>` command also requires permission level 3. It resets only that player's faction creation cooldown, accepts online players and offline players known to the server profile cache or cooldown store, and can be run by an admin player or the server console.
+
 ## Faction chat: `/cc`
 
 Usage: `/cc <message>`; permission level: 0.

--- a/docs/server-administration.md
+++ b/docs/server-administration.md
@@ -29,10 +29,13 @@
 /xc wardisable
 /xc addprestige <faction> <amount>
 /xc setclaim <wild/safe/war> <s/c> <radius>
+/xcfactiontimeoutcreationreset <playername>
 /stonedrop list
 /invsee <player>
 /xmute <player> <seconds|perm> [reason]
 ```
+
+`/xcfactiontimeoutcreationreset <playername>` is admin-only and resets only the specified player's faction creation cooldown. It does not alter faction membership or any other cooldown, and it supports stored offline players.
 
 ## Backups
 

--- a/src/main/java/com/hfr/clowder/FactionCreationCooldownData.java
+++ b/src/main/java/com/hfr/clowder/FactionCreationCooldownData.java
@@ -132,12 +132,13 @@ public class FactionCreationCooldownData {
 
     public static final class ClearResult {
         public final boolean ambiguous;
+        public final boolean resolved;
         public final UUID uuid;
         public final String name;
         public final long removedExpiration;
         public final int removedEntries;
-        private ClearResult(boolean ambiguous, UUID uuid, String name, long expiration, int count) {
-            this.ambiguous = ambiguous; this.uuid = uuid; this.name = name; this.removedExpiration = expiration; this.removedEntries = count;
+        private ClearResult(boolean ambiguous, boolean resolved, UUID uuid, String name, long expiration, int count) {
+            this.ambiguous = ambiguous; this.resolved = resolved; this.uuid = uuid; this.name = name; this.removedExpiration = expiration; this.removedEntries = count;
         }
     }
 
@@ -145,12 +146,37 @@ public class FactionCreationCooldownData {
     public static ClearResult clearNormalizedName(String name) { return clearRepresentations(null, name); }
 
     public static ClearResult clearTarget(String target, World world) {
-        if(target == null || target.trim().isEmpty()) return new ClearResult(true, null, "", 0L, 0);
+        if(target == null || target.trim().isEmpty()) return new ClearResult(true, false, null, "", 0L, 0);
         try { return clearRepresentations(UUID.fromString(target.trim()), null); }
         catch(IllegalArgumentException notUuid) { }
         EntityPlayer online = world == null ? null : world.getPlayerEntityByName(target);
         GameProfile profile = online == null ? PlayerIdentityService.cachedProfile(target) : online.getGameProfile();
         return clearRepresentations(profile == null ? null : profile.getId(), profile == null ? target : profile.getName());
+    }
+
+    /** Resolves a player name from the live server, profile cache, or existing cooldown data, then clears only that identity. */
+    public static ClearResult clearPlayerName(String playerName) {
+        String normalized = PlayerIdentityService.normalizeName(playerName);
+        if(normalized.isEmpty()) return new ClearResult(false, false, null, "", 0L, 0);
+        EntityPlayer online = MinecraftServer.getServer().getConfigurationManager().func_152612_a(playerName);
+        GameProfile profile = online == null ? PlayerIdentityService.cachedProfile(playerName) : online.getGameProfile();
+        if(profile != null)
+            return clearRepresentations(profile.getId(), profile.getName());
+
+        UUID storedUuid = null;
+        String storedName = null;
+        for(Map.Entry<String, CooldownEntry> entry : DATA.entrySet()) {
+            if(entry.getValue() != null && normalized.equals(PlayerIdentityService.normalizeName(entry.getValue().lastKnownName))) {
+                if(storedUuid != null) return new ClearResult(true, true, null, playerName, 0L, 0);
+                try { storedUuid = UUID.fromString(entry.getKey()); }
+                catch(IllegalArgumentException malformed) { return new ClearResult(true, true, null, playerName, 0L, 0); }
+                storedName = entry.getValue().lastKnownName;
+            }
+        }
+        if(storedUuid != null) return clearRepresentations(storedUuid, storedName);
+        CooldownEntry fallback = FALLBACKS.get(normalized);
+        if(fallback != null) return clearRepresentations(null, fallback.lastKnownName);
+        return new ClearResult(false, false, null, playerName, 0L, 0);
     }
 
     public static ClearResult clearRepresentations(UUID uuid, String suppliedName) {
@@ -162,7 +188,7 @@ public class FactionCreationCooldownData {
             if(entry.getValue() != null && normalized.equals(PlayerIdentityService.normalizeName(entry.getValue().lastKnownName)) && !matchingUuids.contains(entry.getKey())) matchingUuids.add(entry.getKey());
         if(!normalized.isEmpty() && matchingUuids.size() > 1) {
             log("Ambiguous cooldown identity '" + normalized + "' matches " + matchingUuids.size() + " UUID entries; nothing cleared", null);
-            return new ClearResult(true, null, suppliedName, 0L, 0);
+            return new ClearResult(true, true, null, suppliedName, 0L, 0);
         }
         long expiration = 0L; int count = 0; String knownName = suppliedName;
         for(String key : matchingUuids) {
@@ -175,7 +201,7 @@ public class FactionCreationCooldownData {
             if(removed != null) { count++; expiration = Math.max(expiration, removed.expiresAt); }
         }
         if(count > 0) save();
-        return new ClearResult(false, uuid, knownName == null ? "" : knownName, expiration, count);
+        return new ClearResult(false, true, uuid, knownName == null ? "" : knownName, expiration, count);
     }
 
     public static Map<String, String> snapshotFactionMembers(Clowder clowder, World world) {

--- a/src/main/java/com/hfr/command/CommandFactionCreationTimeoutReset.java
+++ b/src/main/java/com/hfr/command/CommandFactionCreationTimeoutReset.java
@@ -1,0 +1,65 @@
+package com.hfr.command;
+
+import java.util.List;
+
+import com.hfr.clowder.FactionCreationCooldownData;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
+
+public class CommandFactionCreationTimeoutReset extends CommandBase {
+
+    @Override
+    public String getCommandName() {
+        return "xcfactiontimeoutcreationreset";
+    }
+
+    @Override
+    public String getCommandUsage(ICommandSender sender) {
+        return "/xcfactiontimeoutcreationreset <playername>";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 3;
+    }
+
+    @Override
+    public void processCommand(ICommandSender sender, String[] args) {
+        if(args.length != 1 || !args[0].matches("[A-Za-z0-9_]{1,16}"))
+            throw new WrongUsageException(getCommandUsage(sender));
+
+        FactionCreationCooldownData.ClearResult result = FactionCreationCooldownData.clearPlayerName(args[0]);
+        if(result.ambiguous) {
+            sender.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Player name is ambiguous; no faction creation cooldown was reset."));
+            return;
+        }
+        if(!result.resolved) {
+            sender.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Could not resolve player '" + args[0] + "'."));
+            return;
+        }
+
+        String name = result.name == null || result.name.isEmpty() ? args[0] : result.name;
+        if(result.removedEntries == 0) {
+            sender.addChatMessage(new ChatComponentText(EnumChatFormatting.GREEN + name + " has no active faction creation cooldown."));
+            return;
+        }
+
+        sender.addChatMessage(new ChatComponentText(EnumChatFormatting.GREEN + "Reset faction creation cooldown for " + name + "."));
+        EntityPlayerMP target = MinecraftServer.getServer().getConfigurationManager().func_152612_a(name);
+        if(target != null)
+            target.addChatMessage(new ChatComponentText(EnumChatFormatting.GREEN + "An admin reset your faction creation cooldown."));
+    }
+
+    @Override
+    public List addTabCompletionOptions(ICommandSender sender, String[] args) {
+        if(args.length == 1)
+            return getListOfStringsMatchingLastWord(args, MinecraftServer.getServer().getAllUsernames());
+        return null;
+    }
+}

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -856,6 +856,7 @@ public class MainRegistry
 		event.registerServerCommand(new CommandClowder());
 		event.registerServerCommand(new CommandClowderChat());
 		event.registerServerCommand(new CommandClowderAdmin());
+		event.registerServerCommand(new CommandFactionCreationTimeoutReset());
 		event.registerServerCommand(new CommandEnemy());
 		event.registerServerCommand(new CommandUnenemy());
 


### PR DESCRIPTION
### Motivation

- Provide a single admin command that clears only a target player's faction creation cooldown so they may immediately create a faction again.
- Support both online players and offline/stored identities by reusing the existing UUID/name-backed cooldown storage and profile cache to avoid adding a second database or changing identity semantics.

### Description

- Added a new standalone command `xcfactiontimeoutcreationreset` implemented in `CommandFactionCreationTimeoutReset.java` that requires permission level `3`, accepts exactly one player-name argument, supports console and admin-player use, validates the username form, and offers tab completion of online usernames. 
- Extended `FactionCreationCooldownData` with a `clearPlayerName` resolver plus a `resolved` flag on `ClearResult`, and updated `clearRepresentations`/`clearTarget` behavior so clearing removes only matching UUID/name entries, preserves ambiguity protection, and immediately persists the store when entries are removed. 
- Registered the new command during server startup in `MainRegistry` so it is available alongside existing admin commands. 
- Updated documentation and changelog: `README.md`, `docs/commands.md`, `docs/server-administration.md`, and `CHANGELOG.md` describe the command syntax, permission level, console support, offline lookup behavior, and limited scope (only faction creation cooldown). 

### Testing

- Ran `git diff --check` and repository consistency checks which reported no check failures. 
- Executed a Python source-contract script that verified the command name, single-argument validation, permission level `3`, tab-completion usage, registration in `MainRegistry`, and presence of the new `clearPlayerName` accessor, and the script passed. 
- Verified repository status and diffs to ensure the new files and edits are present and the changelog/docs were updated; a full project compile was not performed per repository policy and the user instruction to avoid building binaries, so build/compile tests remain to be run in the target build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73ea3924b48323bb24443050ebd33f)