### PR TITLE
Fix JourneyMap claim alignment to match Xenofactions territory coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Pull request: fix JourneyMap faction claim alignment
+
+- Corrected JourneyMap claim polygons, exposed borders, and territory-label bounds to use the exact inverse of Xenofactions' legacy `+1` and truncating integer coordinate conversion instead of treating stored territory coordinates as vanilla chunks.
+- Covered positive, negative, axis-crossing, and near-origin territory bounds with focused regression tests while preserving real flag-block label positions and the reflection-only JourneyMap integration.
+
 # Pull request: show command-specific help in the Xenofactions GUI
 
 - Replaced generic legacy-execution text in the Xenofactions command GUI with concise descriptions of each command's actual behavior.

--- a/src/main/java/com/hfr/client/journeymap/JourneyMapClaimDrawHandler.java
+++ b/src/main/java/com/hfr/client/journeymap/JourneyMapClaimDrawHandler.java
@@ -11,6 +11,8 @@ import org.lwjgl.opengl.GL11;
 import com.hfr.client.journeymap.ClientClaimOverlayCache.Snapshot;
 import com.hfr.client.journeymap.ClientClaimOverlayCache.TerritoryGroup;
 import com.hfr.clowder.ClaimOverlayData.Claim;
+import com.hfr.clowder.TerritoryCoordinateBounds;
+import com.hfr.clowder.TerritoryCoordinateBounds.Bounds;
 import com.hfr.config.XFConfig;
 
 import net.minecraft.client.Minecraft;
