### PR TITLE
Add template-backed XF Earth world type (xf_earth) with profile-backed missing-chunk safeguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Pull request: add template-backed XenoFactions Earth world type
+
+- Registered the `xf_earth` dimension-0 world type and a non-generating missing-chunk fallback for externally exported WorldPainter Anvil saves.
+- Added validated, save-cached Earth profiles, startup adoption checks, profile-backed reuse of the existing border, operator status/check commands, localization, configuration, and installation documentation.
+- Kept Earth in the ordinary overworld without a custom dimension or world provider and without bundling map binaries.
+
 # Pull request: add faction creation cooldown reset command
 
 - Added the admin-only `/xcfactiontimeoutcreationreset <playername>` command to reset only one online or stored offline player's faction creation cooldown with immediate persistence.

--- a/docs/XFEARTH_INSTALLATION.md
+++ b/docs/XFEARTH_INSTALLATION.md
@@ -1,0 +1,24 @@
+# XenoFactions Earth installation (Phase 1)
+
+`xf_earth` is a guard around an **already pregenerated** Minecraft 1.7.10 Anvil world. It does not generate Earth, read heightmaps, or read WorldPainter `.world` projects. A `.world` project is not a Minecraft save: WorldPainter must export it to Anvil first. Existing exported chunks continue to be loaded by Minecraft's Anvil loader; the provider only handles absent chunks and prevents vanilla terrain appearing around or inside the map.
+
+## Smoke-map adoption
+
+1. Run the WorldPainter smoke profile and export it as a Minecraft 1.7.10 Anvil save.
+2. Copy `xenoearth-profile-smoke.json` into the exported save root as `xenoearth-profile.json`.
+3. With an NBT editor, set these values in the exported `level.dat`:
+   ```text
+   Data.generatorName=xf_earth
+   Data.generatorVersion=0
+   Data.generatorOptions=
+   ```
+4. On a dedicated server, set `level-type=xf_earth` in `server.properties`.
+5. Copy the save into the directory selected by the server's `level-name`.
+6. Back up the world before starting it.
+7. Start the server and run `/xfearth status` as an operator.
+8. Test the smoke map before preview or production.
+9. Never start a production Earth world with an empty or incomplete `region` directory.
+
+The default `FAIL` policy deliberately stops access when an expected in-bounds chunk is absent. `VOID` is an explicit diagnostic escape hatch, not a repair. Region-file existence reported by `/xfearth check` does not prove that a particular chunk is present in that region.
+
+Production save data, `.world` projects, and `.mca` files are deployed separately and must not be committed to Xenofactions or bundled in its jar.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -251,3 +251,7 @@ Regular leader-run `/c disband <faction name>` writes faction creation penalties
 
 
 The cooldown JSON contains `uuids` and normalized `nameFallbacks`; entries contain epoch-millisecond `expiresAt` and `lastKnownName`. `/xc clearcreationcooldown <player-or-uuid>` (alias `resetcreationcooldown`) works for online/offline targets and saves successful changes immediately via temporary-file replacement.
+
+## XENOFACTIONS_18_EARTH_WORLD
+
+Phase 1's template-backed Earth type is controlled by `enableEarthWorldType`, `earthWorldTypeName` (canonical value `xf_earth`), `earthRequireProfile`, `earthMissingChunkPolicy` (`FAIL` or `VOID`), `earthBoundaryMode` (`OFF`, `PROFILE`, or `CONFIG`), `earthAllowProfileMinecraftVersion`, `earthLogFallbackChunks`, and `earthBoundarySafetyMargin`. `PROFILE` derives the dimension-0 border from the validated save profile; `CONFIG` preserves the legacy administrator border coordinates; `OFF` does not activate a profile border. See [XFEARTH_INSTALLATION.md](XFEARTH_INSTALLATION.md).

