### PR TITLE
Fix JourneyMap minimap claim clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Pull request: fix JourneyMap minimap claim clipping
+
+- Kept JourneyMap's depth-based minimap mask active while faction claim fills, borders, and labels render, preventing overlay geometry from escaping circular and rectangular minimap interiors without adding a separate clipping system.
+- Preserved fullscreen claim rendering and the corrected legacy territory-coordinate bounds by limiting the change to Xenofactions-owned OpenGL state.
+
 # Pull request: fix JourneyMap faction claim alignment
 
 - Corrected JourneyMap claim polygons, exposed borders, and territory-label bounds to use the exact inverse of Xenofactions' legacy `+1` and truncating integer coordinate conversion instead of treating stored territory coordinates as vanilla chunks.

--- a/src/main/java/com/hfr/client/journeymap/JourneyMapClaimDrawHandler.java
+++ b/src/main/java/com/hfr/client/journeymap/JourneyMapClaimDrawHandler.java
@@ -40,11 +40,12 @@ final class JourneyMapClaimDrawHandler implements InvocationHandler {
 				|| mc == null || mc.theWorld == null || mc.thePlayer == null) return;
 		Snapshot snapshot = ClientClaimOverlayCache.get(mc.thePlayer.dimension); if(snapshot == null || snapshot.claims.isEmpty()) return;
 		int width = ((Integer)reflection.getWidth.invoke(grid)).intValue(), height = ((Integer)reflection.getHeight.invoke(grid)).intValue();
-		boolean texture = GL11.glIsEnabled(GL11.GL_TEXTURE_2D), blend = GL11.glIsEnabled(GL11.GL_BLEND), alpha = GL11.glIsEnabled(GL11.GL_ALPHA_TEST), depth = GL11.glIsEnabled(GL11.GL_DEPTH_TEST);
+		boolean texture = GL11.glIsEnabled(GL11.GL_TEXTURE_2D), blend = GL11.glIsEnabled(GL11.GL_BLEND), alpha = GL11.glIsEnabled(GL11.GL_ALPHA_TEST);
 		int blendSrc = GL11.glGetInteger(GL11.GL_BLEND_SRC), blendDst = GL11.glGetInteger(GL11.GL_BLEND_DST); float oldWidth = GL11.glGetFloat(GL11.GL_LINE_WIDTH);
 		// LWJGL 2 generic glGetFloat requires room for 16 floats even when reading GL_CURRENT_COLOR.
 		FloatBuffer color = BufferUtils.createFloatBuffer(16); GL11.glGetFloat(GL11.GL_CURRENT_COLOR, color);
-		GL11.glDisable(GL11.GL_TEXTURE_2D); GL11.glEnable(GL11.GL_BLEND); GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA); GL11.glDisable(GL11.GL_ALPHA_TEST); GL11.glDisable(GL11.GL_DEPTH_TEST);
+		// JourneyMap owns the active depth state: its depth buffer clips minimap DrawStep rendering to the minimap mask.
+		GL11.glDisable(GL11.GL_TEXTURE_2D); GL11.glEnable(GL11.GL_BLEND); GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA); GL11.glDisable(GL11.GL_ALPHA_TEST);
 		try {
 			for(Claim claim : snapshot.claims) renderClaim(grid, claim, snapshot, xOffset, yOffset, width, height);
 			if(XFConfig.journeyMapShowTerritoryLabels) {
@@ -55,7 +56,7 @@ final class JourneyMapClaimDrawHandler implements InvocationHandler {
 		} finally {
 			if(texture) GL11.glEnable(GL11.GL_TEXTURE_2D); else GL11.glDisable(GL11.GL_TEXTURE_2D);
 			if(blend) GL11.glEnable(GL11.GL_BLEND); else GL11.glDisable(GL11.GL_BLEND); GL11.glBlendFunc(blendSrc, blendDst);
-			if(alpha) GL11.glEnable(GL11.GL_ALPHA_TEST); else GL11.glDisable(GL11.GL_ALPHA_TEST); if(depth) GL11.glEnable(GL11.GL_DEPTH_TEST); else GL11.glDisable(GL11.GL_DEPTH_TEST);
+			if(alpha) GL11.glEnable(GL11.GL_ALPHA_TEST); else GL11.glDisable(GL11.GL_ALPHA_TEST);
 			GL11.glLineWidth(oldWidth); GL11.glColor4f(color.get(0), color.get(1), color.get(2), color.get(3));
 		}
 	}

--- a/tools/test_journeymap_claim_depth_state.py
+++ b/tools/test_journeymap_claim_depth_state.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Regression check that the claim DrawStep leaves JourneyMap's depth mask intact."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HANDLER = ROOT / "src/main/java/com/hfr/client/journeymap/JourneyMapClaimDrawHandler.java"
+
+
+class JourneyMapClaimDepthStateTest(unittest.TestCase):
+    def test_claim_renderer_does_not_override_depth_state(self):
+        source = HANDLER.read_text(encoding="utf-8")
+
+        self.assertNotIn("GL_DEPTH_TEST", source)
+        self.assertNotIn("glDepthFunc", source)
+        self.assertNotIn("glDepthMask", source)
+        self.assertIn("JourneyMap owns the active depth state", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- JourneyMap uses the active depth buffer to mask minimap `DrawStep` rendering, but Xenofactions was disabling depth testing (`GL_DEPTH_TEST`) while rendering claim overlays which allowed claim geometry to escape the minimap interior; the fix preserves JourneyMap's clipping behavior by not changing its depth state.

### Description

- Stop disabling `GL_DEPTH_TEST` and remove the unused depth-state capture/restore in `JourneyMapClaimDrawHandler` so JourneyMap's minimap depth-based mask remains active while Xenofactions renders claims. (`src/main/java/com/hfr/client/journeymap/JourneyMapClaimDrawHandler.java`)
- Add a short source comment explaining that JourneyMap owns the active depth state and must not be overridden. (`JourneyMapClaimDrawHandler.java`)
- Add a small source-level regression test that asserts the claim renderer does not contain `GL_DEPTH_TEST`, `glDepthFunc`, or `glDepthMask` overrides. (`tools/test_journeymap_claim_depth_state.py`)
- Document the fix in `CHANGELOG.md` as a JourneyMap minimap clipping correction.

### Testing

- Ran `python3 tools/test_journeymap_claim_depth_state.py`, which passed and confirmed the forbidden depth-state calls are absent. (OK)
- Ran `python3 -m unittest discover -s tools -p 'test_*.py'`, which passed. (OK)
- Ran `git diff --check` and code searches for `GL_DEPTH_TEST`, `glDepthFunc`, and `glDepthMask` in the JourneyMap integration, which returned no forbidden matches. (OK)
- Did not run compilation or a live Forge 1.7.10 + JourneyMap client because the task and environment prohibit producing or running binary builds; manual runtime verification is recommended in a local client with JourneyMap 5.2.x. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77bab57c20832390d826273688c1dd)