@@ -58,10 +60,12 @@ final class JourneyMapClaimDrawHandler implements InvocationHandler {
 		}
 	}
 	private void renderClaim(Object grid, Claim claim, Snapshot snapshot, double xo, double yo, int width, int height) throws Exception {
-		double x = claim.chunkX * 16D, z = claim.chunkZ * 16D;
+		Bounds xBounds = TerritoryCoordinateBounds.forCoordinate(claim.chunkX), zBounds = TerritoryCoordinateBounds.forCoordinate(claim.chunkZ);
+		double x = xBounds.minInclusive, z = zBounds.minInclusive;
+		double maxWorldX = xBounds.maxExclusive, maxWorldZ = zBounds.maxExclusive;
 		// Invoke the required public conversion, then use its uncropped companion so partially visible claims retain all corners.
 		reflection.getPixel.invoke(grid, x, z);
-		Point2D p0 = point(grid, x, z), p1 = point(grid, x + 16D, z), p2 = point(grid, x + 16D, z + 16D), p3 = point(grid, x, z + 16D);
+		Point2D p0 = point(grid, x, z), p1 = point(grid, maxWorldX, z), p2 = point(grid, maxWorldX, maxWorldZ), p3 = point(grid, x, maxWorldZ);
 		double minX = Math.min(Math.min(p0.getX(), p1.getX()), Math.min(p2.getX(), p3.getX())) + xo, maxX = Math.max(Math.max(p0.getX(), p1.getX()), Math.max(p2.getX(), p3.getX())) + xo;
 		double minY = Math.min(Math.min(p0.getY(), p1.getY()), Math.min(p2.getY(), p3.getY())) + yo, maxY = Math.max(Math.max(p0.getY(), p1.getY()), Math.max(p2.getY(), p3.getY())) + yo;
 		if(maxX < -8 || maxY < -8 || minX > width + 8 || minY > height + 8) return;
@@ -76,8 +80,12 @@ final class JourneyMapClaimDrawHandler implements InvocationHandler {
 	}
 	private void renderLabel(Object grid, TerritoryGroup group, double xo, double yo, int width, int height) throws Exception {
 		if(group.label == null || group.label.length() == 0) return;
-		Point2D b0 = point(grid, group.minChunkX * 16D, group.minChunkZ * 16D), b1 = point(grid, (group.maxChunkX + 1) * 16D, group.minChunkZ * 16D);
-		Point2D b2 = point(grid, (group.maxChunkX + 1) * 16D, (group.maxChunkZ + 1) * 16D), b3 = point(grid, group.minChunkX * 16D, (group.maxChunkZ + 1) * 16D);
+		Bounds minXBounds = TerritoryCoordinateBounds.forCoordinate(group.minChunkX), maxXBounds = TerritoryCoordinateBounds.forCoordinate(group.maxChunkX);
+		Bounds minZBounds = TerritoryCoordinateBounds.forCoordinate(group.minChunkZ), maxZBounds = TerritoryCoordinateBounds.forCoordinate(group.maxChunkZ);
+		double minWorldX = minXBounds.minInclusive, maxWorldX = maxXBounds.maxExclusive;
+		double minWorldZ = minZBounds.minInclusive, maxWorldZ = maxZBounds.maxExclusive;
+		Point2D b0 = point(grid, minWorldX, minWorldZ), b1 = point(grid, maxWorldX, minWorldZ);
+		Point2D b2 = point(grid, maxWorldX, maxWorldZ), b3 = point(grid, minWorldX, maxWorldZ);
 		double minX = Math.min(Math.min(b0.getX(), b1.getX()), Math.min(b2.getX(), b3.getX())) + xo, maxX = Math.max(Math.max(b0.getX(), b1.getX()), Math.max(b2.getX(), b3.getX())) + xo;
 		double minY = Math.min(Math.min(b0.getY(), b1.getY()), Math.min(b2.getY(), b3.getY())) + yo, maxY = Math.max(Math.max(b0.getY(), b1.getY()), Math.max(b2.getY(), b3.getY())) + yo;
 		if(maxX < 0 || maxY < 0 || minX > width || minY > height || maxX - minX < 12D || maxY - minY < 8D) return;

--- a/src/main/java/com/hfr/clowder/ClaimOverlayData.java
+++ b/src/main/java/com/hfr/clowder/ClaimOverlayData.java
@@ -37,8 +37,8 @@ public final class ClaimOverlayData {
 			Clowder faction = meta.owner.owner;
 			String groupId = groupId(dimensionId, meta);
 			Bounds bound = bounds.get(groupId);
-			int labelX = bound == null ? coord.x * 16 + 8 : bound.labelX();
-			int labelZ = bound == null ? coord.z * 16 + 8 : bound.labelZ();
+			int labelX = bound == null ? coordinateCenter(coord.x) : bound.labelX();
+			int labelZ = bound == null ? coordinateCenter(coord.z) : bound.labelZ();
 			claims.add(new Claim(dimensionId, coord.x, coord.z, groupId, faction.color & 0xFFFFFF, cleanLabel(meta.cityName), labelX, labelZ));
 		}
 		return Collections.unmodifiableList(claims);
@@ -55,13 +55,22 @@ public final class ClaimOverlayData {
 		return trimmed.length() > max ? trimmed.substring(0, max) : trimmed;
 	}
 
+	private static int coordinateCenter(int coordinate) {
+		return (int)Math.round(TerritoryCoordinateBounds.forCoordinate(coordinate).center());
+	}
+
 	private static final class Bounds {
 		final TerritoryMeta meta; int minX = Integer.MAX_VALUE, minZ = Integer.MAX_VALUE, maxX = Integer.MIN_VALUE, maxZ = Integer.MIN_VALUE;
 		Bounds(TerritoryMeta meta) { this.meta = meta; }
 		void include(int x, int z) { if(x < minX) minX = x; if(z < minZ) minZ = z; if(x > maxX) maxX = x; if(z > maxZ) maxZ = z; }
 		boolean hasValidFlag() { return meta.flagY >= 0; }
-		int labelX() { return hasValidFlag() ? meta.flagX : (minX * 16 + (maxX - minX + 1) * 8); }
-		int labelZ() { return hasValidFlag() ? meta.flagZ : (minZ * 16 + (maxZ - minZ + 1) * 8); }
+		int labelX() { return hasValidFlag() ? meta.flagX : groupCenter(minX, maxX); }
+		int labelZ() { return hasValidFlag() ? meta.flagZ : groupCenter(minZ, maxZ); }
+		int groupCenter(int min, int max) {
+			long lower = TerritoryCoordinateBounds.forCoordinate(min).minInclusive;
+			long upper = TerritoryCoordinateBounds.forCoordinate(max).maxExclusive;
+			return (int)Math.round((lower + upper) / 2D);
+		}
 	}
 
 	public static long chunkKey(int x, int z) {
@@ -72,7 +81,7 @@ public final class ClaimOverlayData {
 		public final int dimensionId, chunkX, chunkZ, color, labelX, labelZ;
 		public final String groupId, label;
 		public Claim(int dimensionId, int chunkX, int chunkZ, String groupId, int color) {
-			this(dimensionId, chunkX, chunkZ, groupId, color, "", chunkX * 16 + 8, chunkZ * 16 + 8);
+			this(dimensionId, chunkX, chunkZ, groupId, color, "", coordinateCenter(chunkX), coordinateCenter(chunkZ));
 		}
 		public Claim(int dimensionId, int chunkX, int chunkZ, String groupId, int color, String label, int labelX, int labelZ) {
 			this.dimensionId = dimensionId; this.chunkX = chunkX; this.chunkZ = chunkZ;

--- a/src/main/java/com/hfr/clowder/TerritoryCoordinateBounds.java
+++ b/src/main/java/com/hfr/clowder/TerritoryCoordinateBounds.java
@@ -1,0 +1,32 @@
+package com.hfr.clowder;
+
+/** Converts Xenofactions' stored territory coordinates back to world-space block bounds. */
+public final class TerritoryCoordinateBounds {
+	private TerritoryCoordinateBounds() { }
+
+	/**
+	 * Returns the half-open world interval containing every integer block coordinate
+	 * which {@link ClowderTerritory#getCoordPair(int, int, int)} maps to {@code territoryCoordinate}.
+	 * Stored territory coordinates are not vanilla chunks: the legacy lookup adds one
+	 * before Java's truncating division. In particular, coordinate zero spans 31 blocks,
+	 * so rendering {@code coordinate * 16} is not a safe approximation.
+	 */
+	public static Bounds forCoordinate(int territoryCoordinate) {
+		long scaled = (long)territoryCoordinate * 16L;
+		if(territoryCoordinate > 0) return new Bounds(scaled - 1L, scaled + 15L);
+		if(territoryCoordinate < 0) return new Bounds(scaled - 16L, scaled);
+		return new Bounds(-16L, 15L);
+	}
+
+	public static final class Bounds {
+		public final long minInclusive;
+		public final long maxExclusive;
+
+		private Bounds(long minInclusive, long maxExclusive) {
+			this.minInclusive = minInclusive;
+			this.maxExclusive = maxExclusive;
+		}
+
+		public double center() { return (minInclusive + maxExclusive) / 2D; }
+	}
+}

--- a/test/java/com/hfr/clowder/TerritoryCoordinateBoundsTest.java
+++ b/test/java/com/hfr/clowder/TerritoryCoordinateBoundsTest.java
@@ -1,0 +1,66 @@
+package com.hfr.clowder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+import com.hfr.clowder.ClowderTerritory.CoordPair;
+import com.hfr.clowder.TerritoryCoordinateBounds.Bounds;
+
+public class TerritoryCoordinateBoundsTest {
+	private static final int[] BOUNDARY_BLOCKS = {
+		-33, -32, -31, -17, -16, -15, -1, 0, 1, 14, 15, 16, 17, 31, 32, 33
+	};
+
+	@Test
+	public void inverseBoundsMatchLegacyLookupAroundEveryBoundaryOnBothAxes() {
+		for(int block : BOUNDARY_BLOCKS) {
+			CoordPair pair = ClowderTerritory.getCoordPair(7, block, block);
+			assertContainsExactly(pair.x, true);
+			assertContainsExactly(pair.z, false);
+		}
+	}
+
+	@Test
+	public void zeroAndAdjacentCoordinatesAreConnectedWithoutOverlap() {
+		assertBounds(-2, -48, -32);
+		assertBounds(-1, -32, -16);
+		assertBounds(0, -16, 15);
+		assertBounds(1, 15, 31);
+		assertBounds(2, 31, 47);
+	}
+
+	@Test
+	public void positiveNegativeAndOriginCityCentersRemainInsideTheirTerritories() {
+		int[][] cities = { { 160, 160 }, { -160, 160 }, { 160, -160 }, { -160, -160 }, { -1, 0 }, { 0, 1 } };
+		for(int[] city : cities) {
+			CoordPair pair = ClowderTerritory.getCoordPair(0, city[0], city[1]);
+			assertIncluded(pair.x, city[0]);
+			assertIncluded(pair.z, city[1]);
+		}
+	}
+
+	private static void assertContainsExactly(int coordinate, boolean xAxis) {
+		Bounds bounds = TerritoryCoordinateBounds.forCoordinate(coordinate);
+		for(long block = bounds.minInclusive; block < bounds.maxExclusive; block++) {
+			CoordPair resolved = xAxis ? ClowderTerritory.getCoordPair(7, (int)block, 0) : ClowderTerritory.getCoordPair(7, 0, (int)block);
+			assertEquals(coordinate, xAxis ? resolved.x : resolved.z);
+		}
+		CoordPair below = xAxis ? ClowderTerritory.getCoordPair(7, (int)bounds.minInclusive - 1, 0) : ClowderTerritory.getCoordPair(7, 0, (int)bounds.minInclusive - 1);
+		CoordPair above = xAxis ? ClowderTerritory.getCoordPair(7, (int)bounds.maxExclusive, 0) : ClowderTerritory.getCoordPair(7, 0, (int)bounds.maxExclusive);
+		assertNotEquals(coordinate, xAxis ? below.x : below.z);
+		assertNotEquals(coordinate, xAxis ? above.x : above.z);
+	}
+
+	private static void assertIncluded(int coordinate, int block) {
+		Bounds bounds = TerritoryCoordinateBounds.forCoordinate(coordinate);
+		assertEquals(true, block >= bounds.minInclusive && block < bounds.maxExclusive);
+	}
+
+	private static void assertBounds(int coordinate, long min, long max) {
+		Bounds bounds = TerritoryCoordinateBounds.forCoordinate(coordinate);
+		assertEquals(min, bounds.minInclusive);
+		assertEquals(max, bounds.maxExclusive);
+	}
+}


### PR DESCRIPTION
### Motivation

- JourneyMap overlays were shifted because `ClowderTerritory.getCoordPair(...)` uses the legacy `+1` then integer division behavior, so stored `CoordPair` values do not correspond to vanilla `chunk * 16` block bounds.  
- The JourneyMap renderer assumed stored territory coordinates map to ordinary chunk ranges, producing a visible offset instead of fixing the coordinate conversion at its source.  
- The change must preserve all existing Xenofactions ownership rules and the legacy `+1` lookup while rendering polygons that exactly match the authoritative territory mapping.  

### Description

- Add a single canonical inverse mapping `TerritoryCoordinateBounds.forCoordinate(int)` with an immutable `Bounds` result and the corrected world-space half-open intervals for positive, negative and zero territory coordinates in `src/main/java/com/hfr/clowder/TerritoryCoordinateBounds.java`.  
- Make JourneyMap rendering use those bounds by updating `src/main/java/com/hfr/client/journeymap/JourneyMapClaimDrawHandler.java` to compute world-space corners from `TerritoryCoordinateBounds` and feed those corners into JourneyMap's `getBlockPixelInGrid`/`getPixel` conversion for fill, exposed borders, and label bounds.  
- Update territory label placement and group centroid math in `src/main/java/com/hfr/clowder/ClaimOverlayData.java` so label positions use the canonical bounds while keeping real flag block coordinates unchanged.  
- Add focused unit tests in `test/java/com/hfr/clowder/TerritoryCoordinateBoundsTest.java` that validate boundary samples around the requested block values and verify included/excluded integer blocks and adjacency, and document the fix in `CHANGELOG.md`.  

### Testing

- Ran an automated Python verifier that exhaustively validated the inverse bounds and adjacency for territory coordinates from `-1000` to `1000` and the requested boundary samples (passed).  
- Ran repository checks (`git diff --check` and searches for remaining direct `chunk*16` assumptions) which found no remaining direct vanilla-chunk geometry assumptions in JourneyMap geometry code (passed).  
- Attempted to run `gradle test` / `./gradlew test` but the build tests could not be executed in this environment due to a missing Gradle wrapper and remote dependency access failures (could not run JUnit in-container).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77b778d2f8832382b51ff0931a00c1)