--- a/src/main/java/com/hfr/command/CommandXFEarth.java
+++ b/src/main/java/com/hfr/command/CommandXFEarth.java
@@ -1,0 +1,11 @@
+package com.hfr.command;
+import java.io.File; import com.hfr.config.XFConfig; import com.hfr.world.earth.*;
+import net.minecraft.command.*; import net.minecraft.server.MinecraftServer; import net.minecraft.util.ChatComponentText; import net.minecraft.world.WorldServer;
+public final class CommandXFEarth extends CommandBase {
+ public String getCommandName(){return "xfearth";} public String getCommandUsage(ICommandSender s){return "/xfearth status | check <chunkX> <chunkZ>";} public int getRequiredPermissionLevel(){return 2;}
+ public void processCommand(ICommandSender s,String[] a){WorldServer w=MinecraftServer.getServer().worldServerForDimension(0);File root=w.getSaveHandler().getWorldDirectory();XFEarthProfile p=null;try{if(XFEarthProfileLoader.exists(root))p=XFEarthProfileLoader.load(root);}catch(Exception e){msg(s,"Profile error: "+e.getMessage());}
+  if(a.length==1&&"status".equalsIgnoreCase(a[0])){msg(s,"Earth world type registered: "+XFEarthRegistry.isRegistered());msg(s,"Current overworld terrain type: "+w.getWorldInfo().getTerrainType().getWorldTypeName());msg(s,"Profile path: "+XFEarthProfileLoader.path(root)); if(p!=null){msg(s,"Profile name: "+p.getProfile());msg(s,"Effective scale: "+p.getEffectiveScale());msg(s,"Block bounds: "+p.getBounds().blockString());msg(s,"Chunk bounds: "+p.getBounds().chunkString());msg(s,"Sea level: "+p.getSeaLevel());}msg(s,"Missing chunk policy: "+XFConfig.earthMissingChunkPolicy);msg(s,"Boundary mode: "+XFConfig.earthBoundaryMode);msg(s,"Correctly adopted: "+(XFEarthRegistry.get()!=null&&w.getWorldInfo().getTerrainType()==XFEarthRegistry.get()&&p!=null));return;}
+  if(a.length==3&&"check".equalsIgnoreCase(a[0])){int x=parseInt(s,a[1]),z=parseInt(s,a[2]);boolean inside=p!=null&&p.getBounds().containsChunk(x,z);File region=new File(new File(root,"region"),"r."+XFEarthBounds.chunkToRegion(x)+"."+XFEarthBounds.chunkToRegion(z)+".mca");msg(s,"Inside profile bounds: "+inside);msg(s,"Region file exists: "+region.isFile()+" (this does not prove that the specific chunk exists)");return;} throw new WrongUsageException(getCommandUsage(s));
+ }
+ private static void msg(ICommandSender s,String m){s.addChatMessage(new ChatComponentText(m));}
+}

--- a/src/main/java/com/hfr/config/XFConfig.java
+++ b/src/main/java/com/hfr/config/XFConfig.java
@@ -40,6 +40,15 @@ public final class XFConfig {
 	public static final String CAT_LEGACY_CHAT = "XENOFACTIONS_15_CHAT_FILTER";
 	public static final String CAT_LEGACY_GENERAL = "XENOFACTIONS_16_GENERAL_LEGACY";
 	public static final String CAT_LEGACY_DEBUG = "XENOFACTIONS_17_DEBUG_LOGGING";
+	public static final String CAT_EARTH_WORLD = "XENOFACTIONS_18_EARTH_WORLD";
+	public static boolean enableEarthWorldType = true;
+	public static String earthWorldTypeName = "xf_earth";
+	public static boolean earthRequireProfile = true;
+	public static String earthMissingChunkPolicy = "FAIL";
+	public static String earthBoundaryMode = "PROFILE";
+	public static String earthAllowProfileMinecraftVersion = "1.7.10";
+	public static boolean earthLogFallbackChunks = true;
+	public static int earthBoundarySafetyMargin = 1;
 
 	public static boolean enableDynmapIntegration = true;
 	public static boolean enableJourneyMapIntegration = true;
@@ -155,6 +164,16 @@ public final class XFConfig {
 
 	public static void load(Configuration config) {
 		commentCategories(config);
+		enableEarthWorldType = bool(config, CAT_EARTH_WORLD, "enableEarthWorldType", true, "Registers the template-backed xf_earth overworld type.");
+		earthWorldTypeName = string(config, CAT_EARTH_WORLD, "earthWorldTypeName", "xf_earth", "Stored generator name (1-16 characters; Phase 1 uses xf_earth).");
+		if(earthWorldTypeName.length() == 0 || earthWorldTypeName.length() > 16) { warn("earthWorldTypeName must contain 1-16 characters; using xf_earth"); earthWorldTypeName = "xf_earth"; }
+		if(!"xf_earth".equals(earthWorldTypeName)) { warn("Phase 1 registers the canonical xf_earth name; configured alias ignored"); earthWorldTypeName = "xf_earth"; }
+		earthRequireProfile = bool(config, CAT_EARTH_WORLD, "earthRequireProfile", true, "Refuse an adopted Earth world without xenoearth-profile.json.");
+		earthMissingChunkPolicy = enumValue(string(config, CAT_EARTH_WORLD, "earthMissingChunkPolicy", "FAIL", "FAIL or VOID."), "FAIL", "VOID", "earthMissingChunkPolicy");
+		earthBoundaryMode = enumValue(string(config, CAT_EARTH_WORLD, "earthBoundaryMode", "PROFILE", "OFF, PROFILE, or CONFIG."), "PROFILE", "OFF,CONFIG", "earthBoundaryMode");
+		earthAllowProfileMinecraftVersion = string(config, CAT_EARTH_WORLD, "earthAllowProfileMinecraftVersion", "1.7.10", "Required profile targetMinecraftVersion.");
+		earthLogFallbackChunks = bool(config, CAT_EARTH_WORLD, "earthLogFallbackChunks", true, "Log fallback chunks once per coordinate.");
+		earthBoundarySafetyMargin = integer(config, CAT_EARTH_WORLD, "earthBoundarySafetyMargin", 1, 0, 15, "Blocks kept inward from profile edges by the existing border handler.");
 
 		enableDynmapIntegration = bool(config, CAT_MODULES, "enableDynmapIntegration", enableDynmapIntegration, "Enables optional Dynmap markers. Safe no-op when Dynmap is absent.");
 		enableJourneyMapIntegration = bool(config, CAT_MODULES, "enableJourneyMapIntegration", enableJourneyMapIntegration, "Enables optional legacy JourneyMap 5.2.x client claim overlays. Safe no-op when JourneyMap is absent or incompatible.");
@@ -297,7 +316,9 @@ public final class XFConfig {
 		config.addCustomCategoryComment(CAT_LEGACY_CHAT, "15 - Legacy chat filter settings.");
 		config.addCustomCategoryComment(CAT_LEGACY_GENERAL, "16 - Miscellaneous legacy settings that do not belong to a specific subsystem.");
 		config.addCustomCategoryComment(CAT_LEGACY_DEBUG, "17 - Legacy debug, logging, and precision-calculation settings.");
+		config.addCustomCategoryComment(CAT_EARTH_WORLD, "18 - Template-backed WorldPainter Earth overworld safeguards.");
 	}
+	private static String enumValue(String value, String def, String alternatives, String name) { String v=value.toUpperCase(); if(v.equals(def)) return v; for(String a:alternatives.split(",")) if(v.equals(a)) return v; warn(name+" is invalid; using "+def); return def; }
 
 	public static int cityRadius(CityLevel level) { return cityRadii[index(level)]; }
 	public static float cityUpgradeCost(CityLevel level) { return cityUpgradeCosts[index(level)]; }

--- a/src/main/java/com/hfr/main/CommonEventHandler.java
+++ b/src/main/java/com/hfr/main/CommonEventHandler.java
@@ -657,7 +657,7 @@ public class CommonEventHandler {
 		// --------------------
 		// World-border logic
 		// --------------------
-		if (border) {
+		if (border && world.provider.dimensionId == 0) {
 			// take a snapshot of the entity list to avoid ConcurrentModificationException
 			List<Entity> snapshot = new ArrayList<Entity>(world.loadedEntityList);
 

--- a/src/main/java/com/hfr/main/MainRegistry.java
+++ b/src/main/java/com/hfr/main/MainRegistry.java
@@ -437,6 +437,8 @@ public class MainRegistry
 		ModBlocks.mainRegistry();
 		ModItems.mainRegistry();
 		loadConfig(PreEvent);
+		com.hfr.world.earth.XFEarthRegistry.register();
+		MinecraftForge.EVENT_BUS.register(new com.hfr.world.earth.XFEarthWorldValidationHandler());
 		CraftingManager.mainRegistry();
 		proxy.registerRenderInfo();
 		FluidHandler.init();
@@ -867,6 +869,7 @@ public class MainRegistry
 		event.registerServerCommand(new CommandXMarket());
 		event.registerServerCommand(new CommandStoneDrop());
 		event.registerServerCommand(new CommandStoneDrops());
+		event.registerServerCommand(new com.hfr.command.CommandXFEarth());
 		MuteManager.init();
 		if(XFConfig.enableTDM)
 			TDMKitManager.init();

--- a/src/main/java/com/hfr/world/earth/XFEarthBounds.java
+++ b/src/main/java/com/hfr/world/earth/XFEarthBounds.java
@@ -1,0 +1,18 @@
+package com.hfr.world.earth;
+
+/** Inclusive block and chunk bounds from an Earth export profile. */
+public final class XFEarthBounds {
+    public final int minimumX, maximumX, minimumZ, maximumZ;
+    public final int minimumChunkX, maximumChunkX, minimumChunkZ, maximumChunkZ;
+    public XFEarthBounds(int minX, int maxX, int minZ, int maxZ) {
+        minimumX=minX; maximumX=maxX; minimumZ=minZ; maximumZ=maxZ;
+        minimumChunkX=floorDiv(minX,16); maximumChunkX=floorDiv(maxX,16);
+        minimumChunkZ=floorDiv(minZ,16); maximumChunkZ=floorDiv(maxZ,16);
+    }
+    public boolean containsChunk(int x,int z) { return x>=minimumChunkX&&x<=maximumChunkX&&z>=minimumChunkZ&&z<=maximumChunkZ; }
+    public boolean containsBlock(double x,double z) { return x>=minimumX&&x<=maximumX&&z>=minimumZ&&z<=maximumZ; }
+    public static int floorDiv(int value,int divisor) { int q=value/divisor, r=value%divisor; return r!=0 && ((value^divisor)<0) ? q-1:q; }
+    public static int chunkToRegion(int chunk) { return floorDiv(chunk,32); }
+    public String blockString(){return minimumX+".."+maximumX+" x "+minimumZ+".."+maximumZ;}
+    public String chunkString(){return minimumChunkX+".."+maximumChunkX+" x "+minimumChunkZ+".."+maximumChunkZ;}
+}

--- a/src/main/java/com/hfr/world/earth/XFEarthChunkProvider.java
+++ b/src/main/java/com/hfr/world/earth/XFEarthChunkProvider.java
@@ -1,0 +1,22 @@
+package com.hfr.world.earth;
+import java.util.*;
+import com.hfr.config.XFConfig; import com.hfr.main.MainRegistry;
+import net.minecraft.entity.EnumCreatureType; import net.minecraft.util.IProgressUpdate;
+import net.minecraft.world.*; import net.minecraft.world.biome.BiomeGenBase; import net.minecraft.world.chunk.*;
+/** Generator invoked only when Anvil has no saved chunk. It never generates terrain. */
+public final class XFEarthChunkProvider implements IChunkProvider {
+ private final World world; private final XFEarthProfile profile; private final Set<Long> logged=new HashSet<Long>();
+ public XFEarthChunkProvider(World world){this.world=world; XFEarthProfile p=null; try{p=XFEarthProfileLoader.load(world.getSaveHandler().getWorldDirectory());}catch(Exception e){if(XFConfig.earthRequireProfile) throw new IllegalStateException("xf_earth requires a valid "+XFEarthProfileLoader.FILE_NAME,e); if(MainRegistry.logger!=null)MainRegistry.logger.error("[XF EARTH] Profile unavailable; only void fallback is possible",e);} profile=p;}
+ public boolean chunkExists(int x,int z){return false;}
+ public Chunk provideChunk(int x,int z){return fallback(x,z);}
+ public Chunk loadChunk(int x,int z){return fallback(x,z);}
+ private Chunk fallback(int x,int z){boolean inside=profile!=null&&profile.getBounds().containsChunk(x,z); long key=((long)x<<32)^(z&0xffffffffL);
+  if(inside&&"FAIL".equals(XFConfig.earthMissingChunkPolicy)){XFEarthMissingChunkException ex=new XFEarthMissingChunkException(x,z,profile); if(logged.add(key)&&MainRegistry.logger!=null)MainRegistry.logger.error("[XF EARTH] "+ex.getMessage()); throw ex;}
+  if(logged.add(key)&&XFConfig.earthLogFallbackChunks&&MainRegistry.logger!=null)MainRegistry.logger.warn("[XF EARTH] RETURNING VOID for "+(inside?"MISSING IN-BOUNDS":"out-of-bounds")+" chunk ("+x+", "+z+")");
+  Chunk chunk=new Chunk(world,x,z); byte[] biomes=new byte[256]; Arrays.fill(biomes,(byte)BiomeGenBase.plains.biomeID); chunk.setBiomeArray(biomes); chunk.generateSkylightMap(); chunk.isTerrainPopulated=true; chunk.isLightPopulated=true; return chunk;
+ }
+ public void populate(IChunkProvider provider,int x,int z){} public boolean saveChunks(boolean all,IProgressUpdate progress){return true;} public boolean unloadQueuedChunks(){return false;} public boolean canSave(){return true;}
+ public String makeString(){return "XFEarthPregeneratedFallback";}
+ public List<BiomeGenBase.SpawnListEntry> getPossibleCreatures(EnumCreatureType type,int x,int y,int z){if(profile==null||!profile.getBounds().containsChunk(XFEarthBounds.floorDiv(x,16),XFEarthBounds.floorDiv(z,16)))return Collections.emptyList(); return world.getBiomeGenForCoords(x,z).getSpawnableList(type);}
+ public ChunkPosition func_147416_a(World world,String structure,int x,int y,int z){return null;} public int getLoadedChunkCount(){return 0;} public void recreateStructures(int x,int z){} public void saveExtraData(){}
+}

--- a/src/main/java/com/hfr/world/earth/XFEarthMissingChunkException.java
+++ b/src/main/java/com/hfr/world/earth/XFEarthMissingChunkException.java
@@ -1,0 +1,5 @@
+package com.hfr.world.earth;
+public final class XFEarthMissingChunkException extends RuntimeException {
+ public XFEarthMissingChunkException(int x,int z,XFEarthProfile p){super(message(x,z,p));}
+ private static String message(int x,int z,XFEarthProfile p){return "Missing pregenerated Earth chunk ("+x+", "+z+") blocks ["+(x*16)+".."+(x*16+15)+", "+(z*16)+".."+(z*16+15)+"] region ("+XFEarthBounds.chunkToRegion(x)+", "+XFEarthBounds.chunkToRegion(z)+") expected profile '"+p.getProfile()+"' ("+p.getWidth()+"x"+p.getHeight()+"). The WorldPainter export is incomplete or incorrectly installed.";}
+}

--- a/src/main/java/com/hfr/world/earth/XFEarthProfile.java
+++ b/src/main/java/com/hfr/world/earth/XFEarthProfile.java
@@ -1,0 +1,26 @@
+package com.hfr.world.earth;
+
+/** Gson DTO made immutable to callers after validation by the loader. */
+public final class XFEarthProfile {
+    int formatVersion; String profile; String targetMinecraftVersion;
+    int sourceScale, resize, effectiveScale, width, height;
+    int minimumX, maximumX, minimumZ, maximumZ;
+    int minimumSurfaceY, maximumSurfaceY, seaLevel;
+    String projection, populationMode; boolean caves, ores, lava, structures, vegetation;
+    private transient XFEarthBounds bounds;
+    void validate(String allowedVersion) {
+        if(formatVersion!=1) bad("unsupported formatVersion: "+formatVersion);
+        if(!allowedVersion.equals(targetMinecraftVersion)) bad("targetMinecraftVersion must be "+allowedVersion);
+        if(width<=0||height<=0||width%16!=0||height%16!=0) bad("width and height must be positive multiples of 16");
+        if((long)maximumX-minimumX+1!=width || (long)maximumZ-minimumZ+1!=height) bad("coordinate bounds do not match width/height");
+        if(minimumSurfaceY<1||maximumSurfaceY>254||minimumSurfaceY>maximumSurfaceY) bad("surface range must be within 1..254");
+        if(seaLevel<minimumSurfaceY||seaLevel>maximumSurfaceY) bad("seaLevel must lie inside surface range");
+        if(!"pregenerated".equals(populationMode)) bad("populationMode must be pregenerated");
+        if(caves||ores||lava||structures) bad("caves, ores, lava, and structures must all be false");
+        if(profile==null||profile.trim().isEmpty()) bad("profile name is required");
+        bounds=new XFEarthBounds(minimumX,maximumX,minimumZ,maximumZ);
+    }
+    private static void bad(String message){throw new IllegalArgumentException("Invalid XenoEarth profile: "+message);}
+    public String getProfile(){return profile;} public int getEffectiveScale(){return effectiveScale;} public int getWidth(){return width;} public int getHeight(){return height;}
+    public int getSeaLevel(){return seaLevel;} public XFEarthBounds getBounds(){return bounds;}
+}

--- a/src/main/java/com/hfr/world/earth/XFEarthProfileLoader.java
+++ b/src/main/java/com/hfr/world/earth/XFEarthProfileLoader.java
@@ -1,0 +1,13 @@
+package com.hfr.world.earth;
+import java.io.*; import java.util.*; import com.google.gson.Gson; import com.hfr.config.XFConfig;
+public final class XFEarthProfileLoader {
+ public static final String FILE_NAME="xenoearth-profile.json";
+ private static final Map<String,XFEarthProfile> CACHE=new HashMap<String,XFEarthProfile>();
+ private XFEarthProfileLoader(){}
+ public static synchronized XFEarthProfile load(File saveRoot) throws IOException {
+  File file=new File(saveRoot,FILE_NAME); String key=file.getCanonicalPath(); if(CACHE.containsKey(key)) return CACHE.get(key);
+  Reader reader=new InputStreamReader(new FileInputStream(file),"UTF-8"); try { XFEarthProfile p=new Gson().fromJson(reader,XFEarthProfile.class); if(p==null) throw new IllegalArgumentException("Invalid XenoEarth profile: empty JSON"); p.validate(XFConfig.earthAllowProfileMinecraftVersion); CACHE.put(key,p); return p; } finally {reader.close();}
+ }
+ public static File path(File root){return new File(root,FILE_NAME);} public static boolean exists(File root){return path(root).isFile();}
+ public static synchronized void clear(){CACHE.clear();}
+}

--- a/src/main/java/com/hfr/world/earth/XFEarthRegistry.java
+++ b/src/main/java/com/hfr/world/earth/XFEarthRegistry.java
@@ -1,0 +1,3 @@
+package com.hfr.world.earth;
+import com.hfr.config.XFConfig;
+public final class XFEarthRegistry { private static XFEarthWorldType type; private XFEarthRegistry(){} public static synchronized void register(){if(XFConfig.enableEarthWorldType&&type==null)type=new XFEarthWorldType();} public static XFEarthWorldType get(){return type;} public static boolean isRegistered(){return type!=null;} }

--- a/src/main/java/com/hfr/world/earth/XFEarthWorldType.java
+++ b/src/main/java/com/hfr/world/earth/XFEarthWorldType.java
@@ -1,0 +1,9 @@
+package com.hfr.world.earth;
+import net.minecraft.world.*; import net.minecraft.world.biome.WorldChunkManager; import net.minecraft.world.chunk.IChunkProvider;
+public final class XFEarthWorldType extends WorldType {
+ public XFEarthWorldType(){super("xf_earth");}
+ @Override public IChunkProvider getChunkGenerator(World world,String options){return new XFEarthChunkProvider(world);}
+ @Override public WorldChunkManager getChunkManager(World world){return new WorldChunkManager(world);}
+ @Override public int getSpawnFuzz(){return 0;}
+ @Override public boolean isCustomizable(){return false;}
+}

--- a/src/main/java/com/hfr/world/earth/XFEarthWorldValidationHandler.java
+++ b/src/main/java/com/hfr/world/earth/XFEarthWorldValidationHandler.java
@@ -1,0 +1,12 @@
+package com.hfr.world.earth;
+import java.io.File; import com.hfr.config.XFConfig; import com.hfr.main.MainRegistry;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent; import net.minecraftforge.event.world.WorldEvent; import net.minecraft.world.World;
+public final class XFEarthWorldValidationHandler {
+ @SubscribeEvent public void onLoad(WorldEvent.Load event){World w=event.world;if(w==null||w.isRemote||w.provider.dimensionId!=0)return; File root=w.getSaveHandler().getWorldDirectory(); boolean profilePresent=XFEarthProfileLoader.exists(root); boolean earth=XFEarthRegistry.get()!=null&&w.getWorldInfo().getTerrainType()==XFEarthRegistry.get();
+  if(!earth){if(profilePresent&&MainRegistry.logger!=null)MainRegistry.logger.warn("[XF EARTH] PROFILE PRESENT BUT WORLD NOT ADOPTED. Set level.dat Data.generatorName=xf_earth");return;}
+  if(!profilePresent){String m="[XF EARTH] Adopted xf_earth world is missing "+XFEarthProfileLoader.FILE_NAME; if(XFConfig.earthRequireProfile)throw new IllegalStateException(m); if(MainRegistry.logger!=null)MainRegistry.logger.error(m);return;}
+  if(!new File(root,"region").isDirectory())throw new IllegalStateException("[XF EARTH] Adopted Earth save has no region directory");
+  try{XFEarthProfile p=XFEarthProfileLoader.load(root);XFEarthBounds b=p.getBounds();if("PROFILE".equals(XFConfig.earthBoundaryMode)){int m=XFConfig.earthBoundarySafetyMargin;MainRegistry.border=true;MainRegistry.borderNegX=b.minimumX+m;MainRegistry.borderPosX=b.maximumX-m;MainRegistry.borderNegZ=b.minimumZ+m;MainRegistry.borderPosZ=b.maximumZ-m;} if(MainRegistry.logger!=null)MainRegistry.logger.info("[XF EARTH] profile='"+p.getProfile()+"' scale="+p.getEffectiveScale()+" bounds="+b.blockString()+" chunks="+b.chunkString()+"; Minecraft population is disabled by this provider.");}
+  catch(Exception e){throw new IllegalStateException("[XF EARTH] Profile validation failed",e);}
+ }
+}

--- a/src/main/resources/assets/hfr/lang/en_US.lang
+++ b/src/main/resources/assets/hfr/lang/en_US.lang
@@ -705,3 +705,5 @@ hfr.nei.coal_mine.supplies=one Miner Supplies item adds one stored supply; maxim
 hfr.nei.coal_mine.canary=one Canary is consumed to prevent one hazard event
 hfr.nei.coal_mine.foundation=the full rotated MachineCoalMine/MultiblockHandler.mine footprint needs a BlockSpeedy foundation
 hfr.nei.coal_mine.clearance=the same full rotated footprint needs clearance at y + 4; hazard checks run before coal and use else-if so one tick cannot run both; unprotected hazards check every occupied Miner slot and create the runtime explosion
+
+generator.xf_earth=XF Earth (Pregenerated)


### PR DESCRIPTION
### Motivation

- Provide a world type that safely hosts externally pregenerated WorldPainter Anvil exports so the mod does not attempt to procedurally recreate Earth or inadvertently allow vanilla terrain generation inside the mapped area. 
- Enforce save-root profile validation and tighten startup checks so an adopted Earth save is explicit (`Data.generatorName=xf_earth`) and missing in-bounds chunks are detected and handled according to operator policy. 
- Reuse the existing Xenofactions border system when a profile defines map bounds so the implementation does not introduce a second competing border handler. 

### Description

- Added a new configuration category `XENOFACTIONS_18_EARTH_WORLD` and keys: `enableEarthWorldType`, `earthWorldTypeName`, `earthRequireProfile`, `earthMissingChunkPolicy`, `earthBoundaryMode`, `earthAllowProfileMinecraftVersion`, `earthLogFallbackChunks`, and `earthBoundarySafetyMargin` with validation and defaults in `XFConfig`. 
- Registered one `WorldType` instance in pre-initialization via `XFEarthRegistry.register()` and added a startup validation handler registration in `MainRegistry` so `xf_earth` is available without registering a new dimension or a custom `WorldProvider`. 
- Implemented `XFEarthWorldType` (uses `super("xf_earth")`) and `XFEarthChunkProvider` that implements the mapped Forge 1.7.10 `IChunkProvider` methods (`chunkExists`, `provideChunk`, `loadChunk`, `populate`, `saveChunks`, `unloadQueuedChunks`, `canSave`, `makeString`, `getPossibleCreatures`, `func_147416_a`, `getLoadedChunkCount`, `recreateStructures`, `saveExtraData`) and returns a non-generating fallback that either throws `XFEarthMissingChunkException` (policy `FAIL`) or returns a deterministic void chunk (policy `VOID`) for missing in-bounds chunks. 
- Added profile model and loader: `XFEarthProfile`, `XFEarthProfileLoader`, and `XFEarthBounds` with Gson parsing, one-per-save caching, validations (format version, `targetMinecraftVersion`, 16-aligned dimensions, coordinate consistency, surface/sea level ranges, `populationMode == "pregenerated"`, and disabled caves/ores/lava/structures) and correct floor-division handling for negative coordinates and region conversion. 
- Added startup adoption and validation: `XFEarthWorldValidationHandler` inspects dimension 0 on `WorldEvent.Load`, warns if a profile is present but `level.dat` is not adopting `xf_earth`, enforces `region` directory presence, validates the profile, logs profile/scale/bounds, and (when `earthBoundaryMode=PROFILE`) applies validated bounds into the existing `MainRegistry` border fields without overwriting `CONFIG`-mode admin values. 
- Added operator commands `
/xfearth status` and `/xfearth check <chunkX> <chunkZ>` in `CommandXFEarth`, with explicit messaging that region-file existence does not prove a given chunk exists. 
- Ensured world-border event logic only applies to dimension 0 to avoid touching Nether/End behavior, and added localization entry `generator.xf_earth=XF Earth (Pregenerated)` and installation documentation `docs/XFEARTH_INSTALLATION.md` explaining the required WorldPainter -> Anvil export and `level.dat` adoption steps. 

### Testing

- Ran source-level structural assertions that verified presence of every mapped `IChunkProvider` method in `XFEarthChunkProvider`, confirmed there is no `ChunkProviderGenerate` fallback reference, confirmed the world-type constructor uses `super("xf_earth")`, and verified the installation docs mention `Data.generatorName=xf_earth`, all of which passed. 
- Performed repository scans (`rg`) to ensure no new dimension registration, no `DimensionManager`/`registerWorldGenerator` usage, and no world-provider replacement, which returned no forbidden usages. 
- Committed the changes as `Add template-backed XF Earth world type` and confirmed the working tree and index state after staging and commit. 
- Did not run `./gradlew compileJava` or `./gradlew build` because the repository instructions and user restrictions prohibit compiling binary files in this environment. 
- Runtime validation (server start / real Anvil WorldPainter export) was not performed here and remains a required manual smoke test following the documented installation steps in `docs/XFEARTH_INSTALLATION.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7428997bc48323866115fbd239064